### PR TITLE
docs(release): add v0.3.0 release notes header

### DIFF
--- a/.github/releases/v0.3.0.md
+++ b/.github/releases/v0.3.0.md
@@ -1,0 +1,23 @@
+## `things-cli` v0.3.0 — Homebrew tap, date filters, polished output
+
+Install with `brew install ryanlewis/tap/things` and start slicing your lists by date — plus a fresh coat of [lipgloss](https://github.com/charmbracelet/lipgloss) styling on `list` and `show`.
+
+### Headline
+
+- **Homebrew cask** — `brew install ryanlewis/tap/things` (auto-published from each release into [`ryanlewis/homebrew-tap`](https://github.com/ryanlewis/homebrew-tap))
+- **Date-range list filters** — narrow any list with `--on`, `--from`, and `--to` (#81)
+- **Styled output** — `list` and `show` now render with [lipgloss](https://github.com/charmbracelet/lipgloss); JSON output (`-j`) is unaffected and remains script-stable
+
+### Fixes
+
+- `things today` keeps completed items visible until you `log` them, matching the Things app (#74)
+- `ThingsDate` marshals as `YYYY-MM-DD` in JSON output (was a packed integer) (#79)
+
+### Docs
+
+- Install page surfaces Homebrew as the recommended option
+- Skill docs cover bulk reschedule, the auth-token flow, and weekday `--when` parsing (#80)
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).


### PR DESCRIPTION
## Summary

Adds the release-notes header GoReleaser will prepend to the v0.3.0 GitHub Release body.

Required-by-tag: `.goreleaser.yaml` runs `readFile ".github/releases/<tag>.md"` at release time, so this file must exist at the tagged commit.

## Test plan

- [ ] Merge this PR
- [ ] `/release minor` then proceeds to tag `v0.3.0` and push, triggering the Release workflow