### PR TITLE
fix(pages): pin Ruby to 3.4.9 for Chirpy compatibility

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0.3"
+          ruby-version: "3.4.9"
           bundler-cache: true
           working-directory: ./docs
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,12 @@
   "minimumReleaseAge": "5 days",
   "vulnerabilityAlerts": {
     "minimumReleaseAge": "0 days"
-  }
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": ["ruby"],
+      "allowedVersions": "<4",
+      "description": "Pin Ruby to 3.x while jekyll-theme-chirpy 7.x requires Ruby ~> 3.1"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Revert `ruby-version` in the Pages workflow from 4.0.3 → 3.4.9. Chirpy 7.x requires Ruby `~> 3.1`, so #66 broke `bundle install` on the Pages build.
- Add a Renovate `packageRule` pinning `ruby` to `<4` until Chirpy supports Ruby 4, so this doesn't bounce back on the next sweep.

## Test plan
- [ ] Pages workflow goes green on this PR.
- [ ] After merge, the previously failed run on `main` is replaced by a passing one and the docs site rebuilds.