### PR TITLE
feat(release): zap things-cli cache on cask uninstall

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,3 +75,6 @@ homebrew_casks:
           if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/things"]
           end
+    zap:
+      trash:
+        - ~/Library/Caches/things-cli


### PR DESCRIPTION
## Summary

Adds a `zap:` stanza to the Homebrew cask so a full uninstall (`brew uninstall --zap things`) cleans up `~/Library/Caches/things-cli` — the last-list cache that backs `things complete 1`-style indices.

Standard Homebrew behaviour: zap is opt-in via `--zap` (or `brew zap things` separately), so plain `brew uninstall things` still leaves the cache alone. That's deliberate — uninstall + reinstall (or switching between brew and a local dev build that reads the same cache path) shouldn't blow away state.

## Generated cask diff

```ruby
   binary "things"

   postflight do
     # ...quarantine xattr removal...
   end

+  zap trash: [
+      "~/Library/Caches/things-cli",
+    ]
```

## Test plan

- [x] `goreleaser check` passes
- [x] `goreleaser release --snapshot --clean --skip=publish` generates a cask with the `zap trash: [...]` block
- [ ] After merge + the next release tag: `brew install ryanlewis/tap/things`, then `brew uninstall --zap things`, confirm `~/Library/Caches/things-cli` is moved to Trash