### PR TITLE
docs(site): add prominent GitHub CTA on home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,15 @@ database (read-only) and writes via the `things:///` URL scheme and
 AppleScript — so the app stays the source of truth and your data never
 leaves the machine.
 
+<div class="github-cta d-flex flex-wrap gap-2 my-4">
+  <a class="btn btn-primary" href="https://github.com/{{ site.repository }}" target="_blank" rel="noopener">
+    <i class="fa-brands fa-github"></i> View on GitHub
+  </a>
+  <a class="btn btn-outline-primary" href="https://github.com/{{ site.repository }}/releases/latest" target="_blank" rel="noopener">
+    Latest release
+  </a>
+</div>
+
 **AI-friendly by design.** Every command speaks JSON (`-j` / `--json`)
 for clean piping into `jq`, agents, or scripts. A bundled agent skill
 ships in the binary itself — `things skill install claude` drops it into


### PR DESCRIPTION
## Summary
- Add a "View on GitHub" / "Latest release" button row at the top of the docs home page so the source repo is obvious above the fold.
- Uses Chirpy's bundled Bootstrap utilities (`btn`, `d-flex`, `gap-2`) and Font Awesome 6 (`fa-brands fa-github`) — no new assets or CSS.

## Test plan
- [ ] Confirm `pages.yml` build succeeds on the PR.
- [ ] Visit the published preview / production page and verify the buttons render with the GitHub icon and link to `https://github.com/ryanlewis/things-cli` and `/releases/latest`.