### PR TITLE
feat(release): publish Homebrew cask to ryanlewis/homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,7 +62,7 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Casks
     homepage: https://github.com/ryanlewis/things-cli
-    description: CLI for Things3 on macOS — read your Things3 database and create/edit tasks from the terminal.
+    description: Manage your Things3 to-dos from the terminal.
     url:
       verified: github.com/ryanlewis/things-cli/
     commit_author:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,3 +50,28 @@ release:
     {{ readFile (printf ".github/releases/%s.md" .Tag) }}
 
     ---
+
+homebrew_casks:
+  - name: things
+    binaries:
+      - things
+    repository:
+      owner: ryanlewis
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Casks
+    homepage: https://github.com/ryanlewis/things-cli
+    description: CLI for Things3 on macOS — read your Things3 database and create/edit tasks from the terminal.
+    url:
+      verified: github.com/ryanlewis/things-cli/
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "chore(brew): {{ .ProjectName }} {{ .Tag }}"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/things"]
+          end

--- a/README.md
+++ b/README.md
@@ -395,7 +395,13 @@ embedded in the binary — so a plain `things` upgrade refreshes it; re-run
 
 ## Install
 
-One-line install (downloads the latest release, verifies checksums,
+With Homebrew:
+
+```sh
+brew install ryanlewis/tap/things
+```
+
+Or one-line install (downloads the latest release, verifies checksums,
 installs to `/usr/local/bin`):
 
 ```sh

--- a/docs/_tabs/install.md
+++ b/docs/_tabs/install.md
@@ -4,8 +4,8 @@ icon: fas fa-download
 order: 1
 ---
 
-`things-cli` runs on macOS and ships as a single static Go binary. Three
-ways to install — pick whichever fits your workflow.
+`things-cli` runs on macOS and ships as a single static Go binary. Pick
+whichever install method fits your workflow.
 
 > **You'll need Things3.** This CLI talks to the
 > [Things3 app by Cultured Code](https://culturedcode.com/things/) —
@@ -14,6 +14,22 @@ ways to install — pick whichever fits your workflow.
 > to exist. `things-cli` is an independent third-party tool and is not
 > affiliated with Cultured Code.
 {: .prompt-info }
+
+## Homebrew
+
+```sh
+brew install ryanlewis/tap/things
+```
+
+Or, if you'd rather add the tap explicitly:
+
+```sh
+brew tap ryanlewis/tap
+brew install things
+```
+
+The cask is auto-published from each tagged release into
+[`ryanlewis/homebrew-tap`](https://github.com/ryanlewis/homebrew-tap).
 
 ## One-line install script
 


### PR DESCRIPTION
## Summary

- Wires up GoReleaser's `homebrew_casks:` block so each tagged release auto-publishes `Casks/things.rb` to [`ryanlewis/homebrew-tap`](https://github.com/ryanlewis/homebrew-tap)
- Users can install with `brew install ryanlewis/tap/things` — surfaced as the first install option in README and docs site
- Uses `homebrew_casks` rather than `brews` because GoReleaser deprecated `brews:` in v2.10 in favour of casks for distributing pre-compiled binaries (no warnings on `goreleaser check`)
- Includes a `postflight` xattr hook to strip `com.apple.quarantine` from the binary, since we don't codesign the release artifacts

Closes #14.

## Prerequisites already in place

- [x] `ryanlewis/homebrew-tap` repo created
- [x] `HOMEBREW_TAP_GITHUB_TOKEN` secret configured in this repo (fine-grained PAT with `Contents: Read and write` on the tap repo only, expires 2027-04-30)

## Test plan

- [x] `goreleaser check` passes with no deprecation warnings
- [x] `goreleaser release --snapshot --clean --skip=publish` generates a syntactically valid `dist/homebrew/Casks/things.rb` with per-arch URLs (amd64 + arm64), correct sha256s, and the postflight xattr block
- [ ] After merge: cut a `v0.3.0` tag and confirm the Release workflow pushes `Casks/things.rb` to `ryanlewis/homebrew-tap`
- [ ] On a clean Mac: `brew install ryanlewis/tap/things && things --version` works end-to-end