### PR TITLE
feat: add `things skill` command group with bundled Claude Code skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ CLI for Things3 on macOS. Reads from the Things3 SQLite database (read-only) and
 - **IMPORTANT:** A PreToolUse hook (`.claude/settings.json`) blocks `git add`/`commit`/`merge` on `main`. If it fires, your workflow is wrong — fix it, don't route around it.
 - **NEVER** `git push` to `main`. It only moves via PR merge or release tag (`/release`).
 - **DO** use Conventional Commits.
+- **DO** update `internal/skill/body.md` when adding, removing, or changing a subcommand's surface — the bundled agent skill is shipped in-binary and drifts silently otherwise.
 
 ## Commands
 

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ryanlewis/things-cli/internal/db"
 	"github.com/ryanlewis/things-cli/internal/model"
 	"github.com/ryanlewis/things-cli/internal/output"
+	"github.com/ryanlewis/things-cli/internal/skill"
 	"github.com/ryanlewis/things-cli/internal/things"
 )
 
@@ -41,6 +42,7 @@ type CLI struct {
 	Search   SearchCmd   `cmd:"" help:"Search tasks by title or notes."`
 	Log      LogCmd      `cmd:"" help:"Move completed and cancelled items from Today to the Logbook (Items → Log Completed)."`
 	Open     OpenCmd     `cmd:"" help:"Reveal a task, project, area, tag, or built-in list in Things3."`
+	Skill    SkillCmd    `cmd:"" help:"Manage the bundled agent skill (Claude Code, etc.)."`
 	Ver      VersionCmd  `cmd:"" name:"version" help:"Print version and exit."`
 }
 
@@ -136,6 +138,31 @@ type SearchCmd struct {
 
 type LogCmd struct{}
 
+type SkillCmd struct {
+	Install   SkillInstallCmd   `cmd:"" help:"Install the bundled skill for an AI coding agent."`
+	Uninstall SkillUninstallCmd `cmd:"" help:"Remove the bundled skill for an AI coding agent."`
+	Show      SkillShowCmd      `cmd:"" help:"Print the skill source (neutral, or rendered for an agent)."`
+	List      SkillListCmd      `cmd:"" help:"List supported agents."`
+}
+
+type SkillInstallCmd struct {
+	Agent string `arg:"" required:"" help:"Target agent (${skill_agents})."`
+	Path  string `help:"Override destination directory."`
+	Yes   bool   `help:"Assume yes — overwrite without prompting." short:"y"`
+}
+
+type SkillUninstallCmd struct {
+	Agent string `arg:"" required:"" help:"Target agent (${skill_agents})."`
+	Path  string `help:"Override directory to uninstall from."`
+	Yes   bool   `help:"Assume yes — uninstall without prompting." short:"y"`
+}
+
+type SkillShowCmd struct {
+	Agent string `arg:"" optional:"" help:"Render for a specific agent (${skill_agents}); default is the neutral source."`
+}
+
+type SkillListCmd struct{}
+
 type OpenCmd struct {
 	Ref        string `arg:"" optional:"" help:"Task/project UUID, numeric list index, title, or built-in list name (${builtin_lists})."`
 	Project    string `help:"Open project by name or UUID." short:"p"`
@@ -155,11 +182,20 @@ func main() {
 		kong.Vars{
 			"version":       fmt.Sprintf("things %s (commit %s, built %s)", version, commit, date),
 			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
+			"skill_agents":  skillAgentNames(),
 		},
 	)
 
 	if ctx.Command() == "version" {
 		fmt.Printf("things %s (commit %s, built %s)\n", version, commit, date)
+		return
+	}
+
+	if strings.HasPrefix(ctx.Command(), "skill ") {
+		if err := runSkill(ctx, &cli); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 		return
 	}
 
@@ -527,6 +563,123 @@ func runSearch(cli *CLI, database *db.DB) error {
 	}
 	cacheTaskUUIDs(tasks)
 	return output.Print(os.Stdout, tasks, cli.JSON)
+}
+
+func skillAgentNames() string {
+	agents := skill.Agents()
+	names := make([]string, len(agents))
+	for i, a := range agents {
+		names[i] = a.Name()
+	}
+	return strings.Join(names, ", ")
+}
+
+func runSkill(ctx *kong.Context, cli *CLI) error {
+	switch ctx.Command() {
+	case "skill install <agent>":
+		return runSkillInstall(cli)
+	case "skill uninstall <agent>":
+		return runSkillUninstall(cli)
+	case "skill show", "skill show <agent>":
+		return runSkillShow(cli)
+	case "skill list":
+		return runSkillList()
+	default:
+		return fmt.Errorf("unknown skill command: %s", ctx.Command())
+	}
+}
+
+func runSkillInstall(cli *CLI) error {
+	agent, err := skill.Lookup(cli.Skill.Install.Agent)
+	if err != nil {
+		return err
+	}
+	dir := cli.Skill.Install.Path
+	if dir == "" {
+		dir, err = agent.DefaultDir()
+		if err != nil {
+			return err
+		}
+	}
+	if skill.Exists(agent, dir) && !cli.Skill.Install.Yes {
+		if !isInteractive() {
+			return fmt.Errorf("skill already installed at %s — pass -y to overwrite", dir)
+		}
+		if !confirmAction(fmt.Sprintf("Skill already installed at %s. Overwrite?", dir)) {
+			return fmt.Errorf("cancelled")
+		}
+	}
+	if err := skill.Install(agent, dir); err != nil {
+		return err
+	}
+	fmt.Printf("Installed %s skill to %s\n", agent.Name(), dir)
+	return nil
+}
+
+func runSkillUninstall(cli *CLI) error {
+	agent, err := skill.Lookup(cli.Skill.Uninstall.Agent)
+	if err != nil {
+		return err
+	}
+	dir := cli.Skill.Uninstall.Path
+	if dir == "" {
+		dir, err = agent.DefaultDir()
+		if err != nil {
+			return err
+		}
+	}
+	present := skill.InstalledFiles(agent, dir)
+	if len(present) == 0 {
+		return fmt.Errorf("no %s skill installed at %s", agent.Name(), dir)
+	}
+	fmt.Fprintf(os.Stderr, "Will remove %d file(s) from %s:\n", len(present), dir)
+	for _, f := range present {
+		fmt.Fprintf(os.Stderr, "  - %s\n", f)
+	}
+	if !cli.Skill.Uninstall.Yes {
+		if !isInteractive() {
+			return fmt.Errorf("refusing to uninstall non-interactively — pass -y to confirm")
+		}
+		if !confirmAction(fmt.Sprintf("Remove %s skill at %s?", agent.Name(), dir)) {
+			return fmt.Errorf("cancelled")
+		}
+	}
+	if err := skill.Uninstall(agent, dir); err != nil {
+		return err
+	}
+	fmt.Printf("Removed %s skill from %s\n", agent.Name(), dir)
+	return nil
+}
+
+func runSkillShow(cli *CLI) error {
+	name := cli.Skill.Show.Agent
+	if name == "" {
+		fmt.Print(skill.Body())
+		return nil
+	}
+	agent, err := skill.Lookup(name)
+	if err != nil {
+		return err
+	}
+	for fname, content := range agent.Files() {
+		fmt.Printf("# %s\n%s", fname, content)
+	}
+	return nil
+}
+
+func runSkillList() error {
+	for _, a := range skill.Agents() {
+		dir, err := a.DefaultDir()
+		if err != nil {
+			dir = "(unknown)"
+		}
+		status := "not installed"
+		if skill.Exists(a, dir) {
+			status = "installed"
+		}
+		fmt.Printf("%-10s %s  (%s)\n", a.Name(), dir, status)
+	}
+	return nil
 }
 
 func cacheTaskUUIDs(tasks []model.Task) {

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -182,7 +182,7 @@ func main() {
 		kong.Vars{
 			"version":       fmt.Sprintf("things %s (commit %s, built %s)", version, commit, date),
 			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
-			"skill_agents":  skillAgentNames(),
+			"skill_agents":  skill.AgentNames(),
 		},
 	)
 
@@ -565,13 +565,11 @@ func runSearch(cli *CLI, database *db.DB) error {
 	return output.Print(os.Stdout, tasks, cli.JSON)
 }
 
-func skillAgentNames() string {
-	agents := skill.Agents()
-	names := make([]string, len(agents))
-	for i, a := range agents {
-		names[i] = a.Name()
+func resolveSkillDir(agent skill.Agent, override string) (string, error) {
+	if override != "" {
+		return override, nil
 	}
-	return strings.Join(names, ", ")
+	return agent.DefaultDir()
 }
 
 func runSkill(ctx *kong.Context, cli *CLI) error {
@@ -594,12 +592,9 @@ func runSkillInstall(cli *CLI) error {
 	if err != nil {
 		return err
 	}
-	dir := cli.Skill.Install.Path
-	if dir == "" {
-		dir, err = agent.DefaultDir()
-		if err != nil {
-			return err
-		}
+	dir, err := resolveSkillDir(agent, cli.Skill.Install.Path)
+	if err != nil {
+		return err
 	}
 	if skill.Exists(agent, dir) && !cli.Skill.Install.Yes {
 		if !isInteractive() {
@@ -621,12 +616,9 @@ func runSkillUninstall(cli *CLI) error {
 	if err != nil {
 		return err
 	}
-	dir := cli.Skill.Uninstall.Path
-	if dir == "" {
-		dir, err = agent.DefaultDir()
-		if err != nil {
-			return err
-		}
+	dir, err := resolveSkillDir(agent, cli.Skill.Uninstall.Path)
+	if err != nil {
+		return err
 	}
 	present := skill.InstalledFiles(agent, dir)
 	if len(present) == 0 {

--- a/cmd/things/main_test.go
+++ b/cmd/things/main_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ryanlewis/things-cli/internal/db"
 	"github.com/ryanlewis/things-cli/internal/db/dbtest"
 	"github.com/ryanlewis/things-cli/internal/model"
+	"github.com/ryanlewis/things-cli/internal/skill"
 	"github.com/ryanlewis/things-cli/internal/things"
 )
 
@@ -19,7 +20,7 @@ func parse(t *testing.T, args ...string) (*CLI, *kong.Context) {
 	parser, err := kong.New(&cli, kong.Name("things"),
 		kong.Vars{
 			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
-			"skill_agents":  skillAgentNames(),
+			"skill_agents":  skill.AgentNames(),
 		},
 	)
 	if err != nil {

--- a/cmd/things/main_test.go
+++ b/cmd/things/main_test.go
@@ -17,7 +17,10 @@ func parse(t *testing.T, args ...string) (*CLI, *kong.Context) {
 	t.Helper()
 	var cli CLI
 	parser, err := kong.New(&cli, kong.Name("things"),
-		kong.Vars{"builtin_lists": strings.Join(things.BuiltinLists, ", ")},
+		kong.Vars{
+			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
+			"skill_agents":  skillAgentNames(),
+		},
 	)
 	if err != nil {
 		t.Fatalf("kong.New: %v", err)
@@ -90,6 +93,31 @@ func TestKongSearch(t *testing.T) {
 	cli, ctx := parse(t, "search", "foo bar")
 	if ctx.Command() != "search <query>" || cli.Search.Query != "foo bar" {
 		t.Errorf("search parse: cmd=%q query=%q", ctx.Command(), cli.Search.Query)
+	}
+}
+
+func TestKongSkillCommands(t *testing.T) {
+	cases := []struct {
+		args    []string
+		command string
+		check   func(*CLI) bool
+	}{
+		{[]string{"skill", "list"}, "skill list", func(*CLI) bool { return true }},
+		{[]string{"skill", "show"}, "skill show", func(c *CLI) bool { return c.Skill.Show.Agent == "" }},
+		{[]string{"skill", "show", "claude"}, "skill show <agent>", func(c *CLI) bool { return c.Skill.Show.Agent == "claude" }},
+		{[]string{"skill", "install", "claude"}, "skill install <agent>", func(c *CLI) bool { return c.Skill.Install.Agent == "claude" && !c.Skill.Install.Yes }},
+		{[]string{"skill", "install", "claude", "-y"}, "skill install <agent>", func(c *CLI) bool { return c.Skill.Install.Yes }},
+		{[]string{"skill", "install", "claude", "--path", "/tmp/x"}, "skill install <agent>", func(c *CLI) bool { return c.Skill.Install.Path == "/tmp/x" }},
+		{[]string{"skill", "uninstall", "claude", "-y"}, "skill uninstall <agent>", func(c *CLI) bool { return c.Skill.Uninstall.Yes }},
+	}
+	for _, tc := range cases {
+		cli, ctx := parse(t, tc.args...)
+		if ctx.Command() != tc.command {
+			t.Errorf("%v: Command = %q, want %q", tc.args, ctx.Command(), tc.command)
+		}
+		if !tc.check(cli) {
+			t.Errorf("%v: check failed, CLI = %+v", tc.args, cli.Skill)
+		}
 	}
 }
 

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -106,7 +106,10 @@ func runWith(t *testing.T, database *db.DB, args ...string) error {
 
 	var cli CLI
 	parser, err := kong.New(&cli, kong.Name("things"),
-		kong.Vars{"builtin_lists": strings.Join(things.BuiltinLists, ", ")},
+		kong.Vars{
+			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
+			"skill_agents":  skillAgentNames(),
+		},
 	)
 	if err != nil {
 		t.Fatalf("kong.New: %v", err)

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ryanlewis/things-cli/internal/db"
 	"github.com/ryanlewis/things-cli/internal/db/dbtest"
 	"github.com/ryanlewis/things-cli/internal/model"
+	"github.com/ryanlewis/things-cli/internal/skill"
 	"github.com/ryanlewis/things-cli/internal/things"
 )
 
@@ -108,7 +109,7 @@ func runWith(t *testing.T, database *db.DB, args ...string) error {
 	parser, err := kong.New(&cli, kong.Name("things"),
 		kong.Vars{
 			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
-			"skill_agents":  skillAgentNames(),
+			"skill_agents":  skill.AgentNames(),
 		},
 	)
 	if err != nil {

--- a/internal/skill/body.md
+++ b/internal/skill/body.md
@@ -1,0 +1,94 @@
+# things-cli — Things3 CLI for macOS
+
+Use the `things` CLI whenever the user mentions Things3, tasks, todos, inbox,
+today, upcoming, projects, or areas on macOS. The binary reads the local
+Things3 SQLite database and writes via the `things:///` URL scheme /
+AppleScript.
+
+## Safety model
+
+- **Read operations hit SQLite read-only** (`PRAGMA query_only = ON`). These
+  are safe and fast: `list`, `show`, `projects`, `areas`, `tags`, `search`.
+- **Write operations go through Things3**: `add`, `project add`, `edit`,
+  `complete`, `cancel`, `log`, `open`. These launch URL schemes or AppleScript
+  and affect the user's real data — confirm before running destructive writes
+  (`complete`, `cancel`, bulk `edit`).
+
+## Output
+
+Most commands accept `--json` / `-j` for machine-readable output. Default
+output is a human-friendly plain text table. Prefer `--json` when piping into
+another tool or parsing in an agent context.
+
+## Core commands
+
+```
+things list [view] [--project P] [--area A] [--tag T]
+    # views: today, inbox, upcoming, anytime, someday, logbook, trash, deadlines
+    # shortcut: `things today`, `things inbox`, etc.
+
+things show <task>              # task detail (title/UUID/numeric index from last list)
+things projects [--area A] [--completed]
+things areas
+things tags
+things search <query>
+
+things add <title> [--notes --when --deadline --tags --checklist --project --heading --list]
+things project add <title> [--notes --when --deadline --tags --area --todos]
+things edit <task> [--title --notes --when --deadline --tags --add-tags --list --heading --complete --cancel --duplicate --reveal ...]
+things complete <task>
+things cancel <task>
+things log                      # move Today → Logbook
+things open <ref|list>          # reveal task/project/area/tag/built-in list in the app
+```
+
+### Task reference forms
+
+`<task>` accepts:
+
+- UUID (e.g. `A1B2C3D4-...`)
+- Numeric index from the last list (1-based) — `things list today; things complete 2`
+- Title substring — interactive prompt disambiguates multiple matches; non-TTY context errors with the match list.
+
+### Multi-line values
+
+Newline-separated fields (`--checklist`, `--todos`, `--checklist`/`--prepend-checklist`/`--append-checklist` on edit) accept the literal two-character escape `\n` to pack multi-line values into a single shell-quoted argument:
+
+```
+things add "Groceries" --checklist "Milk\nBread\nEggs"
+```
+
+## Common flows
+
+Show today and complete the 3rd item:
+
+```
+things list today
+things complete 3
+```
+
+Add a task into a project with a checklist, tagged:
+
+```
+things add "Ship release" --project "things-cli" --tags "oss" \
+  --checklist "Cut tag\nWait on CI\nAnnounce"
+```
+
+Edit a task: reschedule + add a tag:
+
+```
+things edit "Ship release" --when tomorrow --add-tags "priority"
+```
+
+Pipe JSON to another tool:
+
+```
+things --json list today | jq '.[] | .title'
+```
+
+## Tips for agents
+
+- Prefer `--json` in scripted contexts; parse rather than screen-scrape.
+- After listing, the task order is cached — numeric indices stay valid until the next `list`/`search`.
+- `things open` is the right command when the user wants to *see* something in the Things3 app rather than read data.
+- Writes are not transactional: if a URL-scheme write fails, the DB is unchanged but the agent should re-check state with `show`.

--- a/internal/skill/body.md
+++ b/internal/skill/body.md
@@ -1,24 +1,16 @@
 # things-cli — Things3 CLI for macOS
 
 Use the `things` CLI whenever the user mentions Things3, tasks, todos, inbox,
-today, upcoming, projects, or areas on macOS. The binary reads the local
-Things3 SQLite database and writes via the `things:///` URL scheme /
-AppleScript.
+today, upcoming, projects, or areas on macOS.
 
-## Safety model
+## Safety
 
-- **Read operations hit SQLite read-only** (`PRAGMA query_only = ON`). These
-  are safe and fast: `list`, `show`, `projects`, `areas`, `tags`, `search`.
-- **Write operations go through Things3**: `add`, `project add`, `edit`,
-  `complete`, `cancel`, `log`, `open`. These launch URL schemes or AppleScript
-  and affect the user's real data — confirm before running destructive writes
-  (`complete`, `cancel`, bulk `edit`).
+- Reads (`list`, `show`, `projects`, `areas`, `tags`, `search`) are safe — use freely.
+- Writes (`add`, `project add`, `edit`, `complete`, `cancel`, `log`, `open`) modify the user's real data. Confirm before destructive ones (`complete`, `cancel`, bulk `edit`).
 
 ## Output
 
-Most commands accept `--json` / `-j` for machine-readable output. Default
-output is a human-friendly plain text table. Prefer `--json` when piping into
-another tool or parsing in an agent context.
+Most commands accept `--json` / `-j`. Prefer it when parsing output.
 
 ## Core commands
 
@@ -27,7 +19,7 @@ things list [view] [--project P] [--area A] [--tag T]
     # views: today, inbox, upcoming, anytime, someday, logbook, trash, deadlines
     # shortcut: `things today`, `things inbox`, etc.
 
-things show <task>              # task detail (title/UUID/numeric index from last list)
+things show <task>              # task detail
 things projects [--area A] [--completed]
 things areas
 things tags
@@ -46,13 +38,13 @@ things open <ref|list>          # reveal task/project/area/tag/built-in list in 
 
 `<task>` accepts:
 
-- UUID (e.g. `A1B2C3D4-...`)
+- UUID
 - Numeric index from the last list (1-based) — `things list today; things complete 2`
-- Title substring — interactive prompt disambiguates multiple matches; non-TTY context errors with the match list.
+- Title substring — interactive prompt disambiguates; non-TTY errors with the match list.
 
 ### Multi-line values
 
-Newline-separated fields (`--checklist`, `--todos`, `--checklist`/`--prepend-checklist`/`--append-checklist` on edit) accept the literal two-character escape `\n` to pack multi-line values into a single shell-quoted argument:
+Newline-separated fields (`--checklist`, `--todos`, `--prepend-checklist`, `--append-checklist`) accept the literal two-character escape `\n` to pack multi-line values into one shell-quoted argument:
 
 ```
 things add "Groceries" --checklist "Milk\nBread\nEggs"
@@ -74,7 +66,7 @@ things add "Ship release" --project "things-cli" --tags "oss" \
   --checklist "Cut tag\nWait on CI\nAnnounce"
 ```
 
-Edit a task: reschedule + add a tag:
+Reschedule and tag an existing task:
 
 ```
 things edit "Ship release" --when tomorrow --add-tags "priority"
@@ -86,9 +78,8 @@ Pipe JSON to another tool:
 things --json list today | jq '.[] | .title'
 ```
 
-## Tips for agents
+## Tips
 
-- Prefer `--json` in scripted contexts; parse rather than screen-scrape.
-- After listing, the task order is cached — numeric indices stay valid until the next `list`/`search`.
-- `things open` is the right command when the user wants to *see* something in the Things3 app rather than read data.
-- Writes are not transactional: if a URL-scheme write fails, the DB is unchanged but the agent should re-check state with `show`.
+- Prefer `--json` in scripted contexts.
+- After a `list`/`search`, numeric indices stay valid until the next one.
+- Use `things open` when the user wants to *see* something in the app rather than read data back.

--- a/internal/skill/claude.go
+++ b/internal/skill/claude.go
@@ -1,0 +1,37 @@
+package skill
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func init() { register(claudeAgent{}) }
+
+type claudeAgent struct{}
+
+func (claudeAgent) Name() string { return "claude" }
+
+func (claudeAgent) DefaultDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "skills", "things-cli"), nil
+}
+
+func (claudeAgent) Files() map[string][]byte {
+	return map[string][]byte{"SKILL.md": []byte(claudeSkillMD())}
+}
+
+// claudeSkillMD prepends Claude Code's required YAML frontmatter to the
+// neutral skill body.
+func claudeSkillMD() string {
+	const frontmatter = `---
+name: things-cli
+description: Use when the user mentions Things3, tasks, todos, inbox, today, upcoming, projects, areas, or to-do lists on macOS. Provides the ` + "`things`" + ` CLI for reading the local Things3 SQLite database and writing via the things:/// URL scheme.
+---
+
+`
+	return fmt.Sprintf("%s%s", frontmatter, body)
+}

--- a/internal/skill/claude.go
+++ b/internal/skill/claude.go
@@ -1,37 +1,29 @@
 package skill
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 )
 
 func init() { register(claudeAgent{}) }
 
-type claudeAgent struct{}
-
-func (claudeAgent) Name() string { return "claude" }
-
-func (claudeAgent) DefaultDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".claude", "skills", "things-cli"), nil
-}
-
-func (claudeAgent) Files() map[string][]byte {
-	return map[string][]byte{"SKILL.md": []byte(claudeSkillMD())}
-}
-
-// claudeSkillMD prepends Claude Code's required YAML frontmatter to the
-// neutral skill body.
-func claudeSkillMD() string {
-	const frontmatter = `---
+const claudeFrontmatter = `---
 name: things-cli
 description: Use when the user mentions Things3, tasks, todos, inbox, today, upcoming, projects, areas, or to-do lists on macOS. Provides the ` + "`things`" + ` CLI for reading the local Things3 SQLite database and writing via the things:/// URL scheme.
 ---
 
 `
-	return fmt.Sprintf("%s%s", frontmatter, body)
+
+var claudeFiles = map[string][]byte{
+	"SKILL.md": []byte(claudeFrontmatter + body),
 }
+
+type claudeAgent struct{}
+
+func (claudeAgent) Name() string { return "claude" }
+
+func (claudeAgent) DefaultDir() (string, error) {
+	return filepath.Join(os.Getenv("HOME"), ".claude", "skills", "things-cli"), nil
+}
+
+func (claudeAgent) Files() map[string][]byte { return claudeFiles }

--- a/internal/skill/claude.go
+++ b/internal/skill/claude.go
@@ -9,7 +9,7 @@ func init() { register(claudeAgent{}) }
 
 const claudeFrontmatter = `---
 name: things-cli
-description: Use when the user mentions Things3, tasks, todos, inbox, today, upcoming, projects, areas, or to-do lists on macOS. Provides the ` + "`things`" + ` CLI for reading the local Things3 SQLite database and writing via the things:/// URL scheme.
+description: Use when the user mentions Things3, tasks, todos, inbox, today, upcoming, projects, areas, or to-do lists on macOS. Provides the ` + "`things`" + ` CLI for listing, creating, editing, completing, and searching tasks.
 ---
 
 `

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -1,0 +1,120 @@
+// Package skill bundles the things-cli agent skill and manages its
+// installation into supported AI coding agents (e.g. Claude Code).
+//
+// The skill body is authored in a neutral Markdown source (body.md),
+// embedded into the binary. Each Agent adapter renders that source into
+// on-disk files appropriate for its target (e.g. Claude Code's SKILL.md with
+// YAML frontmatter).
+package skill
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+//go:embed body.md
+var body string
+
+// Body returns the neutral, agent-independent skill source.
+func Body() string { return body }
+
+// Agent renders and locates the skill for a particular AI coding agent.
+type Agent interface {
+	// Name is the user-facing identifier passed to `things skill install <name>`.
+	Name() string
+	// DefaultDir returns the default destination directory for this agent.
+	DefaultDir() (string, error)
+	// Files returns relative filename -> file contents for this agent.
+	Files() map[string][]byte
+}
+
+var registry = map[string]Agent{}
+
+func register(a Agent) {
+	registry[a.Name()] = a
+}
+
+// Lookup returns the agent adapter with the given name.
+func Lookup(name string) (Agent, error) {
+	a, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown agent %q (supported: %s)", name, joinNames(Agents()))
+	}
+	return a, nil
+}
+
+// Agents returns the registered agents, sorted by name.
+func Agents() []Agent {
+	out := make([]Agent, 0, len(registry))
+	for _, a := range registry {
+		out = append(out, a)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	return out
+}
+
+func joinNames(agents []Agent) string {
+	names := make([]string, len(agents))
+	for i, a := range agents {
+		names[i] = a.Name()
+	}
+	return strings.Join(names, ", ")
+}
+
+// Exists reports whether the skill already appears to be installed in dir.
+// It returns true if any of the agent's files are present.
+func Exists(a Agent, dir string) bool {
+	return len(InstalledFiles(a, dir)) > 0
+}
+
+// InstalledFiles returns the relative paths of this agent's files that
+// currently exist on disk under dir, sorted for stable output.
+func InstalledFiles(a Agent, dir string) []string {
+	var found []string
+	for name := range a.Files() {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			found = append(found, name)
+		}
+	}
+	sort.Strings(found)
+	return found
+}
+
+// Install writes the agent's rendered files to dir, creating it if needed.
+// Existing files are overwritten.
+func Install(a Agent, dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	for name, content := range a.Files() {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Uninstall removes the agent's installed files from dir. If the directory is
+// empty afterwards, it is also removed.
+func Uninstall(a Agent, dir string) error {
+	for name := range a.Files() {
+		path := filepath.Join(dir, name)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	// Best-effort: remove the directory if it's empty.
+	entries, err := os.ReadDir(dir)
+	if err == nil && len(entries) == 0 {
+		_ = os.Remove(dir)
+	}
+	return nil
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -24,25 +24,20 @@ func Body() string { return body }
 
 // Agent renders and locates the skill for a particular AI coding agent.
 type Agent interface {
-	// Name is the user-facing identifier passed to `things skill install <name>`.
 	Name() string
-	// DefaultDir returns the default destination directory for this agent.
 	DefaultDir() (string, error)
-	// Files returns relative filename -> file contents for this agent.
 	Files() map[string][]byte
 }
 
 var registry = map[string]Agent{}
 
-func register(a Agent) {
-	registry[a.Name()] = a
-}
+func register(a Agent) { registry[a.Name()] = a }
 
 // Lookup returns the agent adapter with the given name.
 func Lookup(name string) (Agent, error) {
 	a, ok := registry[name]
 	if !ok {
-		return nil, fmt.Errorf("unknown agent %q (supported: %s)", name, joinNames(Agents()))
+		return nil, fmt.Errorf("unknown agent %q (supported: %s)", name, AgentNames())
 	}
 	return a, nil
 }
@@ -57,7 +52,9 @@ func Agents() []Agent {
 	return out
 }
 
-func joinNames(agents []Agent) string {
+// AgentNames returns a comma-separated list of registered agent names.
+func AgentNames() string {
+	agents := Agents()
 	names := make([]string, len(agents))
 	for i, a := range agents {
 		names[i] = a.Name()
@@ -65,14 +62,18 @@ func joinNames(agents []Agent) string {
 	return strings.Join(names, ", ")
 }
 
-// Exists reports whether the skill already appears to be installed in dir.
-// It returns true if any of the agent's files are present.
+// Exists reports whether any of the agent's files are present in dir.
 func Exists(a Agent, dir string) bool {
-	return len(InstalledFiles(a, dir)) > 0
+	for name := range a.Files() {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
-// InstalledFiles returns the relative paths of this agent's files that
-// currently exist on disk under dir, sorted for stable output.
+// InstalledFiles returns the agent's files present on disk under dir,
+// sorted for stable output.
 func InstalledFiles(a Agent, dir string) []string {
 	var found []string
 	for name := range a.Files() {
@@ -84,8 +85,8 @@ func InstalledFiles(a Agent, dir string) []string {
 	return found
 }
 
-// Install writes the agent's rendered files to dir, creating it if needed.
-// Existing files are overwritten.
+// Install writes the agent's rendered files to dir, creating it if needed,
+// and overwrites any existing files.
 func Install(a Agent, dir string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
@@ -111,7 +112,6 @@ func Uninstall(a Agent, dir string) error {
 			return err
 		}
 	}
-	// Best-effort: remove the directory if it's empty.
 	entries, err := os.ReadDir(dir)
 	if err == nil && len(entries) == 0 {
 		_ = os.Remove(dir)

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1,0 +1,150 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBodyNonEmpty(t *testing.T) {
+	if strings.TrimSpace(Body()) == "" {
+		t.Fatal("Body() is empty")
+	}
+}
+
+func TestClaudeSkillMDFrontmatterAndCommands(t *testing.T) {
+	a, err := Lookup("claude")
+	if err != nil {
+		t.Fatalf("Lookup(claude): %v", err)
+	}
+	files := a.Files()
+	raw, ok := files["SKILL.md"]
+	if !ok {
+		t.Fatalf("claude files missing SKILL.md: %v", keys(files))
+	}
+	content := string(raw)
+
+	if !strings.HasPrefix(content, "---\n") {
+		t.Fatalf("SKILL.md must start with YAML frontmatter, got: %q", content[:min(len(content), 40)])
+	}
+	end := strings.Index(content[4:], "\n---\n")
+	if end < 0 {
+		t.Fatal("SKILL.md frontmatter not closed")
+	}
+	frontmatter := content[:4+end]
+	for _, need := range []string{"name: things-cli", "description:"} {
+		if !strings.Contains(frontmatter, need) {
+			t.Errorf("frontmatter missing %q:\n%s", need, frontmatter)
+		}
+	}
+	for _, cmd := range []string{"things list", "things show", "things add", "things complete", "things cancel"} {
+		if !strings.Contains(content, cmd) {
+			t.Errorf("SKILL.md missing reference to %q", cmd)
+		}
+	}
+}
+
+func TestLookupUnknown(t *testing.T) {
+	_, err := Lookup("bogus-agent")
+	if err == nil {
+		t.Fatal("expected error for unknown agent")
+	}
+	if !strings.Contains(err.Error(), "supported") {
+		t.Errorf("error should list supported agents: %v", err)
+	}
+}
+
+func TestAgentsSorted(t *testing.T) {
+	agents := Agents()
+	if len(agents) == 0 {
+		t.Fatal("no agents registered")
+	}
+	for i := 1; i < len(agents); i++ {
+		if agents[i-1].Name() > agents[i].Name() {
+			t.Errorf("agents not sorted: %s > %s", agents[i-1].Name(), agents[i].Name())
+		}
+	}
+}
+
+func TestClaudeDefaultDir(t *testing.T) {
+	t.Setenv("HOME", "/tmp/fake-home")
+	a, _ := Lookup("claude")
+	dir, err := a.DefaultDir()
+	if err != nil {
+		t.Fatalf("DefaultDir: %v", err)
+	}
+	want := filepath.Join("/tmp/fake-home", ".claude", "skills", "things-cli")
+	if dir != want {
+		t.Errorf("DefaultDir = %q, want %q", dir, want)
+	}
+}
+
+func TestInstallExistsUninstall(t *testing.T) {
+	dir := t.TempDir()
+	a, _ := Lookup("claude")
+
+	if Exists(a, dir) {
+		t.Error("fresh dir should not report Exists")
+	}
+	if got := InstalledFiles(a, dir); len(got) != 0 {
+		t.Errorf("InstalledFiles on empty dir = %v", got)
+	}
+
+	if err := Install(a, dir); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if !Exists(a, dir) {
+		t.Error("after Install, Exists should be true")
+	}
+	got := InstalledFiles(a, dir)
+	if len(got) != 1 || got[0] != "SKILL.md" {
+		t.Errorf("InstalledFiles = %v, want [SKILL.md]", got)
+	}
+
+	// Install is idempotent (overwrites)
+	if err := Install(a, dir); err != nil {
+		t.Fatalf("re-Install: %v", err)
+	}
+
+	if err := Uninstall(a, dir); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if Exists(a, dir) {
+		t.Error("after Uninstall, Exists should be false")
+	}
+	// Directory should be removed when empty.
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("expected dir removed, stat err = %v", err)
+	}
+}
+
+func TestUninstallLeavesUnrelatedFiles(t *testing.T) {
+	dir := t.TempDir()
+	a, _ := Lookup("claude")
+	if err := Install(a, dir); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	extra := filepath.Join(dir, "user-notes.md")
+	if err := os.WriteFile(extra, []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Uninstall(a, dir); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if _, err := os.Stat(extra); err != nil {
+		t.Errorf("unrelated file removed: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("dir removed despite unrelated file: %v", err)
+	}
+}
+
+func keys(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- Adds `things skill` subcommand group (`install`, `uninstall`, `show`, `list`).
- Introduces `internal/skill/` package: neutral Markdown body embedded via `//go:embed`, rendered by per-agent adapters. Only `claude` (Claude Code) is wired today; the interface is shaped to take more agents additively.
- `install` prompts on overwrite (or fails in non-TTY without `-y`); `uninstall` lists the files it will remove before prompting.

Closes #12

## Test plan

- [x] `make test` (race) passes
- [x] `make lint` clean
- [x] Manual: `things skill list`, `things skill show`, `things skill show claude`, `things skill install claude -y` with `HOME=/tmp/fake` — SKILL.md lands at `<HOME>/.claude/skills/things-cli/SKILL.md` with valid YAML frontmatter
- [x] Reviewer: try `things skill install claude` on real `$HOME` and verify Claude Code picks up the skill