### PR TITLE
feat: add `things open` to reveal items in Things3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ things complete 3
 things cancel "Old idea"
 things search migrate
 
+things open today                 # reveal a built-in list in the app
+things open "Pay rent"            # reveal a task by title
+things open --project "Launch"    # reveal a project
+things open --query staging       # app-side quick find
+
 things log                        # move today's done/cancelled items to Logbook
 things version                    # print version
 ```

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -40,6 +40,7 @@ type CLI struct {
 	Cancel   CancelCmd   `cmd:"" help:"Cancel a task."`
 	Search   SearchCmd   `cmd:"" help:"Search tasks by title or notes."`
 	Log      LogCmd      `cmd:"" help:"Move completed and cancelled items from Today to the Logbook (Items → Log Completed)."`
+	Open     OpenCmd     `cmd:"" help:"Reveal a task, project, area, tag, or built-in list in Things3."`
 	Ver      VersionCmd  `cmd:"" name:"version" help:"Print version and exit."`
 }
 
@@ -135,13 +136,26 @@ type SearchCmd struct {
 
 type LogCmd struct{}
 
+type OpenCmd struct {
+	Ref        string `arg:"" optional:"" help:"Task/project UUID, numeric list index, title, or built-in list name (${builtin_lists})."`
+	Project    string `help:"Open project by name or UUID." short:"p"`
+	Area       string `help:"Open area by name or UUID." short:"a"`
+	Tag        string `help:"Open tag by name or UUID." short:"t"`
+	Query      string `help:"App-side quick find." short:"q"`
+	Filter     string `help:"Tag filter on the shown list (comma-separated)."`
+	Background bool   `help:"Don't bring Things to the foreground."`
+}
+
 func main() {
 	var cli CLI
 	ctx := kong.Parse(&cli,
 		kong.Name("things"),
 		kong.Description("CLI for Things3"),
 		kong.UsageOnError(),
-		kong.Vars{"version": fmt.Sprintf("things %s (commit %s, built %s)", version, commit, date)},
+		kong.Vars{
+			"version":       fmt.Sprintf("things %s (commit %s, built %s)", version, commit, date),
+			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
+		},
 	)
 
 	if ctx.Command() == "version" {
@@ -199,6 +213,8 @@ func run(ctx *kong.Context, cli *CLI, database *db.DB) error {
 		return runSearch(cli, database)
 	case "log":
 		return things.LogCompleted()
+	case "open", "open <ref>":
+		return runOpen(cli, database)
 	case "version":
 		return nil
 	default:
@@ -444,6 +460,64 @@ func confirmAction(msg string) bool {
 	}
 	answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
 	return answer == "y" || answer == "yes"
+}
+
+func runOpen(cli *CLI, database *db.DB) error {
+	cmd := &cli.Open
+
+	flags := 0
+	for _, s := range []string{cmd.Ref, cmd.Project, cmd.Area, cmd.Tag, cmd.Query} {
+		if s != "" {
+			flags++
+		}
+	}
+	if flags == 0 {
+		return fmt.Errorf("open: pass a reference, --project, --area, --tag, or --query")
+	}
+	if flags > 1 {
+		return fmt.Errorf("open: pass only one of <ref>, --project, --area, --tag, --query")
+	}
+
+	params := things.ShowParams{Filter: cmd.Filter, Background: cmd.Background}
+
+	switch {
+	case cmd.Query != "":
+		params.Query = cmd.Query
+	case cmd.Area != "":
+		uuid, err := database.FindAreaUUID(cmd.Area)
+		if err != nil {
+			return err
+		}
+		if uuid == "" {
+			return fmt.Errorf("area not found: %s", cmd.Area)
+		}
+		params.ID = uuid
+	case cmd.Tag != "":
+		uuid, err := database.FindTagUUID(cmd.Tag)
+		if err != nil {
+			return err
+		}
+		if uuid == "" {
+			return fmt.Errorf("tag not found: %s", cmd.Tag)
+		}
+		params.ID = uuid
+	case cmd.Project != "":
+		task, err := resolveTask(cmd.Project, database)
+		if err != nil {
+			return err
+		}
+		params.ID = task.UUID
+	case things.IsBuiltinList(cmd.Ref):
+		params.ID = cmd.Ref
+	default:
+		task, err := resolveTask(cmd.Ref, database)
+		if err != nil {
+			return err
+		}
+		params.ID = task.UUID
+	}
+
+	return things.Show(params)
 }
 
 func runSearch(cli *CLI, database *db.DB) error {

--- a/cmd/things/main_test.go
+++ b/cmd/things/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/alecthomas/kong"
@@ -9,12 +10,15 @@ import (
 	"github.com/ryanlewis/things-cli/internal/db"
 	"github.com/ryanlewis/things-cli/internal/db/dbtest"
 	"github.com/ryanlewis/things-cli/internal/model"
+	"github.com/ryanlewis/things-cli/internal/things"
 )
 
 func parse(t *testing.T, args ...string) (*CLI, *kong.Context) {
 	t.Helper()
 	var cli CLI
-	parser, err := kong.New(&cli, kong.Name("things"))
+	parser, err := kong.New(&cli, kong.Name("things"),
+		kong.Vars{"builtin_lists": strings.Join(things.BuiltinLists, ", ")},
+	)
 	if err != nil {
 		t.Fatalf("kong.New: %v", err)
 	}

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ryanlewis/things-cli/internal/db"
 	"github.com/ryanlewis/things-cli/internal/db/dbtest"
 	"github.com/ryanlewis/things-cli/internal/model"
+	"github.com/ryanlewis/things-cli/internal/things"
 )
 
 // withSilentStdout replaces os.Stdout for the duration of fn with a pipe that
@@ -104,7 +105,9 @@ func runWith(t *testing.T, database *db.DB, args ...string) error {
 	t.Setenv("HOME", t.TempDir())
 
 	var cli CLI
-	parser, err := kong.New(&cli, kong.Name("things"))
+	parser, err := kong.New(&cli, kong.Name("things"),
+		kong.Vars{"builtin_lists": strings.Join(things.BuiltinLists, ", ")},
+	)
 	if err != nil {
 		t.Fatalf("kong.New: %v", err)
 	}
@@ -202,6 +205,38 @@ func TestResolveTaskNumericWithoutCache(t *testing.T) {
 	_, err := resolveTask("1", database)
 	if err == nil {
 		t.Fatal("expected not-found when no cache and no title match")
+	}
+}
+
+func TestRunOpenRequiresArg(t *testing.T) {
+	database := seedFullDB(t)
+	err := runWith(t, database, "open")
+	if err == nil || !strings.Contains(err.Error(), "pass a reference") {
+		t.Fatalf("expected missing-arg error, got: %v", err)
+	}
+}
+
+func TestRunOpenConflictingArgs(t *testing.T) {
+	database := seedFullDB(t)
+	err := runWith(t, database, "open", "today", "--query", "milk")
+	if err == nil || !strings.Contains(err.Error(), "only one of") {
+		t.Fatalf("expected conflict error, got: %v", err)
+	}
+}
+
+func TestRunOpenAreaNotFound(t *testing.T) {
+	database := seedFullDB(t)
+	err := runWith(t, database, "open", "--area", "Nope")
+	if err == nil || !strings.Contains(err.Error(), "area not found") {
+		t.Fatalf("expected area-not-found, got: %v", err)
+	}
+}
+
+func TestRunOpenTagNotFound(t *testing.T) {
+	database := seedFullDB(t)
+	err := runWith(t, database, "open", "--tag", "nope")
+	if err == nil || !strings.Contains(err.Error(), "tag not found") {
+		t.Fatalf("expected tag-not-found, got: %v", err)
 	}
 }
 

--- a/internal/db/areas.go
+++ b/internal/db/areas.go
@@ -1,10 +1,28 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
 
 	"github.com/ryanlewis/things-cli/internal/model"
 )
+
+// FindAreaUUID resolves an area reference (UUID or title) to its UUID,
+// returning "" when no row matches.
+func (d *DB) FindAreaUUID(ref string) (string, error) {
+	var uuid string
+	err := d.db.QueryRow(
+		`SELECT uuid FROM TMArea WHERE uuid = ? OR title = ? LIMIT 1`,
+		ref, ref,
+	).Scan(&uuid)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("finding area: %w", err)
+	}
+	return uuid, nil
+}
 
 func (d *DB) ListAreas() ([]model.Area, error) {
 	query := `

--- a/internal/db/areas_test.go
+++ b/internal/db/areas_test.go
@@ -28,6 +28,29 @@ func TestListAreasOrdered(t *testing.T) {
 	}
 }
 
+func TestFindAreaUUID(t *testing.T) {
+	d := newTestDB(t)
+	mustExec(t, d, `INSERT INTO TMArea (uuid, title, visible, "index") VALUES ('a1', 'Work', 1, 0)`)
+
+	for _, ref := range []string{"Work", "a1"} {
+		got, err := d.FindAreaUUID(ref)
+		if err != nil {
+			t.Fatalf("FindAreaUUID(%q): %v", ref, err)
+		}
+		if got != "a1" {
+			t.Errorf("FindAreaUUID(%q) = %q, want a1", ref, got)
+		}
+	}
+
+	got, err := d.FindAreaUUID("missing")
+	if err != nil {
+		t.Fatalf("FindAreaUUID(missing): %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for missing area, got %q", got)
+	}
+}
+
 func TestListAreasEmpty(t *testing.T) {
 	d := newTestDB(t)
 	areas, err := d.ListAreas()

--- a/internal/db/tags.go
+++ b/internal/db/tags.go
@@ -1,10 +1,28 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
 
 	"github.com/ryanlewis/things-cli/internal/model"
 )
+
+// FindTagUUID resolves a tag reference (UUID or title) to its UUID,
+// returning "" when no row matches.
+func (d *DB) FindTagUUID(ref string) (string, error) {
+	var uuid string
+	err := d.db.QueryRow(
+		`SELECT uuid FROM TMTag WHERE uuid = ? OR title = ? LIMIT 1`,
+		ref, ref,
+	).Scan(&uuid)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("finding tag: %w", err)
+	}
+	return uuid, nil
+}
 
 func (d *DB) ListTags() ([]model.Tag, error) {
 	query := `

--- a/internal/db/tags_test.go
+++ b/internal/db/tags_test.go
@@ -28,6 +28,29 @@ func TestListTagsOrdered(t *testing.T) {
 	}
 }
 
+func TestFindTagUUID(t *testing.T) {
+	d := newTestDB(t)
+	mustExec(t, d, `INSERT INTO TMTag (uuid, title, "index") VALUES ('t1', 'urgent', 0)`)
+
+	for _, ref := range []string{"urgent", "t1"} {
+		got, err := d.FindTagUUID(ref)
+		if err != nil {
+			t.Fatalf("FindTagUUID(%q): %v", ref, err)
+		}
+		if got != "t1" {
+			t.Errorf("FindTagUUID(%q) = %q, want t1", ref, got)
+		}
+	}
+
+	got, err := d.FindTagUUID("missing")
+	if err != nil {
+		t.Fatalf("FindTagUUID(missing): %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for missing tag, got %q", got)
+	}
+}
+
 func TestListTagsEmpty(t *testing.T) {
 	d := newTestDB(t)
 	tags, err := d.ListTags()

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -3,6 +3,7 @@ package things
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 )
 
@@ -28,14 +29,67 @@ type AddProjectParams struct {
 	Todos    string
 }
 
-// openThingsURL builds a things:/// URL for the given command and runs it via
-// `open -g`. url.Values.Encode uses + for spaces, but Things expects %20.
+// openThingsURL hands a things:/// URL to `open -g` so writes don't steal
+// focus. url.Values.Encode uses + for spaces, but Things expects %20.
 func openThingsURL(command string, v url.Values) error {
-	u := "things:///" + command + "?" + strings.ReplaceAll(v.Encode(), "+", "%20")
-	if err := execCommand("open", "-g", u).Run(); err != nil {
+	return runOpen("-g", buildThingsURL(command, v))
+}
+
+func buildThingsURL(command string, v url.Values) string {
+	return "things:///" + command + "?" + strings.ReplaceAll(v.Encode(), "+", "%20")
+}
+
+func runOpen(args ...string) error {
+	if err := execCommand("open", args...).Run(); err != nil {
 		return fmt.Errorf("opening URL scheme: %w", err)
 	}
 	return nil
+}
+
+// BuiltinLists are the navigable list IDs the Things URL scheme accepts
+// verbatim as `id=…`. Some (e.g. repeating, all-projects) have no direct
+// DB equivalent — they're app-side views only.
+var BuiltinLists = []string{
+	"inbox", "today", "anytime", "upcoming", "someday", "logbook",
+	"tomorrow", "deadlines", "repeating", "all-projects", "logged-projects",
+}
+
+func IsBuiltinList(name string) bool {
+	return slices.Contains(BuiltinLists, name)
+}
+
+type ShowParams struct {
+	// ID is a UUID or built-in list name (inbox, today, upcoming, …).
+	ID string
+	// Query triggers app-side quick find instead of a direct show.
+	Query string
+	// Filter is a comma-separated tag list that scopes the shown view.
+	Filter string
+	// Background uses `open -g` to avoid bringing Things to the foreground.
+	Background bool
+}
+
+// Show navigates Things to a task, project, area, tag, built-in list, or
+// query result via `things:///show`.
+func Show(params ShowParams) error {
+	if params.ID == "" && params.Query == "" {
+		return fmt.Errorf("show: id or query is required")
+	}
+	v := url.Values{}
+	if params.ID != "" {
+		v.Set("id", params.ID)
+	}
+	if params.Query != "" {
+		v.Set("query", params.Query)
+	}
+	if params.Filter != "" {
+		v.Set("filter", params.Filter)
+	}
+	u := buildThingsURL("show", v)
+	if params.Background {
+		return runOpen("-g", u)
+	}
+	return runOpen(u)
 }
 
 func AddProject(params AddProjectParams) error {

--- a/internal/things/urlscheme_test.go
+++ b/internal/things/urlscheme_test.go
@@ -368,6 +368,98 @@ func TestUpdateTaskCommandFails(t *testing.T) {
 	}
 }
 
+func TestShowByID(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	if err := Show(ShowParams{ID: "task-uuid"}); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	if len(*captured) != 2 {
+		t.Fatalf("expected 2 args (open <url>), got: %v", *captured)
+	}
+	if (*captured)[0] != "open" {
+		t.Fatalf("unexpected command: %v", *captured)
+	}
+	u := (*captured)[1]
+	if !strings.HasPrefix(u, "things:///show?") {
+		t.Fatalf("expected show URL, got %q", u)
+	}
+	parsed, err := url.Parse(u)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	if got := parsed.Query().Get("id"); got != "task-uuid" {
+		t.Errorf("id = %q", got)
+	}
+}
+
+func TestShowBuiltinList(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	if err := Show(ShowParams{ID: "today"}); err != nil {
+		t.Fatal(err)
+	}
+	parsed, _ := url.Parse((*captured)[1])
+	if got := parsed.Query().Get("id"); got != "today" {
+		t.Errorf("id = %q, want today", got)
+	}
+}
+
+func TestShowQueryAndFilter(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	if err := Show(ShowParams{Query: "staging", Filter: "urgent,work"}); err != nil {
+		t.Fatal(err)
+	}
+	u := (*captured)[1]
+	if strings.Contains(u, "+") {
+		t.Errorf("URL should use %%20 not +: %q", u)
+	}
+	parsed, err := url.Parse(u)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	q := parsed.Query()
+	if q.Get("query") != "staging" {
+		t.Errorf("query = %q", q.Get("query"))
+	}
+	if q.Get("filter") != "urgent,work" {
+		t.Errorf("filter = %q", q.Get("filter"))
+	}
+	if _, ok := q["id"]; ok {
+		t.Errorf("id should be absent when only query is set")
+	}
+}
+
+func TestShowBackgroundUsesDashG(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	if err := Show(ShowParams{ID: "inbox", Background: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(*captured) != 3 || (*captured)[1] != "-g" {
+		t.Fatalf("expected open -g <url>, got: %v", *captured)
+	}
+}
+
+func TestShowRequiresIDOrQuery(t *testing.T) {
+	stubRunner(t, false)
+	if err := Show(ShowParams{}); err == nil {
+		t.Fatal("expected error when id and query are both empty")
+	}
+}
+
+func TestShowCommandFails(t *testing.T) {
+	stubRunner(t, true)
+	err := Show(ShowParams{ID: "today"})
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+	if !strings.Contains(err.Error(), "opening URL scheme") {
+		t.Errorf("error should mention URL scheme: %v", err)
+	}
+}
+
 func TestAddTaskCommandFails(t *testing.T) {
 	stubRunner(t, true)
 


### PR DESCRIPTION
## Summary

- Adds `things open <ref>` to navigate the Things3 app to a task, project, area, tag, built-in list, or query result via `things:///show`.
- Foreground by default (drops `-g` from `open`); `--background` keeps focus.
- Mutually-exclusive forms: positional `<ref>`, `--project`, `--area`, `--tag`, `--query`. Optional `--filter tag1,tag2` scopes the shown list.
- Built-in list names (`inbox`, `today`, `upcoming`, …) live in `internal/things.BuiltinLists` as the single source of truth; the CLI help text is populated from there via a kong var.
- New DB lookups: `FindAreaUUID` / `FindTagUUID`. Projects reuse the existing `resolveTask` path (projects live in `TMTask`).

Closes #20

## Test plan

- [x] `make test` (123 passing, including URL-scheme assertions for `show` and runtime validation errors)
- [x] `make lint`
- [x] Manual: `things open today`, `things open "Pay rent"`, `things open --project "…"`, `things open --query staging --filter urgent`