### PR TITLE
feat(release): ship shell completions in the cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,6 +55,14 @@ homebrew_casks:
   - name: things
     binaries:
       - things
+    # Run `things completions <shell>` at cask install time to drop bash/zsh/fish
+    # completion scripts into the Homebrew prefix. `<shell>` is a positional arg
+    # (shell_parameter_format: arg) — matches the CLI added in #88 PR 1.
+    generate_completions_from_executable:
+      args: [completions]
+      base_name: things
+      shell_parameter_format: arg
+      shells: [bash, zsh, fish]
     repository:
       owner: ryanlewis
       name: homebrew-tap
@@ -69,8 +77,12 @@ homebrew_casks:
       name: goreleaserbot
       email: bot@goreleaser.com
     commit_msg_template: "chore(brew): {{ .ProjectName }} {{ .Tag }}"
+    # De-quarantine in preflight (before artifact install) rather than postflight,
+    # so the binary is runnable when generate_completions_from_executable invokes
+    # it during install — otherwise Gatekeeper blocks the unsigned binary and no
+    # completion files are written.
     hooks:
-      post:
+      pre:
         install: |
           if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/things"]

--- a/README.md
+++ b/README.md
@@ -355,11 +355,11 @@ goes stale as the command surface changes — `things <TAB>` completes
 subcommands and flag names, and a flag's values complete once you've typed it
 (`things list --color <TAB>` → `auto`, `always`, `never`).
 
-The Homebrew cask installs the binary but doesn't generate completions yet —
-that's a planned follow-up. Until it lands, and on every install path, load the
-script yourself. Completion shells out to `things` by name, so it works as long
-as `things` is on your `PATH` (the Homebrew, `go install`, and `make install`
-paths all put it there):
+The Homebrew cask generates these on install, so cask users get `things <TAB>`
+with no extra steps. On every other install path, load the script yourself.
+Completion shells out to `things` by name, so it works as long as `things` is on
+your `PATH` (the Homebrew, `go install`, and `make install` paths all put it
+there):
 
 ```sh
 # bash — add to ~/.bashrc (complete -C is a bash builtin; no extra package needed)

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -117,7 +117,7 @@ things --json list today | jq '.[] | .title'
 
 ## Shell completions
 
-`things completions <bash|zsh|fish>` prints a completion script for that shell. It delegates back to the binary (which must be on `PATH`), so it stays in sync with the CLI surface. The Homebrew cask installs the binary but doesn't generate completions yet (a planned follow-up); for now the user loads it with `source <(things completions zsh)` (bash/zsh) or `things completions fish | source`. Completion is flag/subcommand-name only — it never reads the Things database.
+`things completions <bash|zsh|fish>` prints a completion script for that shell. It delegates back to the binary (which must be on `PATH`), so it stays in sync with the CLI surface. The Homebrew cask generates these on install; on other install paths the user loads it with `source <(things completions zsh)` (bash/zsh) or `things completions fish | source`. Completion is flag/subcommand-name only — it never reads the Things database.
 
 ## Tips
 


### PR DESCRIPTION
PR 2 of #88 — the release plumbing. Builds on PR 1 (#94), which added the `things completions <shell>` command.

## What

Wire `generate_completions_from_executable` into the `homebrew_casks` block so `brew install` runs `things completions bash|zsh|fish` at install time and drops the scripts into the Homebrew prefix. No custom `executable:` — it defaults to the first binary (`things`), which is correct for our root-level archive layout.

```ruby
binary "things"
generate_completions_from_executable "things", "completions",
  base_name: "things",
  shell_parameter_format: :arg,
  shells: [:bash, :zsh, :fish]
```

## The non-obvious part: quarantine ordering

Completion generation **runs the binary during artifact install**, which is *before* `postflight`. Our binary is unsigned, so it's Gatekeeper-quarantined on download — that's exactly why the cask already removed the quarantine xattr. But that removal lived in **`postflight`**, i.e. *after* the completion run. Left as-is, `generate_completions_from_executable` would invoke a still-quarantined binary, Gatekeeper would block it, and **zero completion files would be written** — silently.

Fix: move the `xattr -dr com.apple.quarantine` hook from `postflight` → `preflight` (`hooks.post.install` → `hooks.pre.install`). Homebrew runs `preflight` before artifact install, so the binary is de-quarantined in time. It's strictly safe for runtime too — same removal on the same staged binary, just earlier.

## Docs

Flipped the README + `internal/skill/SKILL.md` wording from "doesn't generate completions yet" to "Homebrew generates these on install." (PR 1 had set the honest interim phrasing.)

## Verification

- [x] `goreleaser check` passes
- [x] `goreleaser release --snapshot --clean --skip=publish` emits `Casks/things.rb` containing the `generate_completions_from_executable` block **and** the `preflight` de-quarantine
- [x] `go test ./internal/skill/` passes (SKILL.md is embedded)
- [ ] **Post-tag (needs a real release):** `brew install ryanlewis/tap/things` (or `brew reinstall`) writes `bash`/`zsh`/`fish` completion files into the prefix
- [ ] **Post-tag:** open a fresh shell, `things <TAB>` shows subcommands

The last two require a published tag, so they're for after merge + `/release`. The quarantine-ordering fix is the thing to watch in that test — if completions still don't appear, the next lever is `no_quarantine` or confirming the sandbox can exec the de-quarantined binary.