### PR TITLE
docs: serve site at things.rlew.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # things-cli
 
-[Website](https://ryanlewis.github.io/things-cli/) ·
+[Website](https://things.rlew.io) ·
 [Releases](https://github.com/ryanlewis/things-cli/releases/latest) ·
 [Issues](https://github.com/ryanlewis/things-cli/issues)
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+things.rlew.io

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,8 +10,8 @@ description: >-
   Every command speaks JSON. A bundled agent skill teaches Claude
   Code, Codex, and Pi when to reach for `things` instead of guessing.
 
-url: "https://ryanlewis.github.io"
-baseurl: "/things-cli"
+url: "https://things.rlew.io"
+baseurl: ""
 repository: ryanlewis/things-cli
 
 github:


### PR DESCRIPTION
## Summary

Move the docs site from `https://ryanlewis.github.io/things-cli/` to the custom subdomain `https://things.rlew.io`.

- `docs/CNAME` containing `things.rlew.io` — GitHub Pages reads this to associate the build artifact with the custom domain.
- `_config.yml`: `url: "https://things.rlew.io"`, `baseurl: ""` (no path prefix at the subdomain root).
- README hub link updated.

## DNS

Already done via Cloudflare:

```
things.rlew.io.   CNAME   ryanlewis.github.io.   (DNS-only, grey cloud)
```

Resolves now:

```
$ dig +short things.rlew.io @1.1.1.1
ryanlewis.github.io.
185.199.109.153
185.199.111.153
185.199.110.153
185.199.108.153
```

DNS-only (not proxied) so GitHub can provision the Let's Encrypt cert directly.

## After merge

One manual step in repo settings:

1. **Settings → Pages → Custom domain**: enter `things.rlew.io`, **Save**.
2. Wait a couple minutes for the GitHub-issued cert.
3. Tick **Enforce HTTPS**.

The Pages workflow will rebuild on merge (paths filter matches `docs/**`). After cert provisioning, every link generated by Liquid (`relative_url`) will be at the bare path (e.g. `/install/`) and resolve via the custom domain.

## Test plan

- [ ] Workflow runs green
- [ ] `https://things.rlew.io/` loads
- [ ] `https://things.rlew.io/install/`, `/commands/`, `/about/` all 200
- [ ] Old `ryanlewis.github.io/things-cli/` redirects to the new domain (GitHub does this automatically once custom domain is set)
- [ ] Search index loads from `https://things.rlew.io/assets/js/data/search.json`
- [ ] HTTPS enforced, no mixed-content warnings