### PR TITLE
docs(release): add v0.2.0 release notes header

### DIFF
--- a/.github/releases/v0.2.0.md
+++ b/.github/releases/v0.2.0.md
@@ -1,0 +1,27 @@
+## `things-cli` v0.2.0 — more writes, safer writes
+
+A bigger surface area for writing back to Things3, plus client-side validation so the URL scheme can't silently swallow bad input. The docs now live at [things.rlew.io](https://things.rlew.io/).
+
+### New commands
+
+- **`things edit`** — update existing tasks (title, notes, when, deadline, tags, checklist, project, area) via the URL scheme
+- **`things open`** — reveal a task, project, or area in the Things3 app
+- **`things import`** — batch-create items from a JSON payload using the `things:///add-json` scheme
+- **`things project add`** / **`things project edit`** — create and update projects
+- **`things skill`** — install the bundled Claude Code skill (also supports Codex and Pi agents) so an AI assistant can drive `things-cli` correctly
+
+### Quality of life
+
+- `--when` and `--deadline` are validated and normalized before being sent to Things
+- URL-scheme size and field limits are checked client-side, with clear errors instead of a silently truncated task
+- `things today` ordering now matches the Things app (projects and area-only items grouped by area index)
+- `--todos` / `--checklist` correctly expand literal `\n` in arguments
+
+### Docs
+
+- Project site published at [things.rlew.io](https://things.rlew.io/) — install guide, command reference, about page
+- README rewritten with grouped command tables and capabilities above the fold
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).


### PR DESCRIPTION
## Summary
- Add `.github/releases/v0.2.0.md` so goreleaser can read the header at tag time

## Test plan
- [x] File present and well-formed