### PR TITLE
docs(skill): document bulk reschedule, auth-token, weekday --when

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,11 @@ things project add "Launch site" --area Work --deadline 2026-05-01
 `things project edit <project>` updates a project via
 `things:///update-project`. Only the flags you pass are sent — unset fields
 stay untouched. An empty value clears the field (e.g. `--deadline ""`).
-Both require the Things auth token — enable *Things → Settings → General →
-Enable Things URLs*.
+
+> **Prerequisite:** `edit`, `project edit`, and `import` payloads with
+> `operation: update` require the Things auth token. Enable it once via
+> *Things → Settings → General → Enable Things URLs*. Without it, writes fail
+> with `update: auth token is required — enable Things URLs in Things → Settings → General …`.
 
 | Flag | `edit` | `project edit` | Description |
 | --- | --- | --- | --- |

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -7,6 +7,7 @@ today, upcoming, projects, or areas on macOS.
 
 - Reads (`list`, `show`, `projects`, `areas`, `tags`, `search`) are safe — use freely.
 - Writes (`add`, `project add`, `edit`, `complete`, `cancel`, `log`, `open`) modify the user's real data. Confirm before destructive ones (`complete`, `cancel`, bulk `edit`).
+- `edit`, `project edit`, and `import` payloads with `operation: update` require *Things → Settings → General → Enable Things URLs*. The error to recognise: `update: auth token is required — enable Things URLs in Things → Settings → General …`.
 
 ## Output
 
@@ -83,6 +84,22 @@ Reschedule and tag an existing task:
 
 ```
 things edit "Ship release" --when tomorrow --add-tags "priority"
+things edit 3 --when monday              # weekday names work
+things edit 4 --when "next friday"
+```
+
+Reschedule several tasks at once (not transactional — partial failures stick):
+
+```
+things upcoming --area Work -j | jq -r '.[].uuid' | \
+  while read uuid; do things edit "$uuid" --when monday; done
+
+things import <<'JSON'
+[
+  {"type":"to-do","operation":"update","id":"<uuid-1>","attributes":{"when":"monday"}},
+  {"type":"to-do","operation":"update","id":"<uuid-2>","attributes":{"when":"tuesday"}}
+]
+JSON
 ```
 
 Pipe JSON to another tool:


### PR DESCRIPTION
Closes #78.

## Summary

- **SKILL.md Safety:** flag the *Enable Things URLs* prerequisite for `edit` / `project edit` / `import`-with-updates, and surface the exact error string so an agent can recognise it mid-flow.
- **SKILL.md Common flows:** add concrete weekday `--when` examples (`monday`, `next friday`) and a bulk-reschedule recipe — both a per-task `while` loop and a `things import` heredoc — with a one-line "not transactional, partial failures stick" caveat.
- **README:** hoist the auth-token prerequisite (previously buried mid-paragraph) into a `> **Prerequisite:**` callout under *Editing tasks and projects*.

## Test plan

- [x] \`make build\` — clean
- [x] \`make test -race\` — all packages pass
- [x] \`make lint\` — 0 issues
- [x] \`./things skill show {claude,codex,pi}\` — all render cleanly with the new content
- [ ] Spot-check the rendered README on the Jekyll site once merged