### PR TITLE
docs(claude): add workflow rules to CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /coverage.out
 /.claude/
 /dist/
+/.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 CLI for Things3 on macOS. Reads from the Things3 SQLite database (read-only) and writes via macOS URL scheme / AppleScript.
 
+## Workflow
+
+- Never commit to `main`. Work on a branch, ideally a worktree (`git worktree add ../things-cli-<topic> -b <topic>`). If you find yourself on `main` with changes, `git switch -c <topic>` before committing.
+- `main` only moves via PR merges and release tags (see `/release`).
+- Use Conventional Commits.
+
 ## Commands
 
 Canonical entry points — CI runs the same targets.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ CLI for Things3 on macOS. Reads from the Things3 SQLite database (read-only) and
 
 ## Workflow
 
-- Never commit to `main`. Work on a branch, ideally a worktree (`git worktree add ../things-cli-<topic> -b <topic>`). If you find yourself on `main` with changes, `git switch -c <topic>` before committing.
+- Never commit to `main`. Work on a branch, ideally a worktree (`git worktree add .worktrees/<topic> -b <topic>`). If you find yourself on `main` with changes, `git switch -c <topic>` before committing.
 - `main` only moves via PR merges and release tags (see `/release`).
 - Use Conventional Commits.
 


### PR DESCRIPTION
## Summary
- Add `## Workflow` section to `CLAUDE.md`: no direct commits to `main` (use a branch/worktree), and use Conventional Commits.

## Test plan
- [x] Docs-only change — no build/test impact.