### PR TITLE
docs(release): add v0.3.1 release notes header

### DIFF
--- a/.github/releases/v0.3.1.md
+++ b/.github/releases/v0.3.1.md
@@ -1,0 +1,13 @@
+## `things-cli` v0.3.1 — clean uninstall
+
+Patch release: the Homebrew cask now ships a `zap` stanza so a full uninstall cleans up after itself.
+
+### Change
+
+- Cask `zap trash:` now lists `~/Library/Caches/things-cli` (the last-list cache that backs `things complete 1`-style indices), so `brew uninstall --zap things` leaves no orphan state behind (#86)
+
+Plain `brew uninstall things` still leaves the cache alone — zap only fires with `--zap` (or `brew zap things` separately), so a routine uninstall + reinstall keeps your indices intact.
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).


### PR DESCRIPTION
## Summary

Release-notes header for the v0.3.1 patch release. GoReleaser reads this file at tag time via `readFile ".github/releases/<tag>.md"`, so it must exist at the tagged commit.

Patch release covers a single change: cask `zap` stanza added in #86 so `brew uninstall --zap things` cleans up `~/Library/Caches/things-cli`.

## Test plan

- [ ] Merge this PR
- [ ] Tag `v0.3.1` and push, triggering the Release workflow
- [ ] Confirm cask republishes to `ryanlewis/homebrew-tap` with the new version