### PR TITLE
fix(skill): emit valid SKILL.md from bare `skill show`

### DIFF
--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -789,7 +789,7 @@ func runSkillUninstall(cli *CLI) error {
 func runSkillShow(cli *CLI) error {
 	name := cli.Skill.Show.Agent
 	if name == "" {
-		fmt.Print(skill.Body())
+		fmt.Print(skill.SkillMD())
 		return nil
 	}
 	agent, err := skill.Lookup(name)

--- a/internal/skill/claude.go
+++ b/internal/skill/claude.go
@@ -7,15 +7,8 @@ import (
 
 func init() { register(claudeAgent{}) }
 
-const claudeFrontmatter = `---
-name: things-cli
-description: Use when the user mentions Things3, tasks, todos, inbox, today, upcoming, projects, areas, or to-do lists on macOS. Provides the ` + "`things`" + ` CLI for listing, creating, editing, completing, and searching tasks.
----
-
-`
-
 var claudeFiles = map[string][]byte{
-	"SKILL.md": []byte(claudeFrontmatter + body),
+	"SKILL.md": []byte(SkillMD()),
 }
 
 type claudeAgent struct{}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -19,8 +19,20 @@ import (
 //go:embed body.md
 var body string
 
-// Body returns the neutral, agent-independent skill source.
+// Skill identity shared across agents. Individual agents may override these
+// when their target requires it, but today every agent uses the defaults.
+const (
+	Name        = "things-cli"
+	Description = "Use when the user mentions Things3, tasks, todos, inbox, today, upcoming, projects, areas, or to-do lists on macOS. Provides the `things` CLI for listing, creating, editing, completing, and searching tasks."
+)
+
+// Body returns the neutral skill source body (no frontmatter).
 func Body() string { return body }
+
+// SkillMD returns a self-contained SKILL.md: shared frontmatter + body.
+func SkillMD() string {
+	return fmt.Sprintf("---\nname: %s\ndescription: %s\n---\n\n%s", Name, Description, body)
+}
 
 // Agent renders and locates the skill for a particular AI coding agent.
 type Agent interface {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -13,6 +13,19 @@ func TestBodyNonEmpty(t *testing.T) {
 	}
 }
 
+func TestSkillMDIsSelfContained(t *testing.T) {
+	out := SkillMD()
+	if !strings.HasPrefix(out, "---\nname: "+Name+"\n") {
+		t.Errorf("SkillMD missing shared frontmatter prefix:\n%s", out[:min(len(out), 80)])
+	}
+	if !strings.Contains(out, "description: "+Description) {
+		t.Error("SkillMD missing shared description")
+	}
+	if !strings.Contains(out, Body()) {
+		t.Error("SkillMD missing body")
+	}
+}
+
 func TestClaudeSkillMDFrontmatterAndCommands(t *testing.T) {
 	a, err := Lookup("claude")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Hoist skill `name`/`description` to shared `skill.Name`/`skill.Description` constants
- Add `skill.SkillMD()` that returns a self-contained `frontmatter + body`
- Neutral `things skill show` now prints `SkillMD()` so its output is a valid SKILL.md
- Claude agent reuses `SkillMD()`, eliminating the duplicated inline `claudeFrontmatter`

Previously `things skill show | tee ~/.claude/skills/things-cli/SKILL.md` produced a file that wouldn't register as a skill (no frontmatter). Now it works.

Closes #33

## Test plan
- [x] `make test` — 192/192 passing, including new `TestSkillMDIsSelfContained`
- [x] `make lint` — clean
- [x] Existing `TestClaudeSkillMDFrontmatterAndCommands` still passes (Claude SKILL.md bytes unchanged)
- [ ] `things skill show > /tmp/SKILL.md` and verify frontmatter is present