### PR TITLE
fix(docs): drop duplicate site name from home page <title>

### DIFF
--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -1,0 +1,13 @@
+---
+layout: default
+refactor: true
+---
+
+{% include lang.html %}
+
+<article class="px-1">
+  <h1 class="dynamic-title">{{ page.title }}</h1>
+  <div class="content">
+    {{ content }}
+  </div>
+</article>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: home
 title: things-cli
 ---
 


### PR DESCRIPTION
## Bug

The landing page rendered `<title>things-cli | things-cli</title>`. Browser tabs and search results show the project name twice.

## Cause

Chirpy's `_includes/head.html`:

```liquid
<title>
  {%- unless page.layout == 'home' -%}
    {{- page.title | append: ' | ' -}}
  {%- endunless -%}
  {{- site.title -}}
</title>
```

`index.md` was on `layout: page`, so the prefix was added. `page.title` and `site.title` are both `things-cli` → duplication.

## Fix

- `index.md` switched to `layout: home` — short-circuits the prefix in head.html.
- Shadow `_layouts/home.html` because Chirpy's bundled version renders a paginated post list (we have no posts). Replacement mirrors `page.html` minus the locale lookup, so the H1 and content area look identical.

## Test plan

- [ ] Workflow runs green on merge
- [ ] `https://things.rlew.io/` renders `<title>things-cli</title>`
- [ ] H1 and body content unchanged
- [ ] All other pages (`/install/`, `/commands/`, `/about/`) still render with `Page | things-cli` titles