### PR TITLE
feat: add `things project edit` to update projects via URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ date).
 `project add` accepts `--notes`, `--when`, `--deadline`, `--tags`, `--area`
 and `--todos` (newline-separated initial to-dos).
 
+`project edit` updates an existing project via the `things:///update-project`
+URL scheme. Only flags you pass are sent. Supported flags: `--title`,
+`--notes`, `--prepend-notes`, `--append-notes`, `--when`, `--deadline`,
+`--tags` (replace), `--add-tags`, `--area` / `--area-id`, `--complete`,
+`--cancel`, `--duplicate`, `--reveal`. An empty value clears the field
+(e.g. `--deadline ""`). Requires the Things auth token, same as `edit`.
+
 `edit` updates an existing task via the `things:///update` URL scheme. Only
 flags you pass are sent, so unset fields stay untouched. Supported flags:
 `--title`, `--notes`, `--prepend-notes`, `--append-notes`, `--when`,

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -81,7 +81,8 @@ type AddCmd struct {
 }
 
 type ProjectCmd struct {
-	Add ProjectAddCmd `cmd:"" help:"Create a new project."`
+	Add  ProjectAddCmd  `cmd:"" help:"Create a new project."`
+	Edit ProjectEditCmd `cmd:"" help:"Edit a project via the Things URL scheme."`
 }
 
 type ProjectAddCmd struct {
@@ -92,6 +93,30 @@ type ProjectAddCmd struct {
 	Tags     string `help:"Comma-separated tags."`
 	Area     string `help:"Area name or UUID."`
 	Todos    string `help:"Newline-separated initial to-dos."`
+}
+
+type ProjectEditCmd struct {
+	Project string `arg:"" required:"" help:"Project title, UUID, or numeric index from last list."`
+
+	Title *string `help:"Replace title."`
+
+	Notes        *string `help:"Replace notes."`
+	PrependNotes *string `help:"Prepend text to notes." name:"prepend-notes"`
+	AppendNotes  *string `help:"Append text to notes." name:"append-notes"`
+
+	When     *string `help:"When to schedule (date, today, tomorrow, evening, someday, anytime, or an ISO date)."`
+	Deadline *string `help:"Deadline date (YYYY-MM-DD) or empty to clear."`
+
+	Tags    *string `help:"Replace all tags (comma-separated)."`
+	AddTags *string `help:"Add tags (comma-separated)." name:"add-tags"`
+
+	Area   *string `help:"Move to area by name."`
+	AreaID *string `help:"Move to area by UUID." name:"area-id"`
+
+	Complete  bool `help:"Mark the project as completed."`
+	Cancel    bool `help:"Mark the project as canceled."`
+	Duplicate bool `help:"Duplicate the project before applying edits."`
+	Reveal    bool `help:"Reveal the project in Things after editing."`
 }
 
 type EditCmd struct {
@@ -239,6 +264,8 @@ func run(ctx *kong.Context, cli *CLI, database *db.DB) error {
 		return runAdd(cli, database)
 	case "project add <title>":
 		return runProjectAdd(cli)
+	case "project edit <project>":
+		return runProjectEdit(cli, database)
 	case "edit <task>":
 		return runEdit(cli, database)
 	case "complete <task>":
@@ -363,6 +390,36 @@ func runProjectAdd(cli *CLI) error {
 // (e.g. --todos "Draft\nShip"). Actual newlines in the input are preserved.
 func expandNewlines(s string) string {
 	return strings.ReplaceAll(s, `\n`, "\n")
+}
+
+func runProjectEdit(cli *CLI, database *db.DB) error {
+	project, err := resolveTask(cli.Project.Edit.Project, database)
+	if err != nil {
+		return err
+	}
+	if project.Type != model.TypeProject {
+		return fmt.Errorf("not a project: %s", project.Title)
+	}
+
+	token, _ := database.GetAuthToken()
+	return things.UpdateProject(things.UpdateProjectParams{
+		ID:           project.UUID,
+		AuthToken:    token,
+		Title:        cli.Project.Edit.Title,
+		Notes:        cli.Project.Edit.Notes,
+		PrependNotes: cli.Project.Edit.PrependNotes,
+		AppendNotes:  cli.Project.Edit.AppendNotes,
+		When:         cli.Project.Edit.When,
+		Deadline:     cli.Project.Edit.Deadline,
+		Tags:         cli.Project.Edit.Tags,
+		AddTags:      cli.Project.Edit.AddTags,
+		Area:         cli.Project.Edit.Area,
+		AreaID:       cli.Project.Edit.AreaID,
+		Completed:    cli.Project.Edit.Complete,
+		Canceled:     cli.Project.Edit.Cancel,
+		Duplicate:    cli.Project.Edit.Duplicate,
+		Reveal:       cli.Project.Edit.Reveal,
+	})
 }
 
 func runEdit(cli *CLI, database *db.DB) error {

--- a/internal/skill/body.md
+++ b/internal/skill/body.md
@@ -27,6 +27,7 @@ things search <query>
 
 things add <title> [--notes --when --deadline --tags --checklist --project --heading --list]
 things project add <title> [--notes --when --deadline --tags --area --todos]
+things project edit <project> [--title --notes --when --deadline --tags --add-tags --area --area-id --complete --cancel --duplicate --reveal ...]
 things edit <task> [--title --notes --when --deadline --tags --add-tags --list --heading --complete --cancel --duplicate --reveal ...]
 things complete <task>
 things cancel <task>

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -187,6 +187,67 @@ func UpdateTask(params UpdateParams) error {
 	return openThingsURL("update", v)
 }
 
+type UpdateProjectParams struct {
+	ID        string
+	AuthToken string
+
+	Title        *string
+	Notes        *string
+	PrependNotes *string
+	AppendNotes  *string
+	When         *string
+	Deadline     *string
+	Tags         *string
+	AddTags      *string
+	Area         *string
+	AreaID       *string
+	Completed    bool
+	Canceled     bool
+	Duplicate    bool
+	Reveal       bool
+}
+
+func UpdateProject(params UpdateProjectParams) error {
+	if params.ID == "" {
+		return fmt.Errorf("update-project: project id is required")
+	}
+	if params.AuthToken == "" {
+		return fmt.Errorf("update-project: auth token is required — enable Things URLs in Things → Settings → General and ensure the app has been launched at least once")
+	}
+
+	v := url.Values{}
+	v.Set("id", params.ID)
+	v.Set("auth-token", params.AuthToken)
+
+	setStr := func(key string, p *string) {
+		if p != nil {
+			v.Set(key, *p)
+		}
+	}
+	setBool := func(key string, b bool) {
+		if b {
+			v.Set(key, "true")
+		}
+	}
+
+	setStr("title", params.Title)
+	setStr("notes", params.Notes)
+	setStr("prepend-notes", params.PrependNotes)
+	setStr("append-notes", params.AppendNotes)
+	setStr("when", params.When)
+	setStr("deadline", params.Deadline)
+	setStr("tags", params.Tags)
+	setStr("add-tags", params.AddTags)
+	setStr("area", params.Area)
+	setStr("area-id", params.AreaID)
+	setBool("completed", params.Completed)
+	setBool("canceled", params.Canceled)
+	setBool("duplicate", params.Duplicate)
+	setBool("reveal", params.Reveal)
+
+	return openThingsURL("update-project", v)
+}
+
 func AddTask(params AddParams) error {
 	v := url.Values{}
 	v.Set("title", params.Title)

--- a/internal/things/urlscheme_test.go
+++ b/internal/things/urlscheme_test.go
@@ -368,6 +368,169 @@ func TestUpdateTaskCommandFails(t *testing.T) {
 	}
 }
 
+func TestUpdateProjectMinimal(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	err := UpdateProject(UpdateProjectParams{
+		ID:        "p-123",
+		AuthToken: "tok",
+		Title:     strPtr("New"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateProject: %v", err)
+	}
+	u := (*captured)[2]
+	if !strings.HasPrefix(u, "things:///update-project?") {
+		t.Fatalf("expected update-project URL, got %q", u)
+	}
+	if strings.Contains(u, "+") {
+		t.Errorf("URL should use %%20 not +: %q", u)
+	}
+	parsed, err := url.Parse(u)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	q := parsed.Query()
+	if q.Get("id") != "p-123" {
+		t.Errorf("id = %q", q.Get("id"))
+	}
+	if q.Get("auth-token") != "tok" {
+		t.Errorf("auth-token = %q", q.Get("auth-token"))
+	}
+	if q.Get("title") != "New" {
+		t.Errorf("title = %q", q.Get("title"))
+	}
+}
+
+func TestUpdateProjectAllFields(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	err := UpdateProject(UpdateProjectParams{
+		ID:           "p-1",
+		AuthToken:    "tok",
+		Title:        strPtr("T"),
+		Notes:        strPtr("n"),
+		PrependNotes: strPtr("pre"),
+		AppendNotes:  strPtr("post"),
+		When:         strPtr("today"),
+		Deadline:     strPtr("2026-05-01"),
+		Tags:         strPtr("a,b"),
+		AddTags:      strPtr("c"),
+		Area:         strPtr("Work"),
+		AreaID:       strPtr("area-uuid"),
+		Completed:    true,
+		Canceled:     true,
+		Duplicate:    true,
+		Reveal:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := url.Parse((*captured)[2])
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	q := parsed.Query()
+
+	cases := map[string]string{
+		"id":            "p-1",
+		"auth-token":    "tok",
+		"title":         "T",
+		"notes":         "n",
+		"prepend-notes": "pre",
+		"append-notes":  "post",
+		"when":          "today",
+		"deadline":      "2026-05-01",
+		"tags":          "a,b",
+		"add-tags":      "c",
+		"area":          "Work",
+		"area-id":       "area-uuid",
+		"completed":     "true",
+		"canceled":      "true",
+		"duplicate":     "true",
+		"reveal":        "true",
+	}
+	for k, want := range cases {
+		if got := q.Get(k); got != want {
+			t.Errorf("query[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestUpdateProjectOmitsUnsetFlags(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	if err := UpdateProject(UpdateProjectParams{
+		ID:        "id",
+		AuthToken: "tok",
+		Title:     strPtr("only"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	u := (*captured)[2]
+	omitted := []string{
+		"notes=", "prepend-notes=", "append-notes=",
+		"when=", "deadline=", "tags=", "add-tags=",
+		"area=", "area-id=",
+		"completed=", "canceled=", "duplicate=", "reveal=",
+	}
+	for _, k := range omitted {
+		if strings.Contains(u, k) {
+			t.Errorf("URL should not contain %q: %s", k, u)
+		}
+	}
+}
+
+func TestUpdateProjectEmptyStringClearsField(t *testing.T) {
+	captured := stubRunner(t, false)
+
+	if err := UpdateProject(UpdateProjectParams{
+		ID:        "id",
+		AuthToken: "tok",
+		Notes:     strPtr(""),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := url.Parse((*captured)[2])
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	if _, ok := parsed.Query()["notes"]; !ok {
+		t.Errorf("expected notes= param to be present (clear field)")
+	}
+}
+
+func TestUpdateProjectRequiresID(t *testing.T) {
+	stubRunner(t, false)
+	err := UpdateProject(UpdateProjectParams{AuthToken: "tok", Title: strPtr("x")})
+	if err == nil {
+		t.Fatal("expected error for missing id")
+	}
+}
+
+func TestUpdateProjectRequiresAuthToken(t *testing.T) {
+	stubRunner(t, false)
+	err := UpdateProject(UpdateProjectParams{ID: "id", Title: strPtr("x")})
+	if err == nil {
+		t.Fatal("expected error for missing auth token")
+	}
+	if !strings.Contains(err.Error(), "auth token") {
+		t.Errorf("error should mention auth token: %v", err)
+	}
+}
+
+func TestUpdateProjectCommandFails(t *testing.T) {
+	stubRunner(t, true)
+	err := UpdateProject(UpdateProjectParams{ID: "id", AuthToken: "tok", Title: strPtr("x")})
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+	if !strings.Contains(err.Error(), "opening URL scheme") {
+		t.Errorf("error should mention URL scheme: %v", err)
+	}
+}
+
 func TestShowByID(t *testing.T) {
 	captured := stubRunner(t, false)
 


### PR DESCRIPTION
## Summary

Mirrors `things edit` for projects using the `things:///update-project` URL scheme. Brings CLI feature parity with the Things3 UI for project metadata edits.

- New `UpdateProject` in `internal/things/urlscheme.go` with `UpdateProjectParams` (title, notes ± prepend/append, when, deadline, tags ± add-tags, area / area-id, completed/canceled/duplicate/reveal).
- New `things project edit <project>` subcommand wired through `runProjectEdit`. Resolves the project ref via the existing `resolveTask` helper and rejects non-project records.
- Tests follow the existing `var execCommand` pattern used by `UpdateTask` tests.
- Skill body and README updated.

Closes #31

## Test plan
- [x] `make test`
- [x] `make lint`
- [x] `make build`
- [x] Manual: created throwaway project, applied `--title --append-notes --add-tags --deadline --reveal`, verified title/notes/deadline updated via `things show --json`. `--cancel` flag transitions project to status=2. Type guard rejects task UUIDs ("not a project: ..."). Cleaned up by canceling the test project.