### PR TITLE
refactor: simplify validators, URL-scheme setters, and runOpen resolution

### DIFF
--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -582,25 +582,30 @@ func runOpen(cli *CLI, database *db.DB) error {
 
 	params := things.ShowParams{Filter: cmd.Filter, Background: cmd.Background}
 
+	resolveUUID := func(kind, name string, find func(string) (string, error)) (string, error) {
+		uuid, err := find(name)
+		if err != nil {
+			return "", err
+		}
+		if uuid == "" {
+			return "", fmt.Errorf("%s not found: %s", kind, name)
+		}
+		return uuid, nil
+	}
+
 	switch {
 	case cmd.Query != "":
 		params.Query = cmd.Query
 	case cmd.Area != "":
-		uuid, err := database.FindAreaUUID(cmd.Area)
+		uuid, err := resolveUUID("area", cmd.Area, database.FindAreaUUID)
 		if err != nil {
 			return err
-		}
-		if uuid == "" {
-			return fmt.Errorf("area not found: %s", cmd.Area)
 		}
 		params.ID = uuid
 	case cmd.Tag != "":
-		uuid, err := database.FindTagUUID(cmd.Tag)
+		uuid, err := resolveUUID("tag", cmd.Tag, database.FindTagUUID)
 		if err != nil {
 			return err
-		}
-		if uuid == "" {
-			return fmt.Errorf("tag not found: %s", cmd.Tag)
 		}
 		params.ID = uuid
 	case cmd.Project != "":

--- a/internal/things/limits.go
+++ b/internal/things/limits.go
@@ -19,19 +19,15 @@ const (
 	MaxStringLen      = 4000
 )
 
-// runeLen counts characters as the URL-scheme docs do — multi-byte UTF-8
-// (emoji, CJK) shouldn't trip the limit earlier than a non-ASCII user expects.
-func runeLen(s string) int { return utf8.RuneCountInString(s) }
-
 func validateNotes(field, v string) error {
-	if n := runeLen(v); n > MaxNotesLen {
+	if n := utf8.RuneCountInString(v); n > MaxNotesLen {
 		return fmt.Errorf("%s: %d characters exceeds the %d-character limit", field, n, MaxNotesLen)
 	}
 	return nil
 }
 
 func validateString(field, v string) error {
-	if n := runeLen(v); n > MaxStringLen {
+	if n := utf8.RuneCountInString(v); n > MaxStringLen {
 		return fmt.Errorf("%s: %d characters exceeds the %d-character limit", field, n, MaxStringLen)
 	}
 	return nil
@@ -48,7 +44,7 @@ func validateChecklist(field, v string) error {
 		return fmt.Errorf("%s: %d items exceeds the %d-item limit", field, n, MaxChecklistItems)
 	}
 	for _, item := range strings.Split(trimmed, "\n") {
-		if c := runeLen(item); c > MaxStringLen {
+		if c := utf8.RuneCountInString(item); c > MaxStringLen {
 			return fmt.Errorf("%s: item %q (%d characters) exceeds the %d-character limit", field, truncate(item), c, MaxStringLen)
 		}
 	}
@@ -61,112 +57,109 @@ func validateTags(field, v string) error {
 	}
 	for _, t := range strings.Split(v, ",") {
 		t = strings.TrimSpace(t)
-		if c := runeLen(t); c > MaxStringLen {
+		if c := utf8.RuneCountInString(t); c > MaxStringLen {
 			return fmt.Errorf("%s: tag %q (%d characters) exceeds the %d-character limit", field, truncate(t), c, MaxStringLen)
 		}
 	}
 	return nil
 }
 
+// truncate returns s capped at 40 runes, with an ellipsis appended when
+// truncation occurred. Slicing by rune (not byte) keeps multi-byte
+// characters intact so the truncated value is always valid UTF-8.
 func truncate(s string) string {
 	const max = 40
-	if len(s) <= max {
-		return s
+	i := 0
+	for idx := range s {
+		if i == max {
+			return s[:idx] + "…"
+		}
+		i++
 	}
-	return s[:max] + "…"
+	return s
 }
 
-func opt(p *string, check func(string) error) error {
+func optString(field string, p *string) error {
 	if p == nil {
 		return nil
 	}
-	return check(*p)
+	return validateString(field, *p)
+}
+
+func optNotes(field string, p *string) error {
+	if p == nil {
+		return nil
+	}
+	return validateNotes(field, *p)
+}
+
+func optTags(field string, p *string) error {
+	if p == nil {
+		return nil
+	}
+	return validateTags(field, *p)
+}
+
+func optChecklist(field string, p *string) error {
+	if p == nil {
+		return nil
+	}
+	return validateChecklist(field, *p)
+}
+
+func firstErr(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validateAdd(p AddParams) error {
-	if err := validateString("title", p.Title); err != nil {
-		return err
-	}
-	if err := validateNotes("notes", p.Notes); err != nil {
-		return err
-	}
-	if err := validateTags("tags", p.Tags); err != nil {
-		return err
-	}
-	if err := validateChecklist("checklist", p.Checklist); err != nil {
-		return err
-	}
-	if err := validateString("list", p.List); err != nil {
-		return err
-	}
-	return validateString("heading", p.Heading)
+	return firstErr(
+		validateString("title", p.Title),
+		validateNotes("notes", p.Notes),
+		validateTags("tags", p.Tags),
+		validateChecklist("checklist", p.Checklist),
+		validateString("list", p.List),
+		validateString("heading", p.Heading),
+	)
 }
 
 func validateAddProject(p AddProjectParams) error {
-	if err := validateString("title", p.Title); err != nil {
-		return err
-	}
-	if err := validateNotes("notes", p.Notes); err != nil {
-		return err
-	}
-	if err := validateTags("tags", p.Tags); err != nil {
-		return err
-	}
-	return validateString("area", p.Area)
+	return firstErr(
+		validateString("title", p.Title),
+		validateNotes("notes", p.Notes),
+		validateTags("tags", p.Tags),
+		validateString("area", p.Area),
+	)
 }
 
 func validateUpdate(p UpdateParams) error {
-	if err := opt(p.Title, func(s string) error { return validateString("title", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.Notes, func(s string) error { return validateNotes("notes", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.PrependNotes, func(s string) error { return validateNotes("prepend-notes", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.AppendNotes, func(s string) error { return validateNotes("append-notes", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.Tags, func(s string) error { return validateTags("tags", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.AddTags, func(s string) error { return validateTags("add-tags", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.Checklist, func(s string) error { return validateChecklist("checklist", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.PrependChecklist, func(s string) error { return validateChecklist("prepend-checklist", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.AppendChecklist, func(s string) error { return validateChecklist("append-checklist", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.List, func(s string) error { return validateString("list", s) }); err != nil {
-		return err
-	}
-	return opt(p.Heading, func(s string) error { return validateString("heading", s) })
+	return firstErr(
+		optString("title", p.Title),
+		optNotes("notes", p.Notes),
+		optNotes("prepend-notes", p.PrependNotes),
+		optNotes("append-notes", p.AppendNotes),
+		optTags("tags", p.Tags),
+		optTags("add-tags", p.AddTags),
+		optChecklist("checklist", p.Checklist),
+		optChecklist("prepend-checklist", p.PrependChecklist),
+		optChecklist("append-checklist", p.AppendChecklist),
+		optString("list", p.List),
+		optString("heading", p.Heading),
+	)
 }
 
 func validateUpdateProject(p UpdateProjectParams) error {
-	if err := opt(p.Title, func(s string) error { return validateString("title", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.Notes, func(s string) error { return validateNotes("notes", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.PrependNotes, func(s string) error { return validateNotes("prepend-notes", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.AppendNotes, func(s string) error { return validateNotes("append-notes", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.Tags, func(s string) error { return validateTags("tags", s) }); err != nil {
-		return err
-	}
-	if err := opt(p.AddTags, func(s string) error { return validateTags("add-tags", s) }); err != nil {
-		return err
-	}
-	return opt(p.Area, func(s string) error { return validateString("area", s) })
+	return firstErr(
+		optString("title", p.Title),
+		optNotes("notes", p.Notes),
+		optNotes("prepend-notes", p.PrependNotes),
+		optNotes("append-notes", p.AppendNotes),
+		optTags("tags", p.Tags),
+		optTags("add-tags", p.AddTags),
+		optString("area", p.Area),
+	)
 }

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -45,6 +45,24 @@ func runOpen(args ...string) error {
 	return nil
 }
 
+func setStr(v url.Values, key string, p *string) {
+	if p != nil {
+		v.Set(key, *p)
+	}
+}
+
+func setBool(v url.Values, key string, b bool) {
+	if b {
+		v.Set(key, "true")
+	}
+}
+
+func setNonEmpty(v url.Values, key, value string) {
+	if value != "" {
+		v.Set(key, value)
+	}
+}
+
 // BuiltinLists are the navigable list IDs the Things URL scheme accepts
 // verbatim as `id=…`. Some (e.g. repeating, all-projects) have no direct
 // DB equivalent — they're app-side views only.
@@ -107,24 +125,12 @@ func AddProject(params AddProjectParams) error {
 	params.Deadline = deadline
 	v := url.Values{}
 	v.Set("title", params.Title)
-	if params.Notes != "" {
-		v.Set("notes", params.Notes)
-	}
-	if params.When != "" {
-		v.Set("when", params.When)
-	}
-	if params.Deadline != "" {
-		v.Set("deadline", params.Deadline)
-	}
-	if params.Tags != "" {
-		v.Set("tags", params.Tags)
-	}
-	if params.Area != "" {
-		v.Set("area", params.Area)
-	}
-	if params.Todos != "" {
-		v.Set("to-dos", params.Todos)
-	}
+	setNonEmpty(v, "notes", params.Notes)
+	setNonEmpty(v, "when", params.When)
+	setNonEmpty(v, "deadline", params.Deadline)
+	setNonEmpty(v, "tags", params.Tags)
+	setNonEmpty(v, "area", params.Area)
+	setNonEmpty(v, "to-dos", params.Todos)
 	return openThingsURL("add-project", v)
 }
 
@@ -182,36 +188,25 @@ func UpdateTask(params UpdateParams) error {
 	v.Set("id", params.ID)
 	v.Set("auth-token", params.AuthToken)
 
-	setStr := func(key string, p *string) {
-		if p != nil {
-			v.Set(key, *p)
-		}
-	}
-	setBool := func(key string, b bool) {
-		if b {
-			v.Set(key, "true")
-		}
-	}
-
-	setStr("title", params.Title)
-	setStr("notes", params.Notes)
-	setStr("prepend-notes", params.PrependNotes)
-	setStr("append-notes", params.AppendNotes)
-	setStr("when", params.When)
-	setStr("deadline", params.Deadline)
-	setStr("tags", params.Tags)
-	setStr("add-tags", params.AddTags)
-	setStr("checklist-items", params.Checklist)
-	setStr("prepend-checklist-items", params.PrependChecklist)
-	setStr("append-checklist-items", params.AppendChecklist)
-	setStr("list", params.List)
-	setStr("list-id", params.ListID)
-	setStr("heading", params.Heading)
-	setStr("heading-id", params.HeadingID)
-	setBool("completed", params.Completed)
-	setBool("canceled", params.Canceled)
-	setBool("duplicate", params.Duplicate)
-	setBool("reveal", params.Reveal)
+	setStr(v, "title", params.Title)
+	setStr(v, "notes", params.Notes)
+	setStr(v, "prepend-notes", params.PrependNotes)
+	setStr(v, "append-notes", params.AppendNotes)
+	setStr(v, "when", params.When)
+	setStr(v, "deadline", params.Deadline)
+	setStr(v, "tags", params.Tags)
+	setStr(v, "add-tags", params.AddTags)
+	setStr(v, "checklist-items", params.Checklist)
+	setStr(v, "prepend-checklist-items", params.PrependChecklist)
+	setStr(v, "append-checklist-items", params.AppendChecklist)
+	setStr(v, "list", params.List)
+	setStr(v, "list-id", params.ListID)
+	setStr(v, "heading", params.Heading)
+	setStr(v, "heading-id", params.HeadingID)
+	setBool(v, "completed", params.Completed)
+	setBool(v, "canceled", params.Canceled)
+	setBool(v, "duplicate", params.Duplicate)
+	setBool(v, "reveal", params.Reveal)
 
 	return openThingsURL("update", v)
 }
@@ -286,31 +281,20 @@ func UpdateProject(params UpdateProjectParams) error {
 	v.Set("id", params.ID)
 	v.Set("auth-token", params.AuthToken)
 
-	setStr := func(key string, p *string) {
-		if p != nil {
-			v.Set(key, *p)
-		}
-	}
-	setBool := func(key string, b bool) {
-		if b {
-			v.Set(key, "true")
-		}
-	}
-
-	setStr("title", params.Title)
-	setStr("notes", params.Notes)
-	setStr("prepend-notes", params.PrependNotes)
-	setStr("append-notes", params.AppendNotes)
-	setStr("when", params.When)
-	setStr("deadline", params.Deadline)
-	setStr("tags", params.Tags)
-	setStr("add-tags", params.AddTags)
-	setStr("area", params.Area)
-	setStr("area-id", params.AreaID)
-	setBool("completed", params.Completed)
-	setBool("canceled", params.Canceled)
-	setBool("duplicate", params.Duplicate)
-	setBool("reveal", params.Reveal)
+	setStr(v, "title", params.Title)
+	setStr(v, "notes", params.Notes)
+	setStr(v, "prepend-notes", params.PrependNotes)
+	setStr(v, "append-notes", params.AppendNotes)
+	setStr(v, "when", params.When)
+	setStr(v, "deadline", params.Deadline)
+	setStr(v, "tags", params.Tags)
+	setStr(v, "add-tags", params.AddTags)
+	setStr(v, "area", params.Area)
+	setStr(v, "area-id", params.AreaID)
+	setBool(v, "completed", params.Completed)
+	setBool(v, "canceled", params.Canceled)
+	setBool(v, "duplicate", params.Duplicate)
+	setBool(v, "reveal", params.Reveal)
 
 	return openThingsURL("update-project", v)
 }
@@ -331,26 +315,12 @@ func AddTask(params AddParams) error {
 	params.Deadline = deadline
 	v := url.Values{}
 	v.Set("title", params.Title)
-	if params.Notes != "" {
-		v.Set("notes", params.Notes)
-	}
-	if params.When != "" {
-		v.Set("when", params.When)
-	}
-	if params.Deadline != "" {
-		v.Set("deadline", params.Deadline)
-	}
-	if params.Tags != "" {
-		v.Set("tags", params.Tags)
-	}
-	if params.Checklist != "" {
-		v.Set("checklist-items", params.Checklist)
-	}
-	if params.List != "" {
-		v.Set("list", params.List)
-	}
-	if params.Heading != "" {
-		v.Set("heading", params.Heading)
-	}
+	setNonEmpty(v, "notes", params.Notes)
+	setNonEmpty(v, "when", params.When)
+	setNonEmpty(v, "deadline", params.Deadline)
+	setNonEmpty(v, "tags", params.Tags)
+	setNonEmpty(v, "checklist-items", params.Checklist)
+	setNonEmpty(v, "list", params.List)
+	setNonEmpty(v, "heading", params.Heading)
 	return openThingsURL("add", v)
 }


### PR DESCRIPTION
## Summary
Post-v0.1.0 review cleanup surfaced by three parallel review agents (reuse, quality, efficiency).

- **Fix UTF-8 bug in `truncate()`**: was slicing by byte, could emit invalid UTF-8 mid-rune in error messages. Now slices by rune.
- **Collapse validator boilerplate**: `validateUpdate` / `validateUpdateProject` were 11 near-identical `opt(p.X, func(s string) error { return validateX("field", s) })` lines each. Replaced with `optString` / `optNotes` / `optTags` / `optChecklist` plus a `firstErr` chainer. `validateAdd` / `validateAddProject` use the same chain shape.
- **Lift URL-scheme setters**: `setStr` / `setBool` were redefined as local closures in both `UpdateTask` and `UpdateProject`. Moved to package helpers; added `setNonEmpty` and used it to collapse ~24 `if params.X != "" { v.Set(...) }` blocks in `AddTask` / `AddProject`.
- **Unify `runOpen` resolution**: three near-identical `FindXUUID` → nil-check → not-found-error arms (area, tag) consolidated via a local `resolveUUID` closure.

Net: **-34 lines**, no behaviour change.

## Test plan
- [x] `make test` — all packages pass
- [x] `make lint` — 0 issues