### PR TITLE
feat: add `things import` for batch JSON URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ things open --project "Launch"    # reveal a project
 things open --query staging       # app-side quick find
 
 things log                        # move today's done/cancelled items to Logbook
+things import < payload.json      # batch create/update via the Things JSON URL scheme
+things import --file payload.json --reveal
 things version                    # print version
 ```
 
@@ -68,6 +70,15 @@ date).
 
 `project add` accepts `--notes`, `--when`, `--deadline`, `--tags`, `--area`
 and `--todos` (newline-separated initial to-dos).
+
+`import` accepts a JSON array on stdin (or via `--file`) matching the
+[Things JSON URL scheme payload](https://culturedcode.com/things/support/articles/2803573/)
+— a batch of `to-do`, `project`, `heading`, and `checklist-item` items, each
+with `operation` and `attributes`. The CLI validates the payload is
+syntactically valid JSON, then forwards it verbatim. The auth token is
+attached automatically (required for `operation: update` items, harmless for
+create-only payloads). Pass `--reveal` to jump to the first created item.
+Note: macOS `open` has a URL length limit; split very large payloads.
 
 `edit` updates an existing task via the `things:///update` URL scheme. Only
 flags you pass are sent, so unset fields stay untouched. Supported flags:

--- a/cmd/things/import_test.go
+++ b/cmd/things/import_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ryanlewis/things-cli/internal/things"
+)
+
+func stubExec(t *testing.T) *[]string {
+	t.Helper()
+	var captured []string
+	prev := things.SetExecCommandForTest(func(name string, args ...string) *exec.Cmd {
+		captured = append([]string{name}, args...)
+		return exec.Command("true")
+	})
+	t.Cleanup(func() { things.SetExecCommandForTest(prev) })
+	return &captured
+}
+
+func TestValidateImportJSON(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{"valid", `[{"type":"to-do","attributes":{"title":"x"}}]`, ""},
+		{"notArray", `{"type":"to-do"}`, "must be a JSON array"},
+		{"emptyArray", `[]`, "empty"},
+		{"syntax", `[{"type":}]`, "invalid JSON at line 1"},
+		{"multilineSyntax", "[\n  {\"a\": 1,},\n]", "invalid JSON at line"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateImportJSON([]byte(c.input))
+			if c.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("want error containing %q, got %v", c.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestRunImportFromFile(t *testing.T) {
+	database := seedFullDB(t)
+	captured := stubExec(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "payload.json")
+	payload := `[{"type":"to-do","attributes":{"title":"Hi"}}]`
+	if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := runWith(t, database, "import", "--file", path, "--reveal"); err != nil {
+		t.Fatalf("runWith: %v", err)
+	}
+	if len(*captured) < 3 {
+		t.Fatalf("expected open invocation, got %v", *captured)
+	}
+	parsed, err := url.Parse((*captured)[2])
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	if !strings.HasPrefix((*captured)[2], "things:///json?") {
+		t.Errorf("expected json URL, got %q", (*captured)[2])
+	}
+	q := parsed.Query()
+	if q.Get("data") != payload {
+		t.Errorf("data = %q, want %q", q.Get("data"), payload)
+	}
+	if q.Get("reveal") != "true" {
+		t.Errorf("reveal = %q", q.Get("reveal"))
+	}
+}
+
+func TestRunImportFromStdin(t *testing.T) {
+	database := seedFullDB(t)
+	captured := stubExec(t)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	payload := `[{"type":"project","attributes":{"title":"P"}}]`
+	go func() {
+		_, _ = w.Write([]byte(payload))
+		w.Close()
+	}()
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig; r.Close() })
+
+	if err := runWith(t, database, "import"); err != nil {
+		t.Fatalf("runWith: %v", err)
+	}
+	parsed, _ := url.Parse((*captured)[2])
+	if got := parsed.Query().Get("data"); got != payload {
+		t.Errorf("data = %q, want %q", got, payload)
+	}
+}
+
+func TestRunImportInvalidJSON(t *testing.T) {
+	database := seedFullDB(t)
+	stubExec(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(path, []byte(`[{"type":}]`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	err := runWith(t, database, "import", "--file", path)
+	if err == nil || !strings.Contains(err.Error(), "invalid JSON") {
+		t.Fatalf("expected invalid JSON error, got %v", err)
+	}
+}
+
+func TestRunImportEmptyPayload(t *testing.T) {
+	database := seedFullDB(t)
+	stubExec(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(path, []byte("   \n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	err := runWith(t, database, "import", "--file", path)
+	if err == nil || !strings.Contains(err.Error(), "empty payload") {
+		t.Fatalf("expected empty-payload error, got %v", err)
+	}
+}

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -42,6 +45,7 @@ type CLI struct {
 	Search   SearchCmd   `cmd:"" help:"Search tasks by title or notes."`
 	Log      LogCmd      `cmd:"" help:"Move completed and cancelled items from Today to the Logbook (Items → Log Completed)."`
 	Open     OpenCmd     `cmd:"" help:"Reveal a task, project, area, tag, or built-in list in Things3."`
+	Import   ImportCmd   `cmd:"" help:"Batch create/update via the Things JSON URL scheme. Reads JSON from stdin or --file."`
 	Skill    SkillCmd    `cmd:"" help:"Manage the bundled agent skill (Claude Code, etc.)."`
 	Ver      VersionCmd  `cmd:"" name:"version" help:"Print version and exit."`
 }
@@ -163,6 +167,11 @@ type SkillShowCmd struct {
 
 type SkillListCmd struct{}
 
+type ImportCmd struct {
+	File   string `help:"Read JSON payload from this file instead of stdin." short:"f" type:"existingfile"`
+	Reveal bool   `help:"Reveal the first created/updated item in Things after import."`
+}
+
 type OpenCmd struct {
 	Ref        string `arg:"" optional:"" help:"Task/project UUID, numeric list index, title, or built-in list name (${builtin_lists})."`
 	Project    string `help:"Open project by name or UUID." short:"p"`
@@ -251,6 +260,8 @@ func run(ctx *kong.Context, cli *CLI, database *db.DB) error {
 		return things.LogCompleted()
 	case "open", "open <ref>":
 		return runOpen(cli, database)
+	case "import":
+		return runImport(cli, database)
 	case "version":
 		return nil
 	default:
@@ -554,6 +565,81 @@ func runOpen(cli *CLI, database *db.DB) error {
 	}
 
 	return things.Show(params)
+}
+
+func runImport(cli *CLI, database *db.DB) error {
+	var data []byte
+	var err error
+	if cli.Import.File != "" {
+		data, err = os.ReadFile(cli.Import.File)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", cli.Import.File, err)
+		}
+	} else {
+		if isInteractive() {
+			return fmt.Errorf("no JSON on stdin and no --file given")
+		}
+		data, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("reading stdin: %w", err)
+		}
+	}
+	if err := validateImportJSON(data); err != nil {
+		return err
+	}
+	token, err := database.GetAuthToken()
+	if err != nil {
+		// Don't fail the import — the payload may be create-only and not need
+		// the token at all — but surface the read error so users debugging an
+		// `operation: update` failure aren't left guessing.
+		fmt.Fprintf(os.Stderr, "warning: could not read Things auth token: %v\n", err)
+	}
+	return things.ImportJSON(string(data), token, cli.Import.Reveal)
+}
+
+// validateImportJSON checks the payload is a non-empty JSON array — the shape
+// the Things JSON URL scheme requires — without allocating on the happy path.
+// On syntax errors it falls back to a full decode purely to extract the byte
+// offset, which it converts to line/column so the user can jump to the bad
+// byte in their editor.
+func validateImportJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return fmt.Errorf("empty payload")
+	}
+	if !json.Valid(data) {
+		// Re-decode to get an offset for the error message; this is the slow
+		// path (only on invalid input) so the allocation doesn't matter.
+		var v any
+		err := json.Unmarshal(data, &v)
+		var syn *json.SyntaxError
+		if errors.As(err, &syn) {
+			line, col := offsetToLineCol(data, syn.Offset)
+			return fmt.Errorf("invalid JSON at line %d, column %d: %s", line, col, syn.Error())
+		}
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	if trimmed[0] != '[' {
+		return fmt.Errorf("payload must be a JSON array of items")
+	}
+	// Valid JSON starting with `[` is at minimum `[]`, so len >= 2.
+	if len(bytes.TrimSpace(trimmed[1:len(trimmed)-1])) == 0 {
+		return fmt.Errorf("payload array is empty")
+	}
+	return nil
+}
+
+func offsetToLineCol(data []byte, offset int64) (int, int) {
+	if offset < 0 {
+		offset = 0
+	}
+	if int(offset) > len(data) {
+		offset = int64(len(data))
+	}
+	prefix := data[:offset]
+	line := 1 + bytes.Count(prefix, []byte{'\n'})
+	col := int(offset) - bytes.LastIndexByte(prefix, '\n')
+	return line, col
 }
 
 func runSearch(cli *CLI, database *db.DB) error {

--- a/internal/skill/body.md
+++ b/internal/skill/body.md
@@ -32,6 +32,10 @@ things complete <task>
 things cancel <task>
 things log                      # move Today → Logbook
 things open <ref|list>          # reveal task/project/area/tag/built-in list in the app
+
+things import [--file F] [--reveal] < payload.json
+    # batch create/update via the Things JSON URL scheme
+    # payload is the array documented at culturedcode.com/things/support/articles/2803573/
 ```
 
 ### Task reference forms

--- a/internal/things/testhook.go
+++ b/internal/things/testhook.go
@@ -1,0 +1,13 @@
+package things
+
+import "os/exec"
+
+// SetExecCommandForTest is a cross-package test seam for stubbing `open` /
+// `osascript` invocations; production code MUST NOT call it. Lives in a
+// non-`_test.go` file because Go does not export `_test.go` symbols to
+// other packages.
+func SetExecCommandForTest(f func(string, ...string) *exec.Cmd) func(string, ...string) *exec.Cmd {
+	prev := execCommand
+	execCommand = f
+	return prev
+}

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -187,6 +187,27 @@ func UpdateTask(params UpdateParams) error {
 	return openThingsURL("update", v)
 }
 
+// ImportJSON dispatches a Things JSON payload via `things:///json`. The
+// auth token is always sent when present: it's required for any item with
+// `operation: update`, and harmless on create-only payloads.
+func ImportJSON(data, authToken string, reveal bool) error {
+	v := url.Values{}
+	v.Set("data", data)
+	if authToken != "" {
+		v.Set("auth-token", authToken)
+	}
+	if reveal {
+		v.Set("reveal", "true")
+	}
+	if err := openThingsURL("json", v); err != nil {
+		// Things reports payload-level errors via an in-app notification, not
+		// via the URL handler exit code, so callers see only `exit status 1`
+		// from `open`. Point them at the right place to look.
+		return fmt.Errorf("%w (check Things for an error notification)", err)
+	}
+	return nil
+}
+
 func AddTask(params AddParams) error {
 	v := url.Values{}
 	v.Set("title", params.Title)

--- a/internal/things/urlscheme_test.go
+++ b/internal/things/urlscheme_test.go
@@ -192,6 +192,57 @@ func TestAddProjectCommandFails(t *testing.T) {
 	}
 }
 
+func TestImportJSON(t *testing.T) {
+	payload := `[{"type":"to-do","attributes":{"title":"Hi"}}]`
+
+	t.Run("minimal", func(t *testing.T) {
+		captured := stubRunner(t, false)
+		if err := ImportJSON(payload, "", false); err != nil {
+			t.Fatal(err)
+		}
+		u := (*captured)[2]
+		if !strings.HasPrefix(u, "things:///json?") {
+			t.Fatalf("expected json URL, got %q", u)
+		}
+		if strings.Contains(u, "+") {
+			t.Errorf("URL should use %%20 not +: %q", u)
+		}
+		parsed, _ := url.Parse(u)
+		q := parsed.Query()
+		if q.Get("data") != payload {
+			t.Errorf("data = %q, want %q", q.Get("data"), payload)
+		}
+		if q.Has("auth-token") {
+			t.Error("auth-token should be omitted when empty")
+		}
+		if q.Has("reveal") {
+			t.Error("reveal should be omitted when false")
+		}
+	})
+
+	t.Run("withTokenAndReveal", func(t *testing.T) {
+		captured := stubRunner(t, false)
+		if err := ImportJSON(payload, "tok", true); err != nil {
+			t.Fatal(err)
+		}
+		parsed, _ := url.Parse((*captured)[2])
+		q := parsed.Query()
+		if q.Get("auth-token") != "tok" {
+			t.Errorf("auth-token = %q", q.Get("auth-token"))
+		}
+		if q.Get("reveal") != "true" {
+			t.Errorf("reveal = %q", q.Get("reveal"))
+		}
+	})
+
+	t.Run("commandFails", func(t *testing.T) {
+		stubRunner(t, true)
+		if err := ImportJSON(payload, "", false); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
 func strPtr(s string) *string { return &s }
 
 func TestUpdateTaskMinimal(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `things import` wrapping `things:///json` so a single invocation can create or update many to-dos, projects, headings, and checklist items
- Reads JSON from stdin or `--file`; validates it's a non-empty JSON array client-side (with line/column on syntax errors) before invoking `open`
- Auto-attaches the auth token (required for `operation: update`, harmless for create-only payloads); surfaces a stderr warning if the token can't be read
- Wraps the `open` error with a hint to check Things' in-app notification, since payload-level errors don't propagate via exit code

Closes #18

## Test plan

- [x] `make test` — new unit tests for `validateImportJSON` (valid, not-array, empty, syntax, multiline syntax), `runImport` (file, stdin, invalid, empty), and `ImportJSON` URL construction (minimal, with token+reveal, command failure)
- [x] `make lint` clean
- [ ] Manual: pipe a real Things JSON payload and verify items land in the app
- [ ] Manual: pipe an `operation: update` payload and verify auth token is forwarded