### PR TITLE
feat: validate and normalize --when / --deadline values

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,24 @@ cache the resulting UUIDs so you can refer to tasks by their index (`1`, `2`,
 ```
 
 `add` accepts `--notes`, `--when`, `--deadline`, `--tags`, `--checklist`,
-`--project`, `--heading` and `--list`. `--when` takes the same values Things
-itself accepts (`today`, `tomorrow`, `evening`, `anytime`, `someday`, or a
-date).
+`--project`, `--heading` and `--list`.
+
+`--when` accepts:
+
+- a keyword: `today`, `tomorrow`, `evening`, `anytime`, `someday`
+- a date: `YYYY-MM-DD` (e.g. `2026-05-01`)
+- a time: `HH:MM` or `H:MMam`/`H:MMpm` (e.g. `21:30`, `9:30PM`)
+- date + time: `YYYY-MM-DD@HH:MM` (e.g. `2026-05-01@09:30`)
+- RFC3339: rewritten to `YYYY-MM-DD@HH:MM` before being sent (the offset is
+  preserved as wall-clock; no conversion to local time)
+- an English natural-language phrase (e.g. `friday`, `next monday`) — passed
+  through verbatim; works only in English locales.
+
+Inputs within edit distance 2 of a known keyword are rejected client-side as
+likely typos (e.g. `tommorrow`, `evning`), with a "did you mean" hint.
+
+`--deadline` accepts a `YYYY-MM-DD` date or an English natural-language
+phrase. Keywords are not accepted.
 
 `project add` accepts `--notes`, `--when`, `--deadline`, `--tags`, `--area`
 and `--todos` (newline-separated initial to-dos).

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -75,8 +75,8 @@ type ShowCmd struct {
 type AddCmd struct {
 	Title     string `arg:"" required:"" help:"Task title."`
 	Notes     string `help:"Notes for the task."`
-	When      string `help:"When to schedule (date, today, tomorrow, evening, etc.)."`
-	Deadline  string `help:"Deadline date."`
+	When      string `help:"Schedule: today|tomorrow|evening|anytime|someday, YYYY-MM-DD, HH:MM, YYYY-MM-DD@HH:MM, or RFC3339."`
+	Deadline  string `help:"Deadline date (YYYY-MM-DD)."`
 	Tags      string `help:"Comma-separated tags."`
 	Checklist string `help:"Newline-separated checklist items."`
 	Project   string `help:"Project name or UUID."`
@@ -92,8 +92,8 @@ type ProjectCmd struct {
 type ProjectAddCmd struct {
 	Title    string `arg:"" required:"" help:"Project title."`
 	Notes    string `help:"Notes for the project."`
-	When     string `help:"When to schedule (date, today, tomorrow, evening, etc.)."`
-	Deadline string `help:"Deadline date."`
+	When     string `help:"Schedule: today|tomorrow|evening|anytime|someday, YYYY-MM-DD, HH:MM, YYYY-MM-DD@HH:MM, or RFC3339."`
+	Deadline string `help:"Deadline date (YYYY-MM-DD)."`
 	Tags     string `help:"Comma-separated tags."`
 	Area     string `help:"Area name or UUID."`
 	Todos    string `help:"Newline-separated initial to-dos."`
@@ -108,7 +108,7 @@ type ProjectEditCmd struct {
 	PrependNotes *string `help:"Prepend text to notes." name:"prepend-notes"`
 	AppendNotes  *string `help:"Append text to notes." name:"append-notes"`
 
-	When     *string `help:"When to schedule (date, today, tomorrow, evening, someday, anytime, or an ISO date)."`
+	When     *string `help:"Schedule: today|tomorrow|evening|anytime|someday, YYYY-MM-DD, HH:MM, YYYY-MM-DD@HH:MM, RFC3339, or empty to clear."`
 	Deadline *string `help:"Deadline date (YYYY-MM-DD) or empty to clear."`
 
 	Tags    *string `help:"Replace all tags (comma-separated)."`
@@ -132,7 +132,7 @@ type EditCmd struct {
 	PrependNotes *string `help:"Prepend text to notes." name:"prepend-notes"`
 	AppendNotes  *string `help:"Append text to notes." name:"append-notes"`
 
-	When     *string `help:"When to schedule (date, today, tomorrow, evening, someday, anytime, or an ISO date)."`
+	When     *string `help:"Schedule: today|tomorrow|evening|anytime|someday, YYYY-MM-DD, HH:MM, YYYY-MM-DD@HH:MM, RFC3339, or empty to clear."`
 	Deadline *string `help:"Deadline date (YYYY-MM-DD) or empty to clear."`
 
 	Tags    *string `help:"Replace all tags (comma-separated)."`

--- a/internal/skill/body.md
+++ b/internal/skill/body.md
@@ -47,6 +47,12 @@ things import [--file F] [--reveal] < payload.json
 - Numeric index from the last list (1-based) — `things list today; things complete 2`
 - Title substring — interactive prompt disambiguates; non-TTY errors with the match list.
 
+### `--when` / `--deadline` values
+
+`--when` accepts a keyword (`today`, `tomorrow`, `evening`, `anytime`, `someday`), a date `YYYY-MM-DD`, a time `HH:MM`, a date+time `YYYY-MM-DD@HH:MM`, or an RFC3339 timestamp. English natural-language phrases (`friday`, `next monday`) are passed through. Likely typos of the keywords (within edit distance 2, e.g. `tommorrow`) are rejected client-side with a "did you mean" hint.
+
+`--deadline` accepts a `YYYY-MM-DD` date or an English natural-language phrase — keywords like `today` are rejected.
+
 ### Multi-line values
 
 Newline-separated fields (`--checklist`, `--todos`, `--prepend-checklist`, `--append-checklist`) accept the literal two-character escape `\n` to pack multi-line values into one shell-quoted argument:

--- a/internal/things/dates.go
+++ b/internal/things/dates.go
@@ -1,0 +1,131 @@
+package things
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+var whenKeywords = []string{"today", "tomorrow", "evening", "anytime", "someday"}
+
+func isWhenKeyword(s string) bool {
+	return slices.Contains(whenKeywords, s)
+}
+
+// NormalizeWhen validates and canonicalises a --when value.
+//
+// Accepted forms:
+//   - keyword: today, tomorrow, evening, anytime, someday (case-insensitive)
+//   - date: YYYY-MM-DD
+//   - time: HH:MM or H:MM[am|pm]
+//   - date+time: YYYY-MM-DD@HH:MM
+//   - RFC3339: rewritten to YYYY-MM-DD@HH:MM (offset preserved as wall-clock)
+//   - English natural-language phrases: passed through verbatim
+//
+// Inputs within edit distance 2 of a known keyword are rejected as typos
+// (e.g. "tommorrow", "evning"); anything else passes through so users can
+// keep using NL forms like "friday" or "tonight".
+func NormalizeWhen(s string) (string, error) {
+	v := strings.TrimSpace(s)
+	if v == "" {
+		return "", nil
+	}
+	if low := strings.ToLower(v); isWhenKeyword(low) {
+		return low, nil
+	}
+	if t, ok := parseISO8601(v); ok {
+		return t.Format("2006-01-02") + "@" + t.Format("15:04"), nil
+	}
+	if k, ok := nearKeyword(v); ok {
+		return "", fmt.Errorf("unrecognised --when value %q (did you mean %q? valid keywords: %s)", v, k, strings.Join(whenKeywords, ", "))
+	}
+	return v, nil
+}
+
+// NormalizeDeadline validates and canonicalises a --deadline value. The URL
+// scheme accepts a date (YYYY-MM-DD) or English natural-language phrase.
+// RFC3339 inputs are reduced to their date component since deadlines have
+// no time-of-day.
+func NormalizeDeadline(s string) (string, error) {
+	v := strings.TrimSpace(s)
+	if v == "" {
+		return "", nil
+	}
+	if t, ok := parseISO8601(v); ok {
+		return t.Format("2006-01-02"), nil
+	}
+	if isWhenKeyword(strings.ToLower(v)) {
+		return "", fmt.Errorf("--deadline does not accept keywords like %q; pass a YYYY-MM-DD date", v)
+	}
+	return v, nil
+}
+
+var iso8601Layouts = [...]string{time.RFC3339Nano, time.RFC3339}
+
+func parseISO8601(s string) (time.Time, bool) {
+	// All accepted layouts have `YYYY-MM-DDTHH:MM:SS` as a prefix; cheap byte
+	// checks let the common non-ISO inputs (keywords, dates, NL phrases) skip
+	// the time.Parse failures.
+	if len(s) < 20 || s[4] != '-' || s[7] != '-' || s[10] != 'T' {
+		return time.Time{}, false
+	}
+	for _, layout := range iso8601Layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// nearKeyword reports whether s is likely a typo of a `when` keyword. The
+// comparison is case-insensitive and uses Levenshtein distance ≤ 2 — enough
+// to catch "tommorrow"/"evning"/"todya" without flagging unrelated NL words
+// like "friday" or "tonight".
+func nearKeyword(s string) (string, bool) {
+	low := strings.ToLower(s)
+	for _, k := range whenKeywords {
+		if low == k {
+			continue
+		}
+		if levenshtein(low, k) <= 2 {
+			return k, true
+		}
+	}
+	return "", false
+}
+
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	ar, br := []rune(a), []rune(b)
+	prev := make([]int, len(br)+1)
+	curr := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		curr[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(br)]
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}

--- a/internal/things/dates_test.go
+++ b/internal/things/dates_test.go
@@ -1,0 +1,98 @@
+package things
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeWhen(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"  ", ""},
+		{"today", "today"},
+		{"Today", "today"},
+		{"TOMORROW", "tomorrow"},
+		{"evening", "evening"},
+		{"anytime", "anytime"},
+		{"someday", "someday"},
+		{"2026-05-01", "2026-05-01"},
+		{"2026-05-01@09:30", "2026-05-01@09:30"},
+		{"9:30PM", "9:30PM"},
+		{"21:30", "21:30"},
+		{"next friday", "next friday"},
+		{"friday", "friday"},
+		{"tonight", "tonight"},
+		{"noon", "noon"},
+		{"2026-03-10T14:30:00Z", "2026-03-10@14:30"},
+		{"2026-03-10T14:30:00+02:00", "2026-03-10@14:30"},
+	}
+	for _, c := range cases {
+		got, err := NormalizeWhen(c.in)
+		if err != nil {
+			t.Errorf("NormalizeWhen(%q) unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("NormalizeWhen(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeWhenRejectsTypos(t *testing.T) {
+	for _, in := range []string{"tommorrow", "tomorow", "evning", "anytim", "Somday"} {
+		_, err := NormalizeWhen(in)
+		if err == nil {
+			t.Errorf("NormalizeWhen(%q) expected error, got nil", in)
+			continue
+		}
+		if !strings.Contains(err.Error(), "did you mean") {
+			t.Errorf("NormalizeWhen(%q) error = %v, want 'did you mean'", in, err)
+		}
+	}
+}
+
+func TestNormalizeDeadline(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"  ", ""},
+		{"2026-05-01", "2026-05-01"},
+		{"2026-03-10T14:30:00Z", "2026-03-10"},
+		{"next friday", "next friday"},
+	}
+	for _, c := range cases {
+		got, err := NormalizeDeadline(c.in)
+		if err != nil {
+			t.Errorf("NormalizeDeadline(%q) unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("NormalizeDeadline(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeDeadlineRejects(t *testing.T) {
+	cases := []struct {
+		in       string
+		contains string
+	}{
+		{"today", "does not accept keywords"},
+		{"tomorrow", "does not accept keywords"},
+	}
+	for _, c := range cases {
+		_, err := NormalizeDeadline(c.in)
+		if err == nil {
+			t.Errorf("NormalizeDeadline(%q) expected error, got nil", c.in)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.contains) {
+			t.Errorf("NormalizeDeadline(%q) error = %v, want substring %q", c.in, err, c.contains)
+		}
+	}
+}

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -96,6 +96,16 @@ func AddProject(params AddProjectParams) error {
 	if err := validateAddProject(params); err != nil {
 		return err
 	}
+	when, err := NormalizeWhen(params.When)
+	if err != nil {
+		return err
+	}
+	params.When = when
+	deadline, err := NormalizeDeadline(params.Deadline)
+	if err != nil {
+		return err
+	}
+	params.Deadline = deadline
 	v := url.Values{}
 	v.Set("title", params.Title)
 	if params.Notes != "" {
@@ -153,6 +163,20 @@ func UpdateTask(params UpdateParams) error {
 	}
 	if err := validateUpdate(params); err != nil {
 		return err
+	}
+	if params.When != nil {
+		v, err := NormalizeWhen(*params.When)
+		if err != nil {
+			return err
+		}
+		params.When = &v
+	}
+	if params.Deadline != nil {
+		v, err := NormalizeDeadline(*params.Deadline)
+		if err != nil {
+			return err
+		}
+		params.Deadline = &v
 	}
 
 	v := url.Values{}
@@ -244,6 +268,20 @@ func UpdateProject(params UpdateProjectParams) error {
 	if err := validateUpdateProject(params); err != nil {
 		return err
 	}
+	if params.When != nil {
+		v, err := NormalizeWhen(*params.When)
+		if err != nil {
+			return err
+		}
+		params.When = &v
+	}
+	if params.Deadline != nil {
+		v, err := NormalizeDeadline(*params.Deadline)
+		if err != nil {
+			return err
+		}
+		params.Deadline = &v
+	}
 
 	v := url.Values{}
 	v.Set("id", params.ID)
@@ -282,6 +320,16 @@ func AddTask(params AddParams) error {
 	if err := validateAdd(params); err != nil {
 		return err
 	}
+	when, err := NormalizeWhen(params.When)
+	if err != nil {
+		return err
+	}
+	params.When = when
+	deadline, err := NormalizeDeadline(params.Deadline)
+	if err != nil {
+		return err
+	}
+	params.Deadline = deadline
 	v := url.Values{}
 	v.Set("title", params.Title)
 	if params.Notes != "" {

--- a/internal/things/urlscheme_test.go
+++ b/internal/things/urlscheme_test.go
@@ -245,6 +245,33 @@ func TestImportJSON(t *testing.T) {
 
 func strPtr(s string) *string { return &s }
 
+func TestUpdateTaskEmptyWhenClearsField(t *testing.T) {
+	captured := stubRunner(t, false)
+	empty := ""
+	if err := UpdateTask(UpdateParams{
+		ID:        "id-1",
+		AuthToken: "tok",
+		When:      &empty,
+		Deadline:  &empty,
+	}); err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
+	parsed, err := url.Parse((*captured)[2])
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	q := parsed.Query()
+	if _, ok := q["when"]; !ok {
+		t.Error("expected `when` parameter present (empty value clears the field)")
+	}
+	if _, ok := q["deadline"]; !ok {
+		t.Error("expected `deadline` parameter present (empty value clears the field)")
+	}
+	if q.Get("when") != "" || q.Get("deadline") != "" {
+		t.Errorf("expected empty values, got when=%q deadline=%q", q.Get("when"), q.Get("deadline"))
+	}
+}
+
 func TestUpdateTaskMinimal(t *testing.T) {
 	captured := stubRunner(t, false)
 


### PR DESCRIPTION
Closes #25.

## Summary

- Adds `NormalizeWhen` / `NormalizeDeadline` in `internal/things/dates.go`, called from `AddTask`, `AddProject`, `UpdateTask`, `UpdateProject` so every write surface gets the same treatment.
- RFC3339 timestamps are rewritten to the URL scheme's preferred forms (`YYYY-MM-DD@HH:MM` for `when`, `YYYY-MM-DD` for `deadline`); the offset is preserved as wall-clock.
- Inputs within Levenshtein distance 2 of a known keyword are rejected client-side as likely typos with a "did you mean" hint (e.g. `tommorrow` -> `today`, `evning` -> `evening`).
- Other natural-language phrases (`friday`, `tonight`, `next monday`) pass through unchanged so existing English-locale usage isn't disrupted.
- `--deadline` rejects the `when` keywords (`today`, `tomorrow`, ...) which the URL scheme silently ignores.
- Help text, README, and the bundled skill body document the accepted forms.

## Test plan

- [x] `make test` — new unit tests cover keywords, casing, dates, times, ISO8601, typos, NL pass-through, and the empty-string-clears-field semantics on `UpdateTask`.
- [x] `make lint` clean.
- [ ] Manual: `things add "x" --when tommorrow` -> friendly error with suggestion.
- [ ] Manual: `things edit 1 --when ""` still clears the schedule.
- [ ] Manual: `things add "x" --when 2026-03-10T14:30:00Z` lands at 14:30 on 2026-03-10.
