### PR TITLE
docs: credit Cultured Code on install + about pages

### DIFF
--- a/docs/_tabs/about.md
+++ b/docs/_tabs/about.md
@@ -33,6 +33,14 @@ things skill install claude
 things skill show
 ```
 
+## Credits
+
+Things3 is built and maintained by
+[Cultured Code](https://culturedcode.com/things/). `things-cli` is an
+independent, unaffiliated third-party tool that talks to the official
+`things:///` URL scheme and reads the on-disk SQLite database — same
+interfaces Cultured Code expose to Shortcuts and other automation.
+
 ## Source
 
 The full command reference and contributing guide live on

--- a/docs/_tabs/install.md
+++ b/docs/_tabs/install.md
@@ -7,6 +7,14 @@ order: 1
 `things-cli` runs on macOS and ships as a single static Go binary. Three
 ways to install — pick whichever fits your workflow.
 
+> **You'll need Things3.** This CLI talks to the
+> [Things3 app by Cultured Code](https://culturedcode.com/things/) —
+> a paid task manager for macOS, iPad, iPhone, and Apple Watch. It must
+> be installed and have been launched at least once for the database
+> to exist. `things-cli` is an independent third-party tool and is not
+> affiliated with Cultured Code.
+{: .prompt-info }
+
 ## One-line install script
 
 ```sh


### PR DESCRIPTION
Picks up the second half of the original #61 — pushed too late, missed the merge.

## Why

Inline `[Things3](https://culturedcode.com/things/)` links on the home and about pages were easy to miss in prose. The install page — where someone unfamiliar with Things3 is most likely to land — had no link at all.

## What

- **install.md**: prompt-info callout explaining `things-cli` needs Things3 (paid app by Cultured Code), with explicit "independent third-party tool" disclaimer.
- **about.md**: new `## Credits` section above Source, naming Cultured Code as upstream and noting `things-cli` only uses the same automation interfaces (URL scheme, SQLite) Cultured Code exposes to Shortcuts.

## Test plan

- [ ] Workflow runs green
- [ ] Install page renders the prompt-info callout with a working `https://culturedcode.com/things/` link
- [ ] About page has a Credits section linking Cultured Code, above Source
- [ ] No regression on home page or `/commands/`