### PR TITLE
docs: drop home-page badges and credit Cultured Code

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,10 +15,6 @@ ships in the binary itself — `things skill install claude` drops it into
 Claude Code, and `things skill show` prints the neutral source so you
 can append it to whatever your agent reads for instructions.
 
-[![Latest release](https://img.shields.io/github/v/release/{{ site.repository }}?display_name=tag&color=blue)](https://github.com/{{ site.repository }}/releases/latest)
-[![MIT licensed](https://img.shields.io/github/license/{{ site.repository }})](https://github.com/{{ site.repository }}/blob/main/LICENSE)
-[![GitHub](https://img.shields.io/badge/source-github-181717?logo=github)](https://github.com/{{ site.repository }})
-
 ## Quickstart
 
 ```sh


### PR DESCRIPTION
Two small docs polish changes that came up after #60 landed.

## 1. Drop shields.io badges from the home page

After #60 switched `index.md` to `layout: home` to dedupe the page title, the three shields.io badges blew up to fullscreen banners on the landing page.

**Cause.** Chirpy's `_includes/refactor-content.html`, line 164:

```liquid
{% if page.layout == 'home' %}
  {% assign _wrapper_start = '<div class="preview-img ...">' %}
```

Every `<img>` on a `layout: home` page gets wrapped in `<div class="preview-img">`, and the CSS for that class is `aspect-ratio: 40 / 21; width: 100%`. Designed for blog post hero images. Catastrophic for shields.io.

No per-image opt-out without shadowing the entire 139-line `head.html` or `refactor-content.html`.

**Fix.** Drop the badges from the home page. They were decorative — release status, license, and source are still surfaced via the GitHub repo card (homepage URL set to `https://things.rlew.io`) and the README's hub link.

## 2. Credit Cultured Code on install + about pages

Inline `[Things3](https://culturedcode.com/things/)` links existed on the home and about pages but were easy to miss in prose. The install page — where someone unfamiliar with Things3 is most likely to land — had no link at all.

- `install.md` gets a callout explaining `things-cli` needs Things3 (paid app by Cultured Code), with explicit "independent third-party tool" disclaimer.
- `about.md` gets a dedicated **Credits** section above **Source**, naming Cultured Code as the upstream and clarifying that `things-cli` only uses the same automation interfaces (URL scheme, SQLite) that Cultured Code exposes to Shortcuts.

## Test plan

- [ ] Workflow runs green
- [ ] Home page no longer has fullscreen-banner badges
- [ ] `<title>things-cli</title>` still clean (no regression of #60)
- [ ] Install page renders the prompt-info callout with a working `https://culturedcode.com/things/` link
- [ ] About page has a Credits section linking Cultured Code
- [ ] `/commands/` unchanged