### PR TITLE
fix(today): order projects and area-only items by area index

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -106,13 +106,13 @@ var viewFilters = map[string]string{
 var viewOrderBy = map[string]string{
 	"logbook":   "ORDER BY t.stopDate DESC",
 	"deadlines": "ORDER BY t.deadline ASC",
-	// Today view groups: (1) top-level items with no project and no area,
-	// (2) area-only items grouped by area.index, (3) project items grouped by
-	// their project (ordered by their own area then project index). Within
-	// each group, sort by status (open before completed/cancelled), then by
-	// todayIndexReferenceDate DESC (most-recently scheduled first), then by
-	// todayIndex ASC (Things' manual ordering within a day).
-	"today":   "ORDER BY CASE WHEN t.project IS NULL AND t.area IS NULL THEN 0 WHEN t.project IS NULL THEN 1 ELSE 2 END, COALESCE(a.\"index\", pa.\"index\", 0), COALESCE(p.\"index\", 0), t.status ASC, t.todayIndexReferenceDate DESC, t.todayIndex ASC",
+	// Today view: top-level items (no project, no area) come first, then
+	// everything else sorted by area then project index. Project tasks and
+	// area-only tasks interleave by area.index — so projects in a low-index
+	// area come before area-only items in higher-index areas, matching the
+	// Things app. Within each group, sort by status (open before completed),
+	// then todayIndexReferenceDate DESC, then todayIndex ASC.
+	"today":   "ORDER BY CASE WHEN t.project IS NULL AND t.area IS NULL THEN 0 ELSE 1 END, COALESCE(a.\"index\", pa.\"index\", 0), COALESCE(p.\"index\", 0), t.status ASC, t.todayIndexReferenceDate DESC, t.todayIndex ASC",
 	"project": "ORDER BY t.start ASC, t.\"index\" ASC",
 }
 


### PR DESCRIPTION
## Summary

`things today` was showing project sections (AFC, Quarterly All-Hands)
*after* area-only sections (Personal Projects, Personal), but the
Things app shows the opposite — projects in the Work area come first
because Work has the lowest area index.

The previous ORDER BY had three buckets:

```
0 = top-level (no project, no area)
1 = area-only (no project)
2 = project items
```

Bucket 1 < bucket 2 forced all area-only items before any project
item, regardless of area index. The fix collapses buckets 1 and 2
into one, so both kinds of rows interleave by `(area.index,
project.index)`. Top-level items still come first.

Verified against my real DB — `things today` now matches the Things
app order exactly (top-level → AFC → Quarterly All-Hands → Personal
Projects → Personal).

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] `things today` order matches the Things app