### PR TITLE
fix(today): keep completed items visible until logged

### DIFF
--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/ryanlewis/things-cli/internal/model"
 )
@@ -92,7 +91,7 @@ func scanTask(row interface{ Scan(...any) error }) (model.Task, error) {
 }
 
 var viewFilters = map[string]string{
-	"today":     "t.start = 1 AND t.startBucket IN (0, 1) AND t.startDate IS NOT NULL AND (t.status = 0 OR (t.status IN (2, 3) AND t.todayIndexReferenceDate = ? AND t.stopDate > COALESCE((SELECT manualLogDate FROM TMSettings LIMIT 1), 0))) AND t.trashed = 0 AND COALESCE(p.trashed, 0) = 0 AND t.type = 0",
+	"today":     "t.start = 1 AND t.startBucket IN (0, 1) AND t.startDate IS NOT NULL AND (t.status = 0 OR (t.status IN (2, 3) AND t.stopDate > COALESCE((SELECT manualLogDate FROM TMSettings LIMIT 1), 0))) AND t.trashed = 0 AND COALESCE(p.trashed, 0) = 0 AND t.type = 0",
 	"inbox":     "t.start = 0 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
 	"upcoming":  "t.start = 2 AND t.startDate IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
 	"anytime":   "t.start = 1 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
@@ -128,9 +127,6 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 	}
 
 	var args []any
-	if view == "today" {
-		args = append(args, int64(model.ThingsDateFromTime(time.Now())))
-	}
 	if opts.Project != "" {
 		where += " AND (p.uuid = ? OR p.title LIKE ?)"
 		args = append(args, opts.Project, opts.Project)

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -122,43 +122,44 @@ func TestListTasksViews(t *testing.T) {
 	}
 }
 
-// Completed items show in Today only while their todayIndexReferenceDate
-// matches today (Things auto-clears them when the day rolls over) AND while
-// their stopDate is newer than TMSettings.manualLogDate (Log Completed Now
-// clears them within the same day). Items completed on previous days, or
-// items whose stopDate is older than manualLogDate, must not appear.
+// Completed items remain in Today until "Log Completed Now" bumps
+// TMSettings.manualLogDate past their stopDate. Items completed on previous
+// days are still visible (matching the Things app, which keeps them on screen
+// regardless of todayIndexReferenceDate until the user explicitly logs).
 func TestListTasksTodayCompletedItemFiltering(t *testing.T) {
 	d := newTestDB(t)
 	seedTasks(t, d)
 
 	today := int64(model.ThingsDateFromTime(time.Now()))
 	yesterday := today - (1 << 7) // ThingsDate encodes the day in bits 7..11
-	recentStop := model.TimeToCoreData(time.Now().Add(-1 * time.Minute))
+	stopToday := model.TimeToCoreData(time.Now().Add(-1 * time.Minute))
+	stopYesterday := model.TimeToCoreData(time.Now().Add(-25 * time.Hour))
 
 	// Completed today, not yet logged → should appear.
 	mustExec(t, d, `INSERT INTO TMTask
 		(uuid, title, type, status, trashed, start, startBucket, startDate,
 		 todayIndexReferenceDate, stopDate, "index")
 		VALUES ('t-just-done', 'Just done', 0, 3, 0, 1, 0, ?, ?, ?, 20)`,
-		today, today, recentStop)
+		today, today, stopToday)
 
-	// Completed yesterday — Things auto-clears these from Today even though
-	// no manual log has run, because their todayIndexReferenceDate is stale.
+	// Completed yesterday but not yet logged → still appears in Today, even
+	// though todayIndexReferenceDate is stale. This matches the Things app.
 	mustExec(t, d, `INSERT INTO TMTask
 		(uuid, title, type, status, trashed, start, startBucket, startDate,
 		 todayIndexReferenceDate, stopDate, "index")
 		VALUES ('t-done-yesterday', 'Done yesterday', 0, 3, 0, 1, 0, ?, ?, ?, 21)`,
-		today, yesterday, recentStop)
+		today, yesterday, stopYesterday)
 
 	got, err := d.ListTasks("today", TaskFilter{})
 	if err != nil {
 		t.Fatalf("ListTasks today: %v", err)
 	}
-	if !sameSet([]string{"t-today", "t-evening", "t-just-done"}, uuidsOf(got)) {
-		t.Fatalf("pre-log: expected {t-today, t-evening, t-just-done}, got %v", uuidsOf(got))
+	want := []string{"t-today", "t-evening", "t-just-done", "t-done-yesterday"}
+	if !sameSet(want, uuidsOf(got)) {
+		t.Fatalf("pre-log: expected %v, got %v", want, uuidsOf(got))
 	}
 
-	// Simulate "Log Completed Now": bump manualLogDate past the stopDate.
+	// Simulate "Log Completed Now": bump manualLogDate past both stopDates.
 	future := model.TimeToCoreData(time.Now().Add(1 * time.Minute))
 	mustExec(t, d, `INSERT INTO TMSettings (uuid, manualLogDate) VALUES ('s', ?)`, future)
 


### PR DESCRIPTION
## Summary
- #43 added a `todayIndexReferenceDate = today` clause to the completed/cancelled branch of the Today filter on the (incorrect) assumption that Things auto-clears items from Today when their reference date goes stale.
- Things actually keeps completed items in Today until the user runs "Log Completed Now" (which bumps `TMSettings.manualLogDate`). The result of #43 was `things today` hiding completed items the Things app itself was still rendering — e.g. tasks marked done on a previous day before the user had logged.
- Drop the reference-date check and rely solely on `stopDate > manualLogDate` as the discriminator (already present in the filter). The regression test had the same wrong assumption baked in; updated it.

## Repro (before this PR)
Things app shows 13 items in Today (including 3 completed and 1 cancelled), `things today` shows 7 — the 4 completed/cancelled items are missing.

## Test plan
- [x] `make test`
- [x] `make lint`
- [x] Run `./things today` against the live DB and verify completed/cancelled items now appear (matching what the Things app renders pre-log)
- [x] Updated `TestListTasksTodayCompletedItemFiltering` to reflect actual Things behaviour: a yesterday-completed item stays visible pre-log, then disappears once `manualLogDate` is bumped past its `stopDate`