### PR TITLE
fix(today): align CLI Today view with the Things app

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -106,8 +106,14 @@ var viewFilters = map[string]string{
 var viewOrderBy = map[string]string{
 	"logbook":   "ORDER BY t.stopDate DESC",
 	"deadlines": "ORDER BY t.deadline ASC",
-	"today":     "ORDER BY CASE WHEN t.project IS NULL THEN 0 ELSE 1 END, CASE WHEN t.project IS NULL THEN t.status ELSE 0 END DESC, CASE WHEN t.project IS NULL THEN t.todayIndexReferenceDate ELSE 0 END DESC, CASE WHEN t.project IS NOT NULL AND pa.uuid IS NULL THEN 1 ELSE 0 END, pa.\"index\", p.\"index\", t.todayIndex ASC",
-	"project":   "ORDER BY t.start ASC, t.\"index\" ASC",
+	// Today view groups: (1) top-level items with no project and no area,
+	// (2) area-only items grouped by area.index, (3) project items grouped by
+	// their project (ordered by their own area then project index). Within
+	// each group, sort by status (open before completed/cancelled), then by
+	// todayIndexReferenceDate DESC (most-recently scheduled first), then by
+	// todayIndex ASC (Things' manual ordering within a day).
+	"today":   "ORDER BY CASE WHEN t.project IS NULL AND t.area IS NULL THEN 0 WHEN t.project IS NULL THEN 1 ELSE 2 END, COALESCE(a.\"index\", pa.\"index\", 0), COALESCE(p.\"index\", 0), t.status ASC, t.todayIndexReferenceDate DESC, t.todayIndex ASC",
+	"project": "ORDER BY t.start ASC, t.\"index\" ASC",
 }
 
 func ValidView(name string) bool {

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ryanlewis/things-cli/internal/model"
 )
@@ -91,7 +92,7 @@ func scanTask(row interface{ Scan(...any) error }) (model.Task, error) {
 }
 
 var viewFilters = map[string]string{
-	"today":     "t.start = 1 AND t.startBucket = 0 AND t.startDate IS NOT NULL AND (t.status = 0 OR (t.status IN (2, 3) AND t.stopDate > COALESCE((SELECT manualLogDate FROM TMSettings LIMIT 1), 0))) AND t.trashed = 0 AND COALESCE(p.trashed, 0) = 0 AND t.type = 0",
+	"today":     "t.start = 1 AND t.startBucket IN (0, 1) AND t.startDate IS NOT NULL AND (t.status = 0 OR (t.status IN (2, 3) AND t.todayIndexReferenceDate = ? AND t.stopDate > COALESCE((SELECT manualLogDate FROM TMSettings LIMIT 1), 0))) AND t.trashed = 0 AND COALESCE(p.trashed, 0) = 0 AND t.type = 0",
 	"inbox":     "t.start = 0 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
 	"upcoming":  "t.start = 1 AND t.startDate IS NOT NULL AND t.startBucket = 1 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
 	"anytime":   "t.start = 1 AND t.startBucket = 0 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
@@ -121,6 +122,9 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 	}
 
 	var args []any
+	if view == "today" {
+		args = append(args, int64(model.ThingsDateFromTime(time.Now())))
+	}
 	if opts.Project != "" {
 		where += " AND (p.uuid = ? OR p.title LIKE ?)"
 		args = append(args, opts.Project, opts.Project)

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -94,9 +94,9 @@ func scanTask(row interface{ Scan(...any) error }) (model.Task, error) {
 var viewFilters = map[string]string{
 	"today":     "t.start = 1 AND t.startBucket IN (0, 1) AND t.startDate IS NOT NULL AND (t.status = 0 OR (t.status IN (2, 3) AND t.todayIndexReferenceDate = ? AND t.stopDate > COALESCE((SELECT manualLogDate FROM TMSettings LIMIT 1), 0))) AND t.trashed = 0 AND COALESCE(p.trashed, 0) = 0 AND t.type = 0",
 	"inbox":     "t.start = 0 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
-	"upcoming":  "t.start = 1 AND t.startDate IS NOT NULL AND t.startBucket = 1 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
-	"anytime":   "t.start = 1 AND t.startBucket = 0 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
-	"someday":   "t.start = 2 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
+	"upcoming":  "t.start = 2 AND t.startDate IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
+	"anytime":   "t.start = 1 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
+	"someday":   "t.start = 2 AND t.startDate IS NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
 	"logbook":   "t.status = 3 AND t.trashed = 0 AND t.type = 0",
 	"trash":     "t.trashed = 1 AND t.type = 0",
 	"deadlines": "t.deadline IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0",

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -28,22 +28,25 @@ func seedTasks(t *testing.T, d *DB) {
 	today := int64(model.ThingsDateFromTime(time.Now()))
 
 	// Tasks covering views:
-	//   t-today       → today view
-	//   t-inbox       → inbox (no start bucket set, start=0)
-	//   t-upcoming    → scheduled for later (startBucket=1)
-	//   t-anytime     → start=1, bucket=0, no startDate (not a today task)
-	//   t-someday     → start=2
+	//   t-today       → today view (start=1, startBucket=0)
+	//   t-inbox       → inbox (start=0)
+	//   t-evening     → today/evening (start=1, startBucket=1)
+	//   t-upcoming    → upcoming, scheduled for the future (start=2, startDate set)
+	//   t-anytime     → anytime (start=1, no startDate)
+	//   t-someday     → someday (start=2, no startDate)
 	//   t-done        → status=completed (logbook)
 	//   t-cancelled   → status=cancelled (logbook)
 	//   t-trashed     → trashed
 	//   t-deadline    → has deadline
 	//   t-in-proj     → open task inside proj-1
+	tomorrow := today + (1 << 7)
 	mustExec(t, d, `INSERT INTO TMTask
 		(uuid, title, notes, type, status, trashed, start, startBucket,
 		 startDate, todayIndexReferenceDate, deadline, project, area, "index", todayIndex) VALUES
 		('t-today',     'Today task',    '',       0, 0, 0, 1, 0, ?, ?, NULL, NULL,     NULL,        10, 1),
 		('t-inbox',     'Inbox task',    'notes',  0, 0, 0, 0, 0, NULL, NULL, NULL, NULL,     NULL,        11, 0),
-		('t-upcoming',  'Upcoming task', '',       0, 0, 0, 1, 1, ?, NULL, NULL, NULL,     NULL,        12, 0),
+		('t-evening',   'Evening task',  '',       0, 0, 0, 1, 1, ?, NULL, NULL, NULL,     NULL,        12, 0),
+		('t-upcoming',  'Upcoming task', '',       0, 0, 0, 2, 0, ?, NULL, NULL, NULL,     NULL,        22, 0),
 		('t-anytime',   'Anytime task',  '',       0, 0, 0, 1, 0, NULL, NULL, NULL, NULL,     NULL,        13, 0),
 		('t-someday',   'Someday task',  '',       0, 0, 0, 2, 0, NULL, NULL, NULL, NULL,     NULL,        14, 0),
 		('t-done',      'Done task',     '',       0, 3, 0, 0, 0, NULL, NULL, NULL, NULL,     NULL,        15, 0),
@@ -51,7 +54,7 @@ func seedTasks(t *testing.T, d *DB) {
 		('t-trashed',   'Trashed task',  '',       0, 0, 1, 0, 0, NULL, NULL, NULL, NULL,     NULL,        17, 0),
 		('t-deadline',  'Has deadline',  '',       0, 0, 0, 1, 0, NULL, NULL, ?,    NULL,     NULL,        18, 0),
 		('t-in-proj',   'Project task',  '',       0, 0, 0, 0, 0, NULL, NULL, NULL, 'proj-1', 'area-work', 19, 0)`,
-		today, today, today, today+1<<7) // last arg is the deadline
+		today, today, today, tomorrow, tomorrow) // last arg is the deadline
 
 	// Tag the today task with urgent + home
 	mustExec(t, d, `INSERT INTO TMTaskTag (tasks, tags) VALUES
@@ -92,13 +95,13 @@ func TestListTasksViews(t *testing.T) {
 		want []string
 	}{
 		// Today view includes both the Today bucket (startBucket=0, here t-today)
-		// and the Evening bucket (startBucket=1, here t-upcoming). This mirrors
+		// and the Evening bucket (startBucket=1, here t-evening). This mirrors
 		// the Things app, which lists Evening items beneath Today's main list.
-		{"today", []string{"t-today", "t-upcoming"}},
+		{"today", []string{"t-today", "t-evening"}},
 		{"inbox", []string{"t-inbox", "t-in-proj"}},
 		{"upcoming", []string{"t-upcoming"}},
-		// "anytime" filters start=1 AND startBucket=0, which matches t-today too.
-		{"anytime", []string{"t-today", "t-anytime", "t-deadline"}},
+		// Anytime is everything with start=1 — Today, Evening, and undated.
+		{"anytime", []string{"t-today", "t-evening", "t-anytime", "t-deadline"}},
 		{"someday", []string{"t-someday"}},
 		{"logbook", []string{"t-done"}},
 		{"trash", []string{"t-trashed"}},
@@ -151,8 +154,8 @@ func TestListTasksTodayCompletedItemFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTasks today: %v", err)
 	}
-	if !sameSet([]string{"t-today", "t-upcoming", "t-just-done"}, uuidsOf(got)) {
-		t.Fatalf("pre-log: expected {t-today, t-upcoming, t-just-done}, got %v", uuidsOf(got))
+	if !sameSet([]string{"t-today", "t-evening", "t-just-done"}, uuidsOf(got)) {
+		t.Fatalf("pre-log: expected {t-today, t-evening, t-just-done}, got %v", uuidsOf(got))
 	}
 
 	// Simulate "Log Completed Now": bump manualLogDate past the stopDate.
@@ -163,8 +166,8 @@ func TestListTasksTodayCompletedItemFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTasks today: %v", err)
 	}
-	if !sameSet([]string{"t-today", "t-upcoming"}, uuidsOf(got)) {
-		t.Fatalf("post-log: expected {t-today, t-upcoming}, got %v", uuidsOf(got))
+	if !sameSet([]string{"t-today", "t-evening"}, uuidsOf(got)) {
+		t.Fatalf("post-log: expected {t-today, t-evening}, got %v", uuidsOf(got))
 	}
 }
 
@@ -230,7 +233,7 @@ func TestTagGroupConcatDelimiter(t *testing.T) {
 	seedTasks(t, d)
 
 	// Filter to t-today specifically; today now also includes the Evening
-	// bucket (t-upcoming), so don't assert the row count of the whole view.
+	// bucket (t-evening), so don't assert the row count of the whole view.
 	tasks, err := d.ListTasks("today", TaskFilter{Tag: "urgent"})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -91,7 +91,10 @@ func TestListTasksViews(t *testing.T) {
 		view string
 		want []string
 	}{
-		{"today", []string{"t-today"}},
+		// Today view includes both the Today bucket (startBucket=0, here t-today)
+		// and the Evening bucket (startBucket=1, here t-upcoming). This mirrors
+		// the Things app, which lists Evening items beneath Today's main list.
+		{"today", []string{"t-today", "t-upcoming"}},
 		{"inbox", []string{"t-inbox", "t-in-proj"}},
 		{"upcoming", []string{"t-upcoming"}},
 		// "anytime" filters start=1 AND startBucket=0, which matches t-today too.
@@ -116,26 +119,40 @@ func TestListTasksViews(t *testing.T) {
 	}
 }
 
-// Recently-completed items scheduled for today should show in the Today view
-// until a Log-Completed action bumps TMSettings.manualLogDate past their stopDate.
-func TestListTasksTodayIncludesRecentlyCompletedUntilLogged(t *testing.T) {
+// Completed items show in Today only while their todayIndexReferenceDate
+// matches today (Things auto-clears them when the day rolls over) AND while
+// their stopDate is newer than TMSettings.manualLogDate (Log Completed Now
+// clears them within the same day). Items completed on previous days, or
+// items whose stopDate is older than manualLogDate, must not appear.
+func TestListTasksTodayCompletedItemFiltering(t *testing.T) {
 	d := newTestDB(t)
 	seedTasks(t, d)
 
 	today := int64(model.ThingsDateFromTime(time.Now()))
-	stop := model.TimeToCoreData(time.Now().Add(-1 * time.Minute))
+	yesterday := today - (1 << 7) // ThingsDate encodes the day in bits 7..11
+	recentStop := model.TimeToCoreData(time.Now().Add(-1 * time.Minute))
 
+	// Completed today, not yet logged → should appear.
 	mustExec(t, d, `INSERT INTO TMTask
-		(uuid, title, type, status, trashed, start, startBucket, startDate, stopDate, "index")
-		VALUES ('t-just-done', 'Just done', 0, 3, 0, 1, 0, ?, ?, 20)`, today, stop)
+		(uuid, title, type, status, trashed, start, startBucket, startDate,
+		 todayIndexReferenceDate, stopDate, "index")
+		VALUES ('t-just-done', 'Just done', 0, 3, 0, 1, 0, ?, ?, ?, 20)`,
+		today, today, recentStop)
 
-	// No manualLogDate yet — should appear in Today.
+	// Completed yesterday — Things auto-clears these from Today even though
+	// no manual log has run, because their todayIndexReferenceDate is stale.
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, startDate,
+		 todayIndexReferenceDate, stopDate, "index")
+		VALUES ('t-done-yesterday', 'Done yesterday', 0, 3, 0, 1, 0, ?, ?, ?, 21)`,
+		today, yesterday, recentStop)
+
 	got, err := d.ListTasks("today", TaskFilter{})
 	if err != nil {
 		t.Fatalf("ListTasks today: %v", err)
 	}
-	if !sameSet([]string{"t-today", "t-just-done"}, uuidsOf(got)) {
-		t.Fatalf("pre-log: expected {t-today, t-just-done}, got %v", uuidsOf(got))
+	if !sameSet([]string{"t-today", "t-upcoming", "t-just-done"}, uuidsOf(got)) {
+		t.Fatalf("pre-log: expected {t-today, t-upcoming, t-just-done}, got %v", uuidsOf(got))
 	}
 
 	// Simulate "Log Completed Now": bump manualLogDate past the stopDate.
@@ -146,8 +163,8 @@ func TestListTasksTodayIncludesRecentlyCompletedUntilLogged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTasks today: %v", err)
 	}
-	if !sameSet([]string{"t-today"}, uuidsOf(got)) {
-		t.Fatalf("post-log: expected {t-today}, got %v", uuidsOf(got))
+	if !sameSet([]string{"t-today", "t-upcoming"}, uuidsOf(got)) {
+		t.Fatalf("post-log: expected {t-today, t-upcoming}, got %v", uuidsOf(got))
 	}
 }
 
@@ -212,7 +229,9 @@ func TestTagGroupConcatDelimiter(t *testing.T) {
 	d := newTestDB(t)
 	seedTasks(t, d)
 
-	tasks, err := d.ListTasks("today", TaskFilter{})
+	// Filter to t-today specifically; today now also includes the Evening
+	// bucket (t-upcoming), so don't assert the row count of the whole view.
+	tasks, err := d.ListTasks("today", TaskFilter{Tag: "urgent"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -48,49 +48,93 @@ func printJSON(w io.Writer, v any) error {
 }
 
 func printTasks(w io.Writer, tasks []model.Task) error {
-	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	const sentinel = "\x00" // distinct from empty string
-	currentProject, currentArea := sentinel, sentinel
+	type row struct {
+		num, status, title, tags, date string
+		groupKey, groupTitle           string
+		isProjectGroup                 bool
+	}
+	rows := make([]row, len(tasks))
+	var numW, statusW, titleW, tagsW int
 	for i, t := range tasks {
-		// Items belonging to a project group under the project header
-		// (whose own area is implicit). Otherwise, group by area.
-		groupKey := t.ProjectUUID
-		groupTitle := t.ProjectTitle
-		current := &currentProject
-		other := &currentArea
-		if t.ProjectUUID == "" {
-			groupKey = t.AreaUUID
-			groupTitle = t.AreaTitle
-			current, other = &currentArea, &currentProject
+		r := row{
+			num:    fmt.Sprintf("%d.", i+1),
+			status: statusIcon(t.Status),
+			title:  t.Title,
 		}
-		if groupKey != *current || *other != sentinel {
+		if t.Start == model.StartAnytime && t.StartBucket == 0 && t.StartDate != nil {
+			r.title = "\u2605 " + r.title
+		}
+		if len(t.Tags) > 0 {
+			r.tags = "[" + strings.Join(t.Tags, ", ") + "]"
+		}
+		switch {
+		case t.Deadline != nil:
+			r.date = "due:" + t.Deadline.String()
+		case t.StartDate != nil:
+			r.date = t.StartDate.String()
+		}
+		if t.ProjectUUID != "" {
+			r.groupKey = t.ProjectUUID
+			r.groupTitle = t.ProjectTitle
+			r.isProjectGroup = true
+		} else {
+			r.groupKey = t.AreaUUID
+			r.groupTitle = t.AreaTitle
+		}
+		rows[i] = r
+
+		if n := len(r.num); n > numW {
+			numW = n
+		}
+		if n := len(r.status); n > statusW {
+			statusW = n
+		}
+		// Length is fine for ASCII; \u2605 is multibyte but rendered single-cell.
+		if n := runeWidth(r.title); n > titleW {
+			titleW = n
+		}
+		if n := len(r.tags); n > tagsW {
+			tagsW = n
+		}
+	}
+
+	const sentinel = "\x00"
+	currentProject, currentArea := sentinel, sentinel
+	for _, r := range rows {
+		current := &currentArea
+		other := &currentProject
+		if r.isProjectGroup {
+			current, other = &currentProject, &currentArea
+		}
+		if r.groupKey != *current || *other != sentinel {
 			if currentProject != sentinel || currentArea != sentinel {
-				fmt.Fprintln(tw)
+				fmt.Fprintln(w)
 			}
-			if groupTitle != "" {
-				fmt.Fprintf(tw, "\t%s\n", groupTitle)
+			if r.groupTitle != "" {
+				fmt.Fprintf(w, "    %s\n", r.groupTitle)
 			}
-			*current = groupKey
+			*current = r.groupKey
 			*other = sentinel
 		}
-		status := statusIcon(t.Status)
-		tags := ""
-		if len(t.Tags) > 0 {
-			tags = "[" + strings.Join(t.Tags, ", ") + "]"
-		}
-		date := ""
-		if t.Deadline != nil {
-			date = "due:" + t.Deadline.String()
-		} else if t.StartDate != nil {
-			date = t.StartDate.String()
-		}
-		star := ""
-		if t.Start == model.StartAnytime && t.StartBucket == 0 && t.StartDate != nil {
-			star = "\u2605 "
-		}
-		fmt.Fprintf(tw, "%d.\t%s\t%s%s\t%s\t%s\n", i+1, status, star, t.Title, tags, date)
+		fmt.Fprintf(w, "%-*s  %-*s  %-*s  %-*s  %s\n",
+			numW, r.num,
+			statusW, r.status,
+			titleW, r.title,
+			tagsW, r.tags,
+			r.date,
+		)
 	}
-	return tw.Flush()
+	return nil
+}
+
+// runeWidth returns the visible width of s (rune count). Good enough for the
+// titles we print \u2014 no combining marks or East-Asian wide chars in practice.
+func runeWidth(s string) int {
+	n := 0
+	for range s {
+		n++
+	}
+	return n
 }
 
 func printTaskDetail(w io.Writer, t *model.Task, items []model.ChecklistItem) error {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -49,16 +49,29 @@ func printJSON(w io.Writer, v any) error {
 
 func printTasks(w io.Writer, tasks []model.Task) error {
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	currentProject := "\x00" // sentinel — distinct from empty string
+	const sentinel = "\x00" // distinct from empty string
+	currentProject, currentArea := sentinel, sentinel
 	for i, t := range tasks {
-		if t.ProjectUUID != currentProject {
-			if currentProject != "\x00" {
+		// Items belonging to a project group under the project header
+		// (whose own area is implicit). Otherwise, group by area.
+		groupKey := t.ProjectUUID
+		groupTitle := t.ProjectTitle
+		current := &currentProject
+		other := &currentArea
+		if t.ProjectUUID == "" {
+			groupKey = t.AreaUUID
+			groupTitle = t.AreaTitle
+			current, other = &currentArea, &currentProject
+		}
+		if groupKey != *current || *other != sentinel {
+			if currentProject != sentinel || currentArea != sentinel {
 				fmt.Fprintln(tw)
 			}
-			if t.ProjectTitle != "" {
-				fmt.Fprintf(tw, "\t%s\n", t.ProjectTitle)
+			if groupTitle != "" {
+				fmt.Fprintf(tw, "\t%s\n", groupTitle)
 			}
-			currentProject = t.ProjectUUID
+			*current = groupKey
+			*other = sentinel
 		}
 		status := statusIcon(t.Status)
 		tags := ""


### PR DESCRIPTION
## Summary

`things today` was diverging from the Things app in three ways. This PR fixes all three.

- **Stale completed items leaking into Today.** The previous filter let completed items show whenever `stopDate > manualLogDate`, but `manualLogDate` is only bumped by *Log Completed Now* — Things' end-of-day auto-clear actually relies on `todayIndexReferenceDate`. With a week-old `manualLogDate`, several days of completions were leaking through. Filter now requires `todayIndexReferenceDate = today` AND `stopDate > manualLogDate`, so items vanish at midnight (matching Things) and `things log` still clears them mid-day.
- **Evening items missing.** The filter required `startBucket = 0`, which excludes the Evening bucket (`startBucket = 1`). Confirmed against `thingsapi/things.py` — Today is just `start = 1` with no bucket constraint. Fixed to `startBucket IN (0, 1)`.
- **Upcoming/Someday/Anytime semantics wrong.** Upcoming was `start=1 AND startBucket=1` (which is actually Evening); should be `start=2 AND startDate IS NOT NULL`. Someday was including future-scheduled items; now requires `startDate IS NULL`. Anytime had a stray `startBucket=0` constraint that hid Evening items.
- **Today list ordering and grouping.** Items with an area but no project were sorted alongside true top-level items. Now grouped into top-level → area sections → project sections, matching the Things app layout. The renderer also prints area headers (previously only project changes broke into sections).
- **Column alignment across sections.** `tabwriter` recomputes column widths at every section break, which made the date column shift between groups. Replaced with manual width computation; section headers are now plain indented lines that don't influence task-row widths.

## Test plan

- [x] `make test` (all packages pass)
- [x] `make lint` (0 issues)
- [x] `things today` against my real DB matches the Things app exactly (order, sections, no stale completions, includes Evening items)
- [x] `things upcoming` shows future-scheduled `start=2` items, not Evening
- [x] `things someday` shows undated items only