### PR TITLE
feat: add `things project add` to create projects via URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ things show "Pay rent"            # show by title (interactive disambig)
 
 things add "Buy milk" --when today --tags errand,shopping
 things add "Ship v2" --project "Launch" --deadline 2026-04-30
+things project add "Launch site" --area Work --deadline 2026-05-01
 things complete 3
 things cancel "Old idea"
 things search migrate
@@ -57,6 +58,9 @@ cache the resulting UUIDs so you can refer to tasks by their index (`1`, `2`,
 `--project`, `--heading` and `--list`. `--when` takes the same values Things
 itself accepts (`today`, `tomorrow`, `evening`, `anytime`, `someday`, or a
 date).
+
+`project add` accepts `--notes`, `--when`, `--deadline`, `--tags`, `--area`
+and `--todos` (newline-separated initial to-dos).
 
 ## How it works
 

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -34,7 +34,7 @@ type CLI struct {
 	Tags     TagsCmd     `cmd:"" help:"List tags."`
 	Show     ShowCmd     `cmd:"" help:"Show task detail."`
 	Add      AddCmd      `cmd:"" help:"Create a new task."`
-	Project  ProjectCmd  `cmd:"" help:"Manage projects (add)."`
+	Project  ProjectCmd  `cmd:"" help:"Manage projects."`
 	Complete CompleteCmd `cmd:"" help:"Mark a task as completed."`
 	Cancel   CancelCmd   `cmd:"" help:"Cancel a task."`
 	Search   SearchCmd   `cmd:"" help:"Search tasks by title or notes."`

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -34,6 +34,7 @@ type CLI struct {
 	Tags     TagsCmd     `cmd:"" help:"List tags."`
 	Show     ShowCmd     `cmd:"" help:"Show task detail."`
 	Add      AddCmd      `cmd:"" help:"Create a new task."`
+	Project  ProjectCmd  `cmd:"" help:"Project mutations."`
 	Complete CompleteCmd `cmd:"" help:"Mark a task as completed."`
 	Cancel   CancelCmd   `cmd:"" help:"Cancel a task."`
 	Search   SearchCmd   `cmd:"" help:"Search tasks by title or notes."`
@@ -73,6 +74,20 @@ type AddCmd struct {
 	Project   string `help:"Project name or UUID."`
 	Heading   string `help:"Heading within project."`
 	List      string `help:"List (project or area) name."`
+}
+
+type ProjectCmd struct {
+	Add ProjectAddCmd `cmd:"" help:"Create a new project."`
+}
+
+type ProjectAddCmd struct {
+	Title    string `arg:"" required:"" help:"Project title."`
+	Notes    string `help:"Notes for the project."`
+	When     string `help:"When to schedule (date, today, tomorrow, evening, etc.)."`
+	Deadline string `help:"Deadline date."`
+	Tags     string `help:"Comma-separated tags."`
+	Area     string `help:"Area name or UUID."`
+	Todos    string `help:"Newline-separated initial to-dos."`
 }
 
 type CompleteCmd struct {
@@ -141,6 +156,8 @@ func run(ctx *kong.Context, cli *CLI, database *db.DB) error {
 		return runShow(cli, database)
 	case "add <title>":
 		return runAdd(cli, database)
+	case "project add <title>":
+		return runProjectAdd(cli)
 	case "complete <task>":
 		return runComplete(cli, database)
 	case "cancel <task>":
@@ -241,6 +258,18 @@ func runAdd(cli *CLI, database *db.DB) error {
 		Heading:   cli.Add.Heading,
 		List:      list,
 		AuthToken: token,
+	})
+}
+
+func runProjectAdd(cli *CLI) error {
+	return things.AddProject(things.AddProjectParams{
+		Title:    cli.Project.Add.Title,
+		Notes:    cli.Project.Add.Notes,
+		When:     cli.Project.Add.When,
+		Deadline: cli.Project.Add.Deadline,
+		Tags:     cli.Project.Add.Tags,
+		Area:     cli.Project.Add.Area,
+		Todos:    cli.Project.Add.Todos,
 	})
 }
 

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -34,7 +34,7 @@ type CLI struct {
 	Tags     TagsCmd     `cmd:"" help:"List tags."`
 	Show     ShowCmd     `cmd:"" help:"Show task detail."`
 	Add      AddCmd      `cmd:"" help:"Create a new task."`
-	Project  ProjectCmd  `cmd:"" help:"Project mutations."`
+	Project  ProjectCmd  `cmd:"" help:"Manage projects (add)."`
 	Complete CompleteCmd `cmd:"" help:"Mark a task as completed."`
 	Cancel   CancelCmd   `cmd:"" help:"Cancel a task."`
 	Search   SearchCmd   `cmd:"" help:"Search tasks by title or notes."`

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -254,7 +254,7 @@ func runAdd(cli *CLI, database *db.DB) error {
 		When:      cli.Add.When,
 		Deadline:  cli.Add.Deadline,
 		Tags:      cli.Add.Tags,
-		Checklist: cli.Add.Checklist,
+		Checklist: expandNewlines(cli.Add.Checklist),
 		Heading:   cli.Add.Heading,
 		List:      list,
 		AuthToken: token,
@@ -269,8 +269,15 @@ func runProjectAdd(cli *CLI) error {
 		Deadline: cli.Project.Add.Deadline,
 		Tags:     cli.Project.Add.Tags,
 		Area:     cli.Project.Add.Area,
-		Todos:    cli.Project.Add.Todos,
+		Todos:    expandNewlines(cli.Project.Add.Todos),
 	})
+}
+
+// expandNewlines converts the literal two-character sequence `\n` into real
+// newlines so users can pass multi-line values in a single shell-quoted flag
+// (e.g. --todos "Draft\nShip"). Actual newlines in the input are preserved.
+func expandNewlines(s string) string {
+	return strings.ReplaceAll(s, `\n`, "\n")
 }
 
 func runComplete(cli *CLI, database *db.DB) error {

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -18,6 +18,50 @@ type AddParams struct {
 	AuthToken string
 }
 
+type AddProjectParams struct {
+	Title    string
+	Notes    string
+	When     string
+	Deadline string
+	Tags     string
+	Area     string
+	Todos    string
+}
+
+// openThingsURL builds a things:/// URL for the given command and runs it via
+// `open -g`. url.Values.Encode uses + for spaces, but Things expects %20.
+func openThingsURL(command string, v url.Values) error {
+	u := "things:///" + command + "?" + strings.ReplaceAll(v.Encode(), "+", "%20")
+	if err := execCommand("open", "-g", u).Run(); err != nil {
+		return fmt.Errorf("opening URL scheme: %w", err)
+	}
+	return nil
+}
+
+func AddProject(params AddProjectParams) error {
+	v := url.Values{}
+	v.Set("title", params.Title)
+	if params.Notes != "" {
+		v.Set("notes", params.Notes)
+	}
+	if params.When != "" {
+		v.Set("when", params.When)
+	}
+	if params.Deadline != "" {
+		v.Set("deadline", params.Deadline)
+	}
+	if params.Tags != "" {
+		v.Set("tags", params.Tags)
+	}
+	if params.Area != "" {
+		v.Set("area", params.Area)
+	}
+	if params.Todos != "" {
+		v.Set("to-dos", params.Todos)
+	}
+	return openThingsURL("add-project", v)
+}
+
 func AddTask(params AddParams) error {
 	v := url.Values{}
 	v.Set("title", params.Title)
@@ -45,12 +89,5 @@ func AddTask(params AddParams) error {
 	if params.AuthToken != "" {
 		v.Set("auth-token", params.AuthToken)
 	}
-
-	// url.Values.Encode uses + for spaces, but Things expects percent-encoding.
-	u := "things:///add?" + strings.ReplaceAll(v.Encode(), "+", "%20")
-	cmd := execCommand("open", "-g", u)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("opening URL scheme: %w", err)
-	}
-	return nil
+	return openThingsURL("add", v)
 }

--- a/internal/things/urlscheme_test.go
+++ b/internal/things/urlscheme_test.go
@@ -107,6 +107,91 @@ func TestAddTaskOmitsEmpty(t *testing.T) {
 	}
 }
 
+func TestAddProjectMinimal(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	if err := AddProject(AddProjectParams{Title: "Launch site"}); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	if len(*captured) != 3 {
+		t.Fatalf("expected 3 args, got: %v", *captured)
+	}
+	u := (*captured)[2]
+	if !strings.HasPrefix(u, "things:///add-project?") {
+		t.Fatalf("expected add-project URL, got %q", u)
+	}
+	if strings.Contains(u, "+") {
+		t.Errorf("URL should use %%20 not +: %q", u)
+	}
+	if !strings.Contains(u, "title=Launch%20site") {
+		t.Errorf("missing encoded title: %q", u)
+	}
+}
+
+func TestAddProjectAllFields(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	err := AddProject(AddProjectParams{
+		Title:    "P",
+		Notes:    "n",
+		When:     "today",
+		Deadline: "2026-05-01",
+		Tags:     "a,b",
+		Area:     "Work",
+		Todos:    "one\ntwo",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := url.Parse((*captured)[2])
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	q := parsed.Query()
+
+	cases := map[string]string{
+		"title":    "P",
+		"notes":    "n",
+		"when":     "today",
+		"deadline": "2026-05-01",
+		"tags":     "a,b",
+		"area":     "Work",
+		"to-dos":   "one\ntwo",
+	}
+	for k, want := range cases {
+		if got := q.Get(k); got != want {
+			t.Errorf("query[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestAddProjectOmitsEmpty(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	if err := AddProject(AddProjectParams{Title: "only"}); err != nil {
+		t.Fatal(err)
+	}
+	u := (*captured)[2]
+	for _, k := range []string{"notes=", "when=", "deadline=", "tags=", "area=", "to-dos="} {
+		if strings.Contains(u, k) {
+			t.Errorf("URL should not contain %q: %s", k, u)
+		}
+	}
+}
+
+func TestAddProjectCommandFails(t *testing.T) {
+	stubRunner(t, true)
+
+	err := AddProject(AddProjectParams{Title: "p"})
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+	if !strings.Contains(err.Error(), "opening URL scheme") {
+		t.Errorf("error should mention URL scheme: %v", err)
+	}
+}
+
 func TestAddTaskCommandFails(t *testing.T) {
 	stubRunner(t, true)
 


### PR DESCRIPTION
## Summary
- Adds `things project add "Title"` with flags mirroring `things add` where they apply: `--notes`, `--when`, `--deadline`, `--tags`, `--area`, `--todos` (newline-separated initial to-dos).
- New `project` command group (singular) for project mutations; existing `things projects` (plural list) is unchanged. Future siblings: `project complete`, `project cancel`.
- Extracts a shared `openThingsURL(command, v)` helper in `internal/things/urlscheme.go` so `AddTask` and `AddProject` no longer duplicate the `+`→`%20` encoding quirk and `open -g` plumbing.

No `auth-token` on `add-project`: per the [official URL-scheme docs](https://culturedcode.com/things/support/articles/2803573/), auth-token is only required for commands that modify existing data (`update`, `update-project`, `json`). `add-project` doesn't accept it.

Closes #15

## Test plan
- [x] `make test` — all packages pass (race)
- [x] `make lint` — 0 issues
- [x] Unit tests assert the generated URL for minimal, all-fields, omitted-empty, and command-failure cases
- [x] Manual: `things project add "Launch site" --area Work --deadline 2026-05-01 --todos "Draft copy\nShip staging"` creates a visible project in Things3