### PR TITLE
refactor(add): stop sending auth-token to things:///add

### DIFF
--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -270,7 +270,7 @@ func run(ctx *kong.Context, cli *CLI, database *db.DB) error {
 	case "show <task>":
 		return runShow(cli, database)
 	case "add <title>":
-		return runAdd(cli, database)
+		return runAdd(cli)
 	case "project add <title>":
 		return runProjectAdd(cli)
 	case "project edit <project>":
@@ -365,12 +365,11 @@ func runShow(cli *CLI, database *db.DB) error {
 	return output.PrintTaskWithChecklist(os.Stdout, task, items, cli.JSON)
 }
 
-func runAdd(cli *CLI, database *db.DB) error {
+func runAdd(cli *CLI) error {
 	list := cli.Add.List
 	if list == "" {
 		list = cli.Add.Project
 	}
-	token, _ := database.GetAuthToken()
 	return things.AddTask(things.AddParams{
 		Title:     cli.Add.Title,
 		Notes:     cli.Add.Notes,
@@ -380,7 +379,6 @@ func runAdd(cli *CLI, database *db.DB) error {
 		Checklist: expandNewlines(cli.Add.Checklist),
 		Heading:   cli.Add.Heading,
 		List:      list,
-		AuthToken: token,
 	})
 }
 

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -16,7 +16,6 @@ type AddParams struct {
 	Checklist string
 	Heading   string
 	List      string
-	AuthToken string
 }
 
 type AddProjectParams struct {
@@ -304,9 +303,6 @@ func AddTask(params AddParams) error {
 	}
 	if params.Heading != "" {
 		v.Set("heading", params.Heading)
-	}
-	if params.AuthToken != "" {
-		v.Set("auth-token", params.AuthToken)
 	}
 	return openThingsURL("add", v)
 }

--- a/internal/things/urlscheme_test.go
+++ b/internal/things/urlscheme_test.go
@@ -62,7 +62,6 @@ func TestAddTaskAllFields(t *testing.T) {
 		Checklist: "x\ny",
 		Heading:   "H",
 		List:      "Inbox",
-		AuthToken: "tok",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -84,12 +83,14 @@ func TestAddTaskAllFields(t *testing.T) {
 		"checklist-items": "x\ny",
 		"heading":         "H",
 		"list":            "Inbox",
-		"auth-token":      "tok",
 	}
 	for k, want := range cases {
 		if got := q.Get(k); got != want {
 			t.Errorf("query[%q] = %q, want %q", k, got, want)
 		}
+	}
+	if q.Has("auth-token") {
+		t.Error("auth-token must not be sent on add (endpoint does not require it)")
 	}
 }
 


### PR DESCRIPTION
## Summary
- The `things:///add` URL scheme endpoint doesn't require `auth-token` — only `update`, `update-project`, and `json` (for updates) do.
- Drop the `GetAuthToken` lookup and the `AuthToken` field from `AddParams` / `runAdd`, removing a per-invocation SQLite read and the misleading impression that `add` needs auth.
- `GetAuthToken` is preserved for `edit` / `project edit` / `import`.

Closes #23

## Test plan
- [x] `make test` passes
- [x] `make lint` passes
- [x] `TestAddTaskAllFields` updated to assert `auth-token` is absent from the generated URL