### PR TITLE
feat: add `things edit` to update tasks via URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ things show "Pay rent"            # show by title (interactive disambig)
 things add "Buy milk" --when today --tags errand,shopping
 things add "Ship v2" --project "Launch" --deadline 2026-04-30
 things project add "Launch site" --area Work --deadline 2026-05-01
+things edit 3 --title "New title" --when tomorrow
+things edit "Buy milk" --add-tags urgent --deadline 2026-05-01
 things complete 3
 things cancel "Old idea"
 things search migrate
@@ -62,13 +64,24 @@ date).
 `project add` accepts `--notes`, `--when`, `--deadline`, `--tags`, `--area`
 and `--todos` (newline-separated initial to-dos).
 
+`edit` updates an existing task via the `things:///update` URL scheme. Only
+flags you pass are sent, so unset fields stay untouched. Supported flags:
+`--title`, `--notes`, `--prepend-notes`, `--append-notes`, `--when`,
+`--deadline`, `--tags` (replace), `--add-tags`, `--checklist`,
+`--prepend-checklist`, `--append-checklist`, `--list` / `--list-id`,
+`--heading` / `--heading-id`, `--complete`, `--cancel`, `--duplicate`,
+`--reveal`. An empty value clears the field (e.g. `--deadline ""`). Requires
+the Things auth token — enable *Things → Settings → General → Enable Things
+URLs*.
+
 ## How it works
 
 - **Reads** go through `modernc.org/sqlite` (pure Go, no cgo) with
   `PRAGMA query_only = ON`, so the CLI cannot mutate the Things database.
-- **Writes** go through the official `things:///add` URL scheme for creating
-  tasks and through AppleScript for completing and cancelling them. This is
-  the same interface Things exposes to Shortcuts and automation tools.
+- **Writes** go through the official `things:///add` and `things:///update`
+  URL schemes for creating and editing tasks, and through AppleScript for
+  completing and cancelling them. This is the same interface Things exposes
+  to Shortcuts and automation tools.
 - **Task resolution** accepts a UUID, a title (with interactive
   disambiguation when multiple tasks match) or a numeric index into the last
   listing.

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -35,6 +35,7 @@ type CLI struct {
 	Show     ShowCmd     `cmd:"" help:"Show task detail."`
 	Add      AddCmd      `cmd:"" help:"Create a new task."`
 	Project  ProjectCmd  `cmd:"" help:"Manage projects."`
+	Edit     EditCmd     `cmd:"" help:"Edit a task via the Things URL scheme."`
 	Complete CompleteCmd `cmd:"" help:"Mark a task as completed."`
 	Cancel   CancelCmd   `cmd:"" help:"Cancel a task."`
 	Search   SearchCmd   `cmd:"" help:"Search tasks by title or notes."`
@@ -88,6 +89,36 @@ type ProjectAddCmd struct {
 	Tags     string `help:"Comma-separated tags."`
 	Area     string `help:"Area name or UUID."`
 	Todos    string `help:"Newline-separated initial to-dos."`
+}
+
+type EditCmd struct {
+	Task string `arg:"" required:"" help:"Task title, UUID, or numeric index from last list."`
+
+	Title *string `help:"Replace title."`
+
+	Notes        *string `help:"Replace notes."`
+	PrependNotes *string `help:"Prepend text to notes." name:"prepend-notes"`
+	AppendNotes  *string `help:"Append text to notes." name:"append-notes"`
+
+	When     *string `help:"When to schedule (date, today, tomorrow, evening, someday, anytime, or an ISO date)."`
+	Deadline *string `help:"Deadline date (YYYY-MM-DD) or empty to clear."`
+
+	Tags    *string `help:"Replace all tags (comma-separated)."`
+	AddTags *string `help:"Add tags (comma-separated)." name:"add-tags"`
+
+	Checklist        *string `help:"Replace checklist items (newline-separated)."`
+	PrependChecklist *string `help:"Prepend checklist items (newline-separated)." name:"prepend-checklist"`
+	AppendChecklist  *string `help:"Append checklist items (newline-separated)." name:"append-checklist"`
+
+	List      *string `help:"Move to list/project by name."`
+	ListID    *string `help:"Move to list/project by UUID." name:"list-id"`
+	Heading   *string `help:"Set heading within project by name."`
+	HeadingID *string `help:"Set heading by UUID." name:"heading-id"`
+
+	Complete  bool `help:"Mark the task as completed."`
+	Cancel    bool `help:"Mark the task as canceled."`
+	Duplicate bool `help:"Duplicate the task before applying edits."`
+	Reveal    bool `help:"Reveal the task in Things after editing."`
 }
 
 type CompleteCmd struct {
@@ -158,6 +189,8 @@ func run(ctx *kong.Context, cli *CLI, database *db.DB) error {
 		return runAdd(cli, database)
 	case "project add <title>":
 		return runProjectAdd(cli)
+	case "edit <task>":
+		return runEdit(cli, database)
 	case "complete <task>":
 		return runComplete(cli, database)
 	case "cancel <task>":
@@ -278,6 +311,46 @@ func runProjectAdd(cli *CLI) error {
 // (e.g. --todos "Draft\nShip"). Actual newlines in the input are preserved.
 func expandNewlines(s string) string {
 	return strings.ReplaceAll(s, `\n`, "\n")
+}
+
+func runEdit(cli *CLI, database *db.DB) error {
+	task, err := resolveTask(cli.Edit.Task, database)
+	if err != nil {
+		return err
+	}
+
+	token, _ := database.GetAuthToken()
+	return things.UpdateTask(things.UpdateParams{
+		ID:               task.UUID,
+		AuthToken:        token,
+		Title:            cli.Edit.Title,
+		Notes:            cli.Edit.Notes,
+		PrependNotes:     cli.Edit.PrependNotes,
+		AppendNotes:      cli.Edit.AppendNotes,
+		When:             cli.Edit.When,
+		Deadline:         cli.Edit.Deadline,
+		Tags:             cli.Edit.Tags,
+		AddTags:          cli.Edit.AddTags,
+		Checklist:        expandNewlinesPtr(cli.Edit.Checklist),
+		PrependChecklist: expandNewlinesPtr(cli.Edit.PrependChecklist),
+		AppendChecklist:  expandNewlinesPtr(cli.Edit.AppendChecklist),
+		List:             cli.Edit.List,
+		ListID:           cli.Edit.ListID,
+		Heading:          cli.Edit.Heading,
+		HeadingID:        cli.Edit.HeadingID,
+		Completed:        cli.Edit.Complete,
+		Canceled:         cli.Edit.Cancel,
+		Duplicate:        cli.Edit.Duplicate,
+		Reveal:           cli.Edit.Reveal,
+	})
+}
+
+func expandNewlinesPtr(p *string) *string {
+	if p == nil {
+		return nil
+	}
+	v := expandNewlines(*p)
+	return &v
 }
 
 func runComplete(cli *CLI, database *db.DB) error {

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -62,6 +62,77 @@ func AddProject(params AddProjectParams) error {
 	return openThingsURL("add-project", v)
 }
 
+type UpdateParams struct {
+	ID        string
+	AuthToken string
+
+	Title            *string
+	Notes            *string
+	PrependNotes     *string
+	AppendNotes      *string
+	When             *string
+	Deadline         *string
+	Tags             *string
+	AddTags          *string
+	Checklist        *string
+	PrependChecklist *string
+	AppendChecklist  *string
+	List             *string
+	ListID           *string
+	Heading          *string
+	HeadingID        *string
+	Completed        bool
+	Canceled         bool
+	Duplicate        bool
+	Reveal           bool
+}
+
+func UpdateTask(params UpdateParams) error {
+	if params.ID == "" {
+		return fmt.Errorf("update: task id is required")
+	}
+	if params.AuthToken == "" {
+		return fmt.Errorf("update: auth token is required — enable Things URLs in Things → Settings → General and ensure the app has been launched at least once")
+	}
+
+	v := url.Values{}
+	v.Set("id", params.ID)
+	v.Set("auth-token", params.AuthToken)
+
+	setStr := func(key string, p *string) {
+		if p != nil {
+			v.Set(key, *p)
+		}
+	}
+	setBool := func(key string, b bool) {
+		if b {
+			v.Set(key, "true")
+		}
+	}
+
+	setStr("title", params.Title)
+	setStr("notes", params.Notes)
+	setStr("prepend-notes", params.PrependNotes)
+	setStr("append-notes", params.AppendNotes)
+	setStr("when", params.When)
+	setStr("deadline", params.Deadline)
+	setStr("tags", params.Tags)
+	setStr("add-tags", params.AddTags)
+	setStr("checklist-items", params.Checklist)
+	setStr("prepend-checklist-items", params.PrependChecklist)
+	setStr("append-checklist-items", params.AppendChecklist)
+	setStr("list", params.List)
+	setStr("list-id", params.ListID)
+	setStr("heading", params.Heading)
+	setStr("heading-id", params.HeadingID)
+	setBool("completed", params.Completed)
+	setBool("canceled", params.Canceled)
+	setBool("duplicate", params.Duplicate)
+	setBool("reveal", params.Reveal)
+
+	return openThingsURL("update", v)
+}
+
 func AddTask(params AddParams) error {
 	v := url.Values{}
 	v.Set("title", params.Title)

--- a/internal/things/urlscheme_test.go
+++ b/internal/things/urlscheme_test.go
@@ -192,6 +192,182 @@ func TestAddProjectCommandFails(t *testing.T) {
 	}
 }
 
+func strPtr(s string) *string { return &s }
+
+func TestUpdateTaskMinimal(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	err := UpdateTask(UpdateParams{
+		ID:        "abc-123",
+		AuthToken: "tok",
+		Title:     strPtr("New Title"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
+	u := (*captured)[2]
+	if !strings.HasPrefix(u, "things:///update?") {
+		t.Fatalf("expected update URL, got %q", u)
+	}
+	if strings.Contains(u, "+") {
+		t.Errorf("URL should use %%20 not +: %q", u)
+	}
+	parsed, err := url.Parse(u)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	q := parsed.Query()
+	if q.Get("id") != "abc-123" {
+		t.Errorf("id = %q", q.Get("id"))
+	}
+	if q.Get("auth-token") != "tok" {
+		t.Errorf("auth-token = %q", q.Get("auth-token"))
+	}
+	if q.Get("title") != "New Title" {
+		t.Errorf("title = %q", q.Get("title"))
+	}
+}
+
+func TestUpdateTaskAllFields(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	err := UpdateTask(UpdateParams{
+		ID:               "id-1",
+		AuthToken:        "tok",
+		Title:            strPtr("T"),
+		Notes:            strPtr("n"),
+		PrependNotes:     strPtr("pre"),
+		AppendNotes:      strPtr("post"),
+		When:             strPtr("today"),
+		Deadline:         strPtr("2026-05-01"),
+		Tags:             strPtr("a,b"),
+		AddTags:          strPtr("c"),
+		Checklist:        strPtr("x\ny"),
+		PrependChecklist: strPtr("pc"),
+		AppendChecklist:  strPtr("ac"),
+		List:             strPtr("Inbox"),
+		ListID:           strPtr("list-uuid"),
+		Heading:          strPtr("H"),
+		HeadingID:        strPtr("heading-uuid"),
+		Completed:        true,
+		Canceled:         true,
+		Duplicate:        true,
+		Reveal:           true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := url.Parse((*captured)[2])
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	q := parsed.Query()
+
+	cases := map[string]string{
+		"id":                      "id-1",
+		"auth-token":              "tok",
+		"title":                   "T",
+		"notes":                   "n",
+		"prepend-notes":           "pre",
+		"append-notes":            "post",
+		"when":                    "today",
+		"deadline":                "2026-05-01",
+		"tags":                    "a,b",
+		"add-tags":                "c",
+		"checklist-items":         "x\ny",
+		"prepend-checklist-items": "pc",
+		"append-checklist-items":  "ac",
+		"list":                    "Inbox",
+		"list-id":                 "list-uuid",
+		"heading":                 "H",
+		"heading-id":              "heading-uuid",
+		"completed":               "true",
+		"canceled":                "true",
+		"duplicate":               "true",
+		"reveal":                  "true",
+	}
+	for k, want := range cases {
+		if got := q.Get(k); got != want {
+			t.Errorf("query[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestUpdateTaskOmitsUnsetFlags(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	if err := UpdateTask(UpdateParams{
+		ID:        "id",
+		AuthToken: "tok",
+		Title:     strPtr("only"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	u := (*captured)[2]
+	omitted := []string{
+		"notes=", "prepend-notes=", "append-notes=",
+		"when=", "deadline=", "tags=", "add-tags=",
+		"checklist-items=", "prepend-checklist-items=", "append-checklist-items=",
+		"list=", "list-id=", "heading=", "heading-id=",
+		"completed=", "canceled=", "duplicate=", "reveal=",
+	}
+	for _, k := range omitted {
+		if strings.Contains(u, k) {
+			t.Errorf("URL should not contain %q: %s", k, u)
+		}
+	}
+}
+
+func TestUpdateTaskEmptyStringClearsField(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	if err := UpdateTask(UpdateParams{
+		ID:        "id",
+		AuthToken: "tok",
+		Notes:     strPtr(""),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := url.Parse((*captured)[2])
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	if _, ok := parsed.Query()["notes"]; !ok {
+		t.Errorf("expected notes= param to be present (clear field)")
+	}
+}
+
+func TestUpdateTaskRequiresID(t *testing.T) {
+	stubRunner(t, false)
+	err := UpdateTask(UpdateParams{AuthToken: "tok", Title: strPtr("x")})
+	if err == nil {
+		t.Fatal("expected error for missing id")
+	}
+}
+
+func TestUpdateTaskRequiresAuthToken(t *testing.T) {
+	stubRunner(t, false)
+	err := UpdateTask(UpdateParams{ID: "id", Title: strPtr("x")})
+	if err == nil {
+		t.Fatal("expected error for missing auth token")
+	}
+	if !strings.Contains(err.Error(), "auth token") {
+		t.Errorf("error should mention auth token: %v", err)
+	}
+}
+
+func TestUpdateTaskCommandFails(t *testing.T) {
+	stubRunner(t, true)
+	err := UpdateTask(UpdateParams{ID: "id", AuthToken: "tok", Title: strPtr("x")})
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+	if !strings.Contains(err.Error(), "opening URL scheme") {
+		t.Errorf("error should mention URL scheme: %v", err)
+	}
+}
+
 func TestAddTaskCommandFails(t *testing.T) {
 	stubRunner(t, true)
 


### PR DESCRIPTION
## Summary

- Adds `things edit <task>` which wraps the `things:///update` URL scheme.
- Supports `--title`, `--notes` / `--prepend-notes` / `--append-notes`, `--when`, `--deadline`, `--tags` / `--add-tags`, `--checklist` / `--prepend-checklist` / `--append-checklist`, `--list` / `--list-id`, `--heading` / `--heading-id`, `--complete`, `--cancel`, `--duplicate`, `--reveal`.
- Tri-state `*string` flag handling: unset flags are omitted, while `--foo ""` explicitly clears the field (matching the URL scheme semantics).

Closes #17.

## Test plan

- [x] `make test` — unit tests assert each flag round-trips through the generated URL, and cover the "unset omits / empty clears" semantics.
- [x] `make lint` — clean.
- [x] Manual smoke: `things edit <task> --title "…"`, `--add-tags`, `--when tomorrow`, `--deadline ""` to clear, `--reveal`.
- [x] Verify actionable error when Things auth token is not available.