### PR TITLE
fix(model): marshal ThingsDate as YYYY-MM-DD in JSON output

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,6 +1,10 @@
 package model
 
-import "time"
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
 
 const (
 	TypeTask    = 0
@@ -31,6 +35,25 @@ func ThingsDateFromTime(t time.Time) ThingsDate {
 
 func (d ThingsDate) String() string {
 	return d.ToTime().Format("2006-01-02")
+}
+
+// MarshalJSON renders the date as YYYY-MM-DD so jq/agents/scripts see a real
+// date rather than the bit-encoded int.
+func (d ThingsDate) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+func (d *ThingsDate) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("ThingsDate: %w", err)
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return fmt.Errorf("ThingsDate: %w", err)
+	}
+	*d = ThingsDateFromTime(t)
+	return nil
 }
 
 var coreDataEpoch = time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -40,6 +41,73 @@ func TestThingsDateEncoding(t *testing.T) {
 	want := ThingsDate(2026<<16 | 4<<12 | 14<<7)
 	if d != want {
 		t.Fatalf("encoding mismatch: got %d, want %d", d, want)
+	}
+}
+
+func TestThingsDateMarshalJSON(t *testing.T) {
+	d := ThingsDateFromTime(time.Date(2026, 5, 9, 0, 0, 0, 0, time.Local))
+	got, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if want := `"2026-05-09"`; string(got) != want {
+		t.Fatalf("Marshal = %s, want %s", got, want)
+	}
+}
+
+func TestThingsDateUnmarshalJSON(t *testing.T) {
+	var d ThingsDate
+	if err := json.Unmarshal([]byte(`"2026-05-09"`), &d); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got, want := d.String(), "2026-05-09"; got != want {
+		t.Fatalf("Unmarshal -> String = %q, want %q", got, want)
+	}
+	want := ThingsDateFromTime(time.Date(2026, 5, 9, 0, 0, 0, 0, time.Local))
+	if d != want {
+		t.Fatalf("Unmarshal value = %d, want %d", d, want)
+	}
+}
+
+func TestThingsDateUnmarshalInvalid(t *testing.T) {
+	cases := []string{
+		`"2026/05/09"`,
+		`"not a date"`,
+		`12345`,
+	}
+	for _, in := range cases {
+		var d ThingsDate
+		if err := json.Unmarshal([]byte(in), &d); err == nil {
+			t.Errorf("Unmarshal(%s) succeeded, want error", in)
+		}
+	}
+}
+
+func TestThingsDateOmitemptyNil(t *testing.T) {
+	type holder struct {
+		StartDate *ThingsDate `json:"startDate,omitempty"`
+	}
+	got, err := json.Marshal(holder{})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(got) != `{}` {
+		t.Fatalf("Marshal of nil = %s, want {}", got)
+	}
+}
+
+func TestThingsDateRoundTripJSON(t *testing.T) {
+	in := ThingsDateFromTime(time.Date(2024, 2, 29, 0, 0, 0, 0, time.Local))
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out ThingsDate
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if in != out {
+		t.Fatalf("round-trip mismatch: in=%d out=%d", in, out)
 	}
 }
 

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -45,17 +45,30 @@ func TestPrintTasksPlain(t *testing.T) {
 }
 
 func TestPrintTasksJSON(t *testing.T) {
-	tasks := []model.Task{{UUID: "u1", Title: "T1", Status: model.StatusOpen}}
+	tasks := []model.Task{{
+		UUID: "u1", Title: "T1", Status: model.StatusOpen,
+		StartDate: mustDate(2026, 5, 9),
+		Deadline:  mustDate(2026, 5, 20),
+	}}
 	var buf bytes.Buffer
 	if err := Print(&buf, tasks, true); err != nil {
 		t.Fatalf("Print: %v", err)
 	}
+	out := buf.String()
+	for _, want := range []string{`"startDate": "2026-05-09"`, `"deadline": "2026-05-20"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("json missing %q:\n%s", want, out)
+		}
+	}
 	var got []model.Task
 	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
-		t.Fatalf("parse json: %v\n%s", err, buf.String())
+		t.Fatalf("parse json: %v\n%s", err, out)
 	}
 	if len(got) != 1 || got[0].UUID != "u1" || got[0].Title != "T1" {
 		t.Fatalf("unexpected json: %+v", got)
+	}
+	if got[0].StartDate == nil || got[0].StartDate.String() != "2026-05-09" {
+		t.Fatalf("startDate round-trip wrong: %+v", got[0].StartDate)
 	}
 }
 
@@ -181,11 +194,14 @@ func TestPrintTaskDetail(t *testing.T) {
 }
 
 func TestPrintTaskDetailJSON(t *testing.T) {
-	task := &model.Task{UUID: "u1", Title: "T1"}
+	task := &model.Task{UUID: "u1", Title: "T1", Deadline: mustDate(2026, 5, 20)}
 	items := []model.ChecklistItem{{UUID: "c1", Title: "step", Status: model.StatusOpen}}
 	var buf bytes.Buffer
 	if err := PrintTaskWithChecklist(&buf, task, items, true); err != nil {
 		t.Fatalf("PrintTaskWithChecklist: %v", err)
+	}
+	if want := `"deadline": "2026-05-20"`; !strings.Contains(buf.String(), want) {
+		t.Errorf("json missing %q:\n%s", want, buf.String())
 	}
 	var got struct {
 		UUID      string                `json:"uuid"`


### PR DESCRIPTION
## Summary

- `ThingsDate.MarshalJSON` returns a quoted `YYYY-MM-DD` string (same form as `String()`), so `things <view> --json` now emits real dates instead of the raw bit-encoded int (`132906112`).
- `ThingsDate.UnmarshalJSON` parses that form back, so round-trip via `... -j | jq | things ...` works.
- Output tests now assert the wire shape (`"startDate": "2026-05-09"`), not just Go-to-Go round-trip.

## Behaviour change

Anything external that was parsing `startDate`/`deadline` as a number (rather than a string) will break — that's the bug being fixed. The fields stay `omitempty`-friendly because the struct still uses `*ThingsDate`.

## Test plan

- [x] `make test` (`-race`) green
- [x] `make lint` clean
- [x] Live: `things upcoming -j | jq '.[0].startDate'` → `"2026-05-07"`
- [x] Round-trip and invalid-input cases covered in `internal/model/model_test.go`
- [x] Wire-shape asserted in `internal/output/output_test.go` for both list and detail views

Closes #76