### PR TITLE
docs(release): add v0.3.2 release notes header

### DIFF
--- a/.github/releases/v0.3.2.md
+++ b/.github/releases/v0.3.2.md
@@ -1,0 +1,13 @@
+## `things-cli` v0.3.2 — fuller bundled skill
+
+Patch release: the in-binary agent skill now spells out flags that were previously hidden behind `...` or missing entirely.
+
+### Change
+
+- `things skill show` (and the installed `SKILL.md`) now documents every flag on `things open` (`-p`/`-a`/`-t`/`-q`/`--filter`/`--background`), and lists `--prepend-notes`/`--append-notes`/`--checklist`/`--prepend-checklist`/`--append-checklist`/`--list-id`/`--heading-id` on `things edit` (and the project-edit equivalents) explicitly instead of trailing `...` (#89)
+
+No CLI behavior changes — only the bundled agent skill text. Reinstall it for your agent of choice (`things skill install claude`, `…codex`, `…pi`) to pick up the new content.
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).


### PR DESCRIPTION
## Summary
- Adds `.github/releases/v0.3.2.md`, the header GoReleaser prepends to the auto-generated changelog when the `v0.3.2` tag is pushed.

Patch release covers #89 (fuller bundled SKILL.md — `things open` flags + explicit edit/project-edit flag listing).

## Test plan
- [x] File matches the v0.3.1 / v0.3.0 format
- [ ] After merge, tag v0.3.2 and confirm the GoReleaser workflow picks the header up