### PR TITLE
chore: block commits to main via hook; strengthen workflow docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git *)",
+            "command": "input=$(cat); cmd=$(echo \"$input\" | jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -qE '(^|[[:space:]]|;|&&|\\|\\|)git[[:space:]]+(add|commit|merge)\\b'; then branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Blocked by CLAUDE.md workflow: never commit to main. Create a topic branch first: git switch -c <topic> (or git worktree add .worktrees/<topic> -b <topic>).\"}}'; fi; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /things
 /coverage.out
-/.claude/
+/.claude/*
+!/.claude/settings.json
 /dist/
 /.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@ CLI for Things3 on macOS. Reads from the Things3 SQLite database (read-only) and
 
 ## Workflow
 
-- **Before making any changes**, check the current branch (`git branch --show-current`). If it's `main`, create a topic branch first — don't edit files, don't run write commands, don't stage anything while on `main`. This applies to all changes (code, tests, docs, `.claude/` config, everything), not just commits.
-- Prefer a worktree: `git worktree add .worktrees/<topic> -b <topic>` and work from there. Otherwise `git switch -c <topic>` on the current clone.
-- If you realize mid-task that you're on `main` with uncommitted changes, `git switch -c <topic>` immediately — this carries the working tree to the new branch — then continue.
-- A PreToolUse hook (`.claude/settings.local.json`) blocks `git add`/`commit`/`merge` while on `main` as a safety net. Treat the block as a bug in your workflow, not an obstacle to route around.
-- `main` only moves via PR merges and release tags (see `/release`). Never `git push` directly to `main`.
-- Use Conventional Commits.
+- **IMPORTANT: NEVER edit, write, or stage anything while on `main`.** First action every task: `git branch --show-current`. If `main`, **STOP**.
+- **DO** create a worktree: `git worktree add .worktrees/<topic> -b <topic>`, then work there. Fallback: `git switch -c <topic>`.
+- On `main` with uncommitted changes? **DO** `git switch -c <topic>` immediately — it carries the working tree over.
+- **IMPORTANT:** A PreToolUse hook blocks `git add`/`commit`/`merge` on `main`. If it fires, your workflow is wrong — fix it, don't route around it.
+- **NEVER** `git push` to `main`. It only moves via PR merge or release tag (`/release`).
+- **DO** use Conventional Commits.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,11 @@ CLI for Things3 on macOS. Reads from the Things3 SQLite database (read-only) and
 
 ## Workflow
 
-- Never commit to `main`. Work on a branch, ideally a worktree (`git worktree add .worktrees/<topic> -b <topic>`). If you find yourself on `main` with changes, `git switch -c <topic>` before committing.
-- `main` only moves via PR merges and release tags (see `/release`).
+- **Before making any changes**, check the current branch (`git branch --show-current`). If it's `main`, create a topic branch first — don't edit files, don't run write commands, don't stage anything while on `main`. This applies to all changes (code, tests, docs, `.claude/` config, everything), not just commits.
+- Prefer a worktree: `git worktree add .worktrees/<topic> -b <topic>` and work from there. Otherwise `git switch -c <topic>` on the current clone.
+- If you realize mid-task that you're on `main` with uncommitted changes, `git switch -c <topic>` immediately — this carries the working tree to the new branch — then continue.
+- A PreToolUse hook (`.claude/settings.local.json`) blocks `git add`/`commit`/`merge` while on `main` as a safety net. Treat the block as a bug in your workflow, not an obstacle to route around.
+- `main` only moves via PR merges and release tags (see `/release`). Never `git push` directly to `main`.
 - Use Conventional Commits.
 
 ## Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ CLI for Things3 on macOS. Reads from the Things3 SQLite database (read-only) and
 - **IMPORTANT: NEVER edit, write, or stage anything while on `main`.** First action every task: `git branch --show-current`. If `main`, **STOP**.
 - **DO** create a worktree: `git worktree add .worktrees/<topic> -b <topic>`, then work there. Fallback: `git switch -c <topic>`.
 - On `main` with uncommitted changes? **DO** `git switch -c <topic>` immediately — it carries the working tree over.
-- **IMPORTANT:** A PreToolUse hook blocks `git add`/`commit`/`merge` on `main`. If it fires, your workflow is wrong — fix it, don't route around it.
+- **IMPORTANT:** A PreToolUse hook (`.claude/settings.json`) blocks `git add`/`commit`/`merge` on `main`. If it fires, your workflow is wrong — fix it, don't route around it.
 - **NEVER** `git push` to `main`. It only moves via PR merge or release tag (`/release`).
 - **DO** use Conventional Commits.
 


### PR DESCRIPTION
## Summary
- Tightens `## Workflow` in CLAUDE.md: check branch *before making changes* (not just before committing), covers all files including config, uses **DO**/**IMPORTANT**/**NEVER** markers for stronger steering.
- Adds a committed PreToolUse hook at `.claude/settings.json` that blocks `git add`/`commit`/`merge` while on `main`, so every Claude Code instance working in this repo gets the safety net without per-clone setup.
- Whitelists `.claude/settings.json` through `.gitignore`; personal files (`settings.local.json`, `commands/`) stay ignored.

## Test plan
- [x] Hook pipe-tested on real stdin payloads: `git commit` on main → deny JSON; `git status` → no-op; chained `make test && git add .` on main → deny.
- [x] Hook proven live: `git commit --dry-run` on main was blocked with the CLAUDE.md message.
- [x] `.gitignore` verified: `git check-ignore` reports `settings.json` matches the negation rule; `settings.local.json` and `commands/` still ignored.
- [x] JSON schema validated with `jq -e` on the hook path.