### PR TITLE
docs(skill): document things open flags and edit prepend/append

### DIFF
--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -33,12 +33,16 @@ things search <query>
 
 things add <title> [--notes --when --deadline --tags --checklist --project --heading --list]
 things project add <title> [--notes --when --deadline --tags --area --todos]
-things project edit <project> [--title --notes --when --deadline --tags --add-tags --area --area-id --complete --cancel --duplicate --reveal ...]
-things edit <task> [--title --notes --when --deadline --tags --add-tags --list --heading --complete --cancel --duplicate --reveal ...]
+things project edit <project> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --area --area-id --complete --cancel --duplicate --reveal]
+things edit <task> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --checklist --prepend-checklist --append-checklist --list --list-id --heading --heading-id --complete --cancel --duplicate --reveal]
 things complete <task>
 things cancel <task>
 things log                      # move Today → Logbook
-things open <ref|list>          # reveal task/project/area/tag/built-in list in the app
+things open [<ref>] [-p P | -a A | -t T | -q Q] [--filter T1,T2] [--background]
+    # ref: task/project UUID, numeric list index, title, or built-in list name
+    #      (today, inbox, upcoming, anytime, someday, logbook, trash, deadlines)
+    # exactly one of <ref> / -p / -a / -t / -q is required
+    # --filter narrows the opened list by tags; --background keeps focus elsewhere
 
 things import [--file F] [--reveal] < payload.json
     # batch create/update via the Things JSON URL scheme


### PR DESCRIPTION
## Summary
- Spell out `things open`'s flags (`-p`/`-a`/`-t`/`-q`/`--filter`/`--background`) — the bundled SKILL.md previously showed only `things open <ref|list>`, leaving every flag invisible to agents that read the skill.
- Replace the trailing `...` on `things edit` / `things project edit` with the actual flag list — adds `--prepend-notes`, `--append-notes`, `--checklist`, `--prepend-checklist`, `--append-checklist`, `--list-id`, `--heading-id` to edit and `--prepend-notes` / `--append-notes` to project edit.

The recent `--on / --from / --to` list filters (#81) were already documented in #80, so no change needed there.

## Test plan
- [x] \`make test\` passes
- [ ] After merge, \`things skill show\` reflects the new lines