### PR TITLE
fix(release): blank line before changelog separator

### DIFF
--- a/.github/releases/v0.2.0.md
+++ b/.github/releases/v0.2.0.md
@@ -25,3 +25,4 @@ A bigger surface area for writing back to Things3, plus client-side validation s
 ### Requirements
 
 macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).
+

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,4 +48,5 @@ release:
   mode: replace
   header: |
     {{ readFile (printf ".github/releases/%s.md" .Tag) }}
+
     ---


### PR DESCRIPTION
## Summary
- The goreleaser header template inserts `---` directly after the contents of `.github/releases/<tag>.md`. If that file's last line is text (no trailing blank line), Markdown reads the result as a setext H2 — the last paragraph renders as a giant heading. v0.2.0 hit this on the "Requirements" line.
- Add a blank line between the header file contents and the `---` in the template, so any header is safe regardless of trailing-newline count.
- Also normalise `v0.2.0.md` to end with a trailing blank line for consistency with `v0.1.0.md`.

The published v0.2.0 release body has already been patched directly via `gh release edit`.

## Test plan
- [x] `goreleaser check` passes
- [x] v0.2.0 release page now renders correctly above and below the separator