### PR TITLE
feat(things): validate URL scheme limits client-side

### DIFF
--- a/internal/things/limits.go
+++ b/internal/things/limits.go
@@ -1,0 +1,172 @@
+package things
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Limits enforced by the Things URL scheme. Checking client-side turns
+// silent truncation / opaque app failures into clean errors.
+//
+// Rate limit: `add` is capped at 250 items per 10-second rolling window
+// app-side. That check is deferred until `things import` (or another
+// bulk-add surface) lands — single-item `add`/`add-project` invocations
+// can't realistically hit it.
+const (
+	MaxNotesLen       = 10000
+	MaxChecklistItems = 100
+	MaxStringLen      = 4000
+)
+
+// runeLen counts characters as the URL-scheme docs do — multi-byte UTF-8
+// (emoji, CJK) shouldn't trip the limit earlier than a non-ASCII user expects.
+func runeLen(s string) int { return utf8.RuneCountInString(s) }
+
+func validateNotes(field, v string) error {
+	if n := runeLen(v); n > MaxNotesLen {
+		return fmt.Errorf("%s: %d characters exceeds the %d-character limit", field, n, MaxNotesLen)
+	}
+	return nil
+}
+
+func validateString(field, v string) error {
+	if n := runeLen(v); n > MaxStringLen {
+		return fmt.Errorf("%s: %d characters exceeds the %d-character limit", field, n, MaxStringLen)
+	}
+	return nil
+}
+
+func validateChecklist(field, v string) error {
+	if v == "" {
+		return nil
+	}
+	// TrimRight so a trailing newline isn't counted as an extra item.
+	trimmed := strings.TrimRight(v, "\n")
+	n := strings.Count(trimmed, "\n") + 1
+	if n > MaxChecklistItems {
+		return fmt.Errorf("%s: %d items exceeds the %d-item limit", field, n, MaxChecklistItems)
+	}
+	for _, item := range strings.Split(trimmed, "\n") {
+		if c := runeLen(item); c > MaxStringLen {
+			return fmt.Errorf("%s: item %q (%d characters) exceeds the %d-character limit", field, truncate(item), c, MaxStringLen)
+		}
+	}
+	return nil
+}
+
+func validateTags(field, v string) error {
+	if v == "" {
+		return nil
+	}
+	for _, t := range strings.Split(v, ",") {
+		t = strings.TrimSpace(t)
+		if c := runeLen(t); c > MaxStringLen {
+			return fmt.Errorf("%s: tag %q (%d characters) exceeds the %d-character limit", field, truncate(t), c, MaxStringLen)
+		}
+	}
+	return nil
+}
+
+func truncate(s string) string {
+	const max = 40
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}
+
+func opt(p *string, check func(string) error) error {
+	if p == nil {
+		return nil
+	}
+	return check(*p)
+}
+
+func validateAdd(p AddParams) error {
+	if err := validateString("title", p.Title); err != nil {
+		return err
+	}
+	if err := validateNotes("notes", p.Notes); err != nil {
+		return err
+	}
+	if err := validateTags("tags", p.Tags); err != nil {
+		return err
+	}
+	if err := validateChecklist("checklist", p.Checklist); err != nil {
+		return err
+	}
+	if err := validateString("list", p.List); err != nil {
+		return err
+	}
+	return validateString("heading", p.Heading)
+}
+
+func validateAddProject(p AddProjectParams) error {
+	if err := validateString("title", p.Title); err != nil {
+		return err
+	}
+	if err := validateNotes("notes", p.Notes); err != nil {
+		return err
+	}
+	if err := validateTags("tags", p.Tags); err != nil {
+		return err
+	}
+	return validateString("area", p.Area)
+}
+
+func validateUpdate(p UpdateParams) error {
+	if err := opt(p.Title, func(s string) error { return validateString("title", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.Notes, func(s string) error { return validateNotes("notes", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.PrependNotes, func(s string) error { return validateNotes("prepend-notes", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.AppendNotes, func(s string) error { return validateNotes("append-notes", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.Tags, func(s string) error { return validateTags("tags", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.AddTags, func(s string) error { return validateTags("add-tags", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.Checklist, func(s string) error { return validateChecklist("checklist", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.PrependChecklist, func(s string) error { return validateChecklist("prepend-checklist", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.AppendChecklist, func(s string) error { return validateChecklist("append-checklist", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.List, func(s string) error { return validateString("list", s) }); err != nil {
+		return err
+	}
+	return opt(p.Heading, func(s string) error { return validateString("heading", s) })
+}
+
+func validateUpdateProject(p UpdateProjectParams) error {
+	if err := opt(p.Title, func(s string) error { return validateString("title", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.Notes, func(s string) error { return validateNotes("notes", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.PrependNotes, func(s string) error { return validateNotes("prepend-notes", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.AppendNotes, func(s string) error { return validateNotes("append-notes", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.Tags, func(s string) error { return validateTags("tags", s) }); err != nil {
+		return err
+	}
+	if err := opt(p.AddTags, func(s string) error { return validateTags("add-tags", s) }); err != nil {
+		return err
+	}
+	return opt(p.Area, func(s string) error { return validateString("area", s) })
+}

--- a/internal/things/limits_test.go
+++ b/internal/things/limits_test.go
@@ -1,0 +1,225 @@
+package things
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func repeat(n int) string { return strings.Repeat("a", n) }
+
+func checklist(items int) string {
+	parts := make([]string, items)
+	for i := range parts {
+		parts[i] = "item"
+	}
+	return strings.Join(parts, "\n")
+}
+
+func TestValidateNotes(t *testing.T) {
+	tests := []struct {
+		name    string
+		val     string
+		wantErr bool
+	}{
+		{"below", repeat(MaxNotesLen - 1), false},
+		{"at", repeat(MaxNotesLen), false},
+		{"above", repeat(MaxNotesLen + 1), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNotes("notes", tt.val)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), "notes") {
+				t.Errorf("error should name the field: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateString(t *testing.T) {
+	tests := []struct {
+		name    string
+		val     string
+		wantErr bool
+	}{
+		{"below", repeat(MaxStringLen - 1), false},
+		{"at", repeat(MaxStringLen), false},
+		{"above", repeat(MaxStringLen + 1), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateString("title", tt.val)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateChecklist_Count(t *testing.T) {
+	tests := []struct {
+		name    string
+		val     string
+		wantErr bool
+	}{
+		{"empty", "", false},
+		{"below", checklist(MaxChecklistItems - 1), false},
+		{"at", checklist(MaxChecklistItems), false},
+		{"above", checklist(MaxChecklistItems + 1), true},
+		{"trailing-newline-at-limit", checklist(MaxChecklistItems) + "\n", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateChecklist("checklist", tt.val)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateChecklist_ItemLength(t *testing.T) {
+	tests := []struct {
+		name    string
+		val     string
+		wantErr bool
+	}{
+		{"below", "ok\n" + repeat(MaxStringLen-1), false},
+		{"at", "ok\n" + repeat(MaxStringLen), false},
+		{"above", "ok\n" + repeat(MaxStringLen+1), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateChecklist("checklist", tt.val)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateTags_PerTag(t *testing.T) {
+	tests := []struct {
+		name    string
+		val     string
+		wantErr bool
+	}{
+		{"below", "ok," + repeat(MaxStringLen-1), false},
+		{"at", "ok," + repeat(MaxStringLen), false},
+		{"above", "ok," + repeat(MaxStringLen+1), true},
+		{"many-small-tags", strings.Repeat("a,", 5000) + "b", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTags("tags", tt.val)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Multi-byte input must be measured in characters, not bytes — a 10k-rune
+// note of CJK or emoji is well within the documented limit.
+func TestValidateNotes_CountsRunesNotBytes(t *testing.T) {
+	notes := strings.Repeat("好", MaxNotesLen) // each rune is 3 bytes
+	if err := validateNotes("notes", notes); err != nil {
+		t.Fatalf("10k-rune notes should pass: %v", err)
+	}
+	overshoot := strings.Repeat("好", MaxNotesLen+1)
+	if err := validateNotes("notes", overshoot); err == nil {
+		t.Fatal("10k+1-rune notes should fail")
+	}
+}
+
+func TestValidateAdd(t *testing.T) {
+	if err := validateAdd(AddParams{Title: repeat(MaxStringLen + 1)}); err == nil {
+		t.Fatal("expected title limit error")
+	}
+	if err := validateAdd(AddParams{Notes: repeat(MaxNotesLen + 1)}); err == nil {
+		t.Fatal("expected notes limit error")
+	}
+	if err := validateAdd(AddParams{Checklist: checklist(MaxChecklistItems + 1)}); err == nil {
+		t.Fatal("expected checklist limit error")
+	}
+	if err := validateAdd(AddParams{
+		Title:     "ok",
+		Notes:     repeat(MaxNotesLen),
+		Checklist: checklist(MaxChecklistItems),
+		Tags:      "one,two",
+	}); err != nil {
+		t.Fatalf("valid params should pass: %v", err)
+	}
+}
+
+func TestValidateUpdate(t *testing.T) {
+	big := repeat(MaxNotesLen + 1)
+	if err := validateUpdate(UpdateParams{ID: "x", AuthToken: "t", Notes: &big}); err == nil {
+		t.Fatal("expected notes limit error")
+	}
+
+	bigChk := checklist(MaxChecklistItems + 1)
+	if err := validateUpdate(UpdateParams{AppendChecklist: &bigChk}); err == nil {
+		t.Fatal("expected append-checklist limit error")
+	}
+
+	// Nil optional fields must not trip validation.
+	if err := validateUpdate(UpdateParams{ID: "x", AuthToken: "t"}); err != nil {
+		t.Fatalf("empty update should pass: %v", err)
+	}
+}
+
+func TestValidateUpdateProject(t *testing.T) {
+	big := repeat(MaxNotesLen + 1)
+	if err := validateUpdateProject(UpdateProjectParams{PrependNotes: &big}); err == nil {
+		t.Fatal("expected prepend-notes limit error")
+	}
+	if err := validateUpdateProject(UpdateProjectParams{}); err != nil {
+		t.Fatalf("empty update-project should pass: %v", err)
+	}
+}
+
+// stubExec swaps execCommand and reports whether it was invoked.
+func stubExec(t *testing.T) *bool {
+	t.Helper()
+	called := false
+	orig := execCommand
+	t.Cleanup(func() { execCommand = orig })
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		called = true
+		return exec.Command("true")
+	}
+	return &called
+}
+
+func TestRejectsBeforeOpen(t *testing.T) {
+	bigNotes := repeat(MaxNotesLen + 1)
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"AddTask", func() error { return AddTask(AddParams{Notes: bigNotes}) }},
+		{"AddProject", func() error { return AddProject(AddProjectParams{Notes: bigNotes}) }},
+		{"UpdateTask", func() error {
+			return UpdateTask(UpdateParams{ID: "x", AuthToken: "t", Notes: &bigNotes})
+		}},
+		{"UpdateProject", func() error {
+			return UpdateProject(UpdateProjectParams{ID: "x", AuthToken: "t", Notes: &bigNotes})
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := stubExec(t)
+			if err := tc.call(); err == nil {
+				t.Fatal("expected validation error")
+			}
+			if *called {
+				t.Fatal("execCommand must not run when validation fails")
+			}
+		})
+	}
+}

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -93,6 +93,9 @@ func Show(params ShowParams) error {
 }
 
 func AddProject(params AddProjectParams) error {
+	if err := validateAddProject(params); err != nil {
+		return err
+	}
 	v := url.Values{}
 	v.Set("title", params.Title)
 	if params.Notes != "" {
@@ -147,6 +150,9 @@ func UpdateTask(params UpdateParams) error {
 	}
 	if params.AuthToken == "" {
 		return fmt.Errorf("update: auth token is required — enable Things URLs in Things → Settings → General and ensure the app has been launched at least once")
+	}
+	if err := validateUpdate(params); err != nil {
+		return err
 	}
 
 	v := url.Values{}
@@ -214,6 +220,9 @@ func UpdateProject(params UpdateProjectParams) error {
 	if params.AuthToken == "" {
 		return fmt.Errorf("update-project: auth token is required — enable Things URLs in Things → Settings → General and ensure the app has been launched at least once")
 	}
+	if err := validateUpdateProject(params); err != nil {
+		return err
+	}
 
 	v := url.Values{}
 	v.Set("id", params.ID)
@@ -249,6 +258,9 @@ func UpdateProject(params UpdateProjectParams) error {
 }
 
 func AddTask(params AddParams) error {
+	if err := validateAdd(params); err != nil {
+		return err
+	}
 	v := url.Values{}
 	v.Set("title", params.Title)
 	if params.Notes != "" {


### PR DESCRIPTION
## Summary

- Enforce the documented Things URL scheme limits (notes ≤10k, checklist ≤100 items, generic strings ≤4k) before invoking `open`, replacing silent truncation / opaque app failures with clean errors that name the field, actual size, and limit.
- Limits centralized as `MaxNotesLen` / `MaxChecklistItems` / `MaxStringLen` constants in `internal/things`.
- Counts characters (runes), not bytes, so multi-byte content (CJK, emoji) isn't rejected before the documented limit. Error messages stay accurate.
- Rate-limit (250 adds / 10s) is documented as deferred until a bulk-add surface (e.g. `things import`) lands — single invocations can't hit it.

Closes #24

## Test plan

- [x] `make test` — 65 tests in `internal/things` pass with `-race`
- [x] `make lint` — 0 issues
- [x] Below / at / above coverage for each limit (notes, generic string, checklist count, per-checklist-item length, per-tag length)
- [x] Reject-before-open verified for `AddTask`, `AddProject`, `UpdateTask`, `UpdateProject`
- [x] Multi-byte rune behaviour pinned by `TestValidateNotes_CountsRunesNotBytes`
- [x] Nil pointer paths in `UpdateParams` / `UpdateProjectParams` covered