### PR TITLE
feat(list): filter by --on / --from / --to date ranges

### DIFF
--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -102,6 +102,9 @@ type ListCmd struct {
 	Project string   `help:"Filter by project name or UUID." short:"p"`
 	Area    string   `help:"Filter by area name or UUID." short:"a"`
 	Tag     string   `help:"Filter by tag name." short:"t"`
+	On      string   `help:"Only tasks scheduled on YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline. Mutually exclusive with --from/--to."`
+	From    string   `help:"Only tasks scheduled on or after YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline."`
+	To      string   `help:"Only tasks scheduled on or before YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline."`
 }
 
 func (c *ListCmd) Run(d *Deps) error {
@@ -125,16 +128,60 @@ func (c *ListCmd) Run(d *Deps) error {
 		}
 	}
 
-	tasks, err := database.ListTasks(view, db.TaskFilter{
+	filter := db.TaskFilter{
 		Project: project,
 		Area:    c.Area,
 		Tag:     c.Tag,
-	})
+	}
+	if err := applyDateFilters(&filter, view, c.On, c.From, c.To); err != nil {
+		return err
+	}
+
+	tasks, err := database.ListTasks(view, filter)
 	if err != nil {
 		return err
 	}
 	cacheTaskUUIDs(tasks)
 	return output.Print(d.Stdout, tasks, d.JSON)
+}
+
+func applyDateFilters(filter *db.TaskFilter, view, on, from, to string) error {
+	if on == "" && from == "" && to == "" {
+		return nil
+	}
+	if !db.DateFilterableView(view) {
+		return fmt.Errorf("--on/--from/--to are not supported on the %q view", view)
+	}
+	if on != "" && (from != "" || to != "") {
+		return fmt.Errorf("--on cannot be combined with --from/--to")
+	}
+
+	parse := func(flag, raw string) (*model.ThingsDate, error) {
+		if raw == "" {
+			return nil, nil
+		}
+		t, err := things.ParseListDate(flag, raw)
+		if err != nil {
+			return nil, err
+		}
+		d := model.ThingsDateFromTime(t)
+		return &d, nil
+	}
+
+	var err error
+	if filter.On, err = parse("on", on); err != nil {
+		return err
+	}
+	if filter.From, err = parse("from", from); err != nil {
+		return err
+	}
+	if filter.To, err = parse("to", to); err != nil {
+		return err
+	}
+	if filter.From != nil && filter.To != nil && *filter.From > *filter.To {
+		return fmt.Errorf("--from %s is after --to %s", filter.From, filter.To)
+	}
+	return nil
 }
 
 type ProjectsCmd struct {

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -164,6 +164,69 @@ func TestRunListWithTagFilter(t *testing.T) {
 	}
 }
 
+func TestRunListDateFilterEndToEnd(t *testing.T) {
+	database := seedFullDB(t)
+	today := time.Now().Format("2006-01-02")
+	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+
+	// task-1 in seedFullDB is scheduled for today — --on today should match,
+	// --on tomorrow should not. Assert via the last-list cache, which records
+	// exactly the uuids `list` returned.
+	if err := runWith(t, database, "list", "today", "--on", today); err != nil {
+		t.Fatalf("run list today --on today: %v", err)
+	}
+	got, err := cache.ReadLastList()
+	if err != nil {
+		t.Fatalf("ReadLastList: %v", err)
+	}
+	if len(got) != 1 || got[0] != "task-1" {
+		t.Errorf("--on today: got %v, want [task-1]", got)
+	}
+
+	if err := runWith(t, database, "list", "today", "--on", tomorrow); err != nil {
+		t.Fatalf("run list today --on tomorrow: %v", err)
+	}
+	got, err = cache.ReadLastList()
+	if err != nil {
+		t.Fatalf("ReadLastList: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("--on tomorrow: got %v, want empty", got)
+	}
+}
+
+func TestRunListDateFilterRejectsView(t *testing.T) {
+	database := seedFullDB(t)
+	err := runWith(t, database, "list", "inbox", "--on", "2026-05-09")
+	if err == nil || !strings.Contains(err.Error(), "not supported on the \"inbox\" view") {
+		t.Fatalf("expected view-rejection error, got: %v", err)
+	}
+}
+
+func TestRunListDateFilterRejectsOnWithRange(t *testing.T) {
+	database := seedFullDB(t)
+	err := runWith(t, database, "list", "upcoming", "--on", "2026-05-09", "--from", "2026-05-09")
+	if err == nil || !strings.Contains(err.Error(), "--on cannot be combined with --from/--to") {
+		t.Fatalf("expected mutex error, got: %v", err)
+	}
+}
+
+func TestRunListDateFilterRejectsBadDate(t *testing.T) {
+	database := seedFullDB(t)
+	err := runWith(t, database, "list", "upcoming", "--from", "tomorrow")
+	if err == nil || !strings.Contains(err.Error(), "invalid date") {
+		t.Fatalf("expected invalid-date error, got: %v", err)
+	}
+}
+
+func TestRunListDateFilterRejectsInvertedRange(t *testing.T) {
+	database := seedFullDB(t)
+	err := runWith(t, database, "list", "upcoming", "--from", "2026-05-10", "--to", "2026-05-09")
+	if err == nil || !strings.Contains(err.Error(), "is after --to") {
+		t.Fatalf("expected inverted-range error, got: %v", err)
+	}
+}
+
 func TestResolveTaskAmbiguousNonInteractive(t *testing.T) {
 	sqlDB := dbtest.NewSQL(t)
 	for _, uuid := range []string{"a1", "a2"} {

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -12,6 +12,27 @@ type TaskFilter struct {
 	Project string
 	Area    string
 	Tag     string
+
+	On   *model.ThingsDate
+	From *model.ThingsDate
+	To   *model.ThingsDate
+}
+
+// dateFilterableViews lists the views where --on/--from/--to make sense.
+// Excluded: inbox tasks have no startDate; trash is trashed-only; logbook
+// items have a stopDate but no meaningful startDate filter.
+var dateFilterableViews = map[string]bool{
+	"today":     true,
+	"upcoming":  true,
+	"anytime":   true,
+	"someday":   true,
+	"deadlines": true,
+	"project":   true,
+}
+
+// DateFilterableView reports whether --on/--from/--to apply to the view.
+func DateFilterableView(view string) bool {
+	return dateFilterableViews[view]
 }
 
 const baseTaskQuery = `
@@ -138,6 +159,27 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 	if opts.Tag != "" {
 		where += " AND t.uuid IN (SELECT tt2.tasks FROM TMTaskTag tt2 JOIN TMTag tg2 ON tt2.tags = tg2.uuid WHERE tg2.title LIKE ?)"
 		args = append(args, opts.Tag)
+	}
+
+	if opts.On != nil || opts.From != nil || opts.To != nil {
+		// ThingsDate is bit-encoded year<<16|month<<12|day<<7 — directly
+		// comparable across (year, month, day), so no decode is needed.
+		col := "t.startDate"
+		if view == "deadlines" {
+			col = "t.deadline"
+		}
+		if opts.On != nil {
+			where += " AND " + col + " = ?"
+			args = append(args, int64(*opts.On))
+		}
+		if opts.From != nil {
+			where += " AND " + col + " >= ?"
+			args = append(args, int64(*opts.From))
+		}
+		if opts.To != nil {
+			where += " AND " + col + " <= ?"
+			args = append(args, int64(*opts.To))
+		}
 	}
 
 	orderBy := viewOrderBy[view]

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -229,6 +229,86 @@ func TestListTasksTagFilter(t *testing.T) {
 	}
 }
 
+func TestListTasksDateFilters(t *testing.T) {
+	d := newTestDB(t)
+
+	mustExec(t, d, `INSERT INTO TMArea (uuid, title, visible, "index") VALUES ('a', 'Work', 1, 0)`)
+
+	d1 := int64(model.ThingsDateFromTime(time.Date(2026, 5, 9, 0, 0, 0, 0, time.Local)))
+	d2 := int64(model.ThingsDateFromTime(time.Date(2026, 5, 10, 0, 0, 0, 0, time.Local)))
+	d3 := int64(model.ThingsDateFromTime(time.Date(2026, 5, 11, 0, 0, 0, 0, time.Local)))
+
+	mustExec(t, d, `INSERT INTO TMTask (uuid, title, type, status, trashed, start, startBucket, startDate, area, "index") VALUES
+		('u-09', 'Sat', 0, 0, 0, 2, 0, ?, 'a', 1),
+		('u-10', 'Sun', 0, 0, 0, 2, 0, ?, 'a', 2),
+		('u-11', 'Mon', 0, 0, 0, 2, 0, ?, 'a', 3)`,
+		d1, d2, d3)
+
+	on09 := model.ThingsDate(d1)
+	on10 := model.ThingsDate(d2)
+
+	cases := []struct {
+		name   string
+		filter TaskFilter
+		want   []string
+	}{
+		{"on exact", TaskFilter{On: &on09}, []string{"u-09"}},
+		{"from inclusive", TaskFilter{From: &on10}, []string{"u-10", "u-11"}},
+		{"to inclusive", TaskFilter{To: &on10}, []string{"u-09", "u-10"}},
+		{"range weekend", TaskFilter{From: &on09, To: &on10}, []string{"u-09", "u-10"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := d.ListTasks("upcoming", tc.filter)
+			if err != nil {
+				t.Fatalf("ListTasks: %v", err)
+			}
+			if !sameSet(uuidsOf(got), tc.want) {
+				t.Errorf("got %v, want %v", uuidsOf(got), tc.want)
+			}
+		})
+	}
+}
+
+// On the deadlines view, --on/--from/--to filter against t.deadline rather
+// than t.startDate; verify we hit the right column.
+func TestListTasksDeadlinesDateFilters(t *testing.T) {
+	d := newTestDB(t)
+
+	d1 := int64(model.ThingsDateFromTime(time.Date(2026, 6, 1, 0, 0, 0, 0, time.Local)))
+	d2 := int64(model.ThingsDateFromTime(time.Date(2026, 6, 2, 0, 0, 0, 0, time.Local)))
+
+	mustExec(t, d, `INSERT INTO TMTask (uuid, title, type, status, trashed, deadline, "index") VALUES
+		('dl-1', 'A', 0, 0, 0, ?, 1),
+		('dl-2', 'B', 0, 0, 0, ?, 2)`,
+		d1, d2)
+
+	on := model.ThingsDate(d1)
+	got, err := d.ListTasks("deadlines", TaskFilter{On: &on})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if !sameSet(uuidsOf(got), []string{"dl-1"}) {
+		t.Errorf("deadlines --on: got %v", uuidsOf(got))
+	}
+}
+
+func TestDateFilterableView(t *testing.T) {
+	allowed := []string{"today", "upcoming", "anytime", "someday", "deadlines", "project"}
+	denied := []string{"inbox", "trash", "logbook", "bogus"}
+	for _, v := range allowed {
+		if !DateFilterableView(v) {
+			t.Errorf("%q: expected filterable", v)
+		}
+	}
+	for _, v := range denied {
+		if DateFilterableView(v) {
+			t.Errorf("%q: expected NOT filterable", v)
+		}
+	}
+}
+
 func TestTagGroupConcatDelimiter(t *testing.T) {
 	d := newTestDB(t)
 	seedTasks(t, d)

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -17,9 +17,12 @@ Human output is styled with colors and aligned columns. Color auto-disables when
 ## Core commands
 
 ```
-things list [view] [--project P] [--area A] [--tag T]
+things list [view] [--project P] [--area A] [--tag T] [--on D | --from D --to D]
     # views: today, inbox, upcoming, anytime, someday, logbook, trash, deadlines
     # shortcut: `things today`, `things inbox`, etc.
+    # --on / --from / --to take YYYY-MM-DD (or RFC3339). They filter startDate
+    # on most views and `deadline` on the `deadlines` view. Not supported on
+    # inbox/trash/logbook. --on is mutually exclusive with --from/--to.
 
 things show <task>              # task detail
 things projects [--area A] [--completed]

--- a/internal/things/dates.go
+++ b/internal/things/dates.go
@@ -43,6 +43,26 @@ func NormalizeWhen(s string) (string, error) {
 	return v, nil
 }
 
+// ParseListDate parses a list-filter date (--on/--from/--to). Accepts
+// YYYY-MM-DD or RFC3339 (reduced to its date portion). Returns midnight in
+// the local timezone — callers convert into whichever representation they
+// need (e.g. model.ThingsDateFromTime). The flag name is used in error
+// messages so the user knows which input was bad.
+func ParseListDate(flag, s string) (time.Time, error) {
+	v := strings.TrimSpace(s)
+	if v == "" {
+		return time.Time{}, fmt.Errorf("--%s: date is empty", flag)
+	}
+	if t, ok := parseISO8601(v); ok {
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.Local), nil
+	}
+	t, err := time.ParseInLocation("2006-01-02", v, time.Local)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("--%s: invalid date %q (expected YYYY-MM-DD)", flag, v)
+	}
+	return t, nil
+}
+
 // NormalizeDeadline validates and canonicalises a --deadline value. The URL
 // scheme accepts a date (YYYY-MM-DD) or English natural-language phrase.
 // RFC3339 inputs are reduced to their date component since deadlines have

--- a/internal/things/dates_test.go
+++ b/internal/things/dates_test.go
@@ -3,6 +3,7 @@ package things
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNormalizeWhen(t *testing.T) {
@@ -73,6 +74,63 @@ func TestNormalizeDeadline(t *testing.T) {
 		}
 		if got != c.want {
 			t.Errorf("NormalizeDeadline(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseListDate(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantYear int
+		wantMon  time.Month
+		wantDay  int
+	}{
+		{"2026-05-09", 2026, time.May, 9},
+		{"  2026-05-09  ", 2026, time.May, 9},
+		{"2026-03-10T14:30:00Z", 2026, time.March, 10},
+		{"2026-03-10T14:30:00+02:00", 2026, time.March, 10},
+	}
+	for _, c := range cases {
+		got, err := ParseListDate("on", c.in)
+		if err != nil {
+			t.Errorf("ParseListDate(%q): unexpected error: %v", c.in, err)
+			continue
+		}
+		if got.Year() != c.wantYear || got.Month() != c.wantMon || got.Day() != c.wantDay {
+			t.Errorf("ParseListDate(%q) = %v, want %d-%02d-%02d", c.in, got, c.wantYear, c.wantMon, c.wantDay)
+		}
+		// Always midnight local time.
+		if got.Hour() != 0 || got.Minute() != 0 || got.Second() != 0 {
+			t.Errorf("ParseListDate(%q): expected midnight, got %v", c.in, got)
+		}
+	}
+}
+
+func TestParseListDateRejects(t *testing.T) {
+	cases := []struct {
+		in       string
+		contains string
+	}{
+		{"", "is empty"},
+		{"   ", "is empty"},
+		{"today", "invalid date"},
+		{"tomorrow", "invalid date"},
+		{"next friday", "invalid date"},
+		{"2026/05/09", "invalid date"},
+		{"05-09-2026", "invalid date"},
+		{"not-a-date", "invalid date"},
+	}
+	for _, c := range cases {
+		_, err := ParseListDate("from", c.in)
+		if err == nil {
+			t.Errorf("ParseListDate(%q): expected error", c.in)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.contains) {
+			t.Errorf("ParseListDate(%q): error = %v, want substring %q", c.in, err, c.contains)
+		}
+		if !strings.Contains(err.Error(), "--from") {
+			t.Errorf("ParseListDate(%q): error %v should mention --from", c.in, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `--on YYYY-MM-DD`, `--from`, `--to` flags to `things list` (and view shortcuts like `things upcoming`).
- Filters apply to `t.startDate` for most views and to `t.deadline` on the `deadlines` view.
- Not supported on `inbox` / `trash` / `logbook`. `--on` is mutually exclusive with `--from`/`--to`. Inputs accept `YYYY-MM-DD` or RFC3339 (date portion); invalid input fails fast in the same style as `--when` / `--deadline`.

ThingsDate is bit-encoded (`year<<16 | month<<12 | day<<7`) and monotonic across calendar order, so the SQL filter compares the encoded `int64` directly — no decode round-trip.

Closes #77.

## Test plan

- [x] `go test -race ./...` (234 passing)
- [x] `golangci-lint run ./...` clean
- [x] DB-level: exact-match, inclusive `--from`, inclusive `--to`, range, deadlines-view-targets-deadline
- [x] CLI-level: end-to-end `--on today` returns the seeded task, `--on tomorrow` returns nothing; rejects on inbox view; rejects `--on` mixed with `--from`; rejects bad date strings; rejects inverted range
- [x] Updated `internal/skill/SKILL.md` per CLAUDE.md mandate