### PR TITLE
fix(release): use positional shell arg for cask completions

### DIFF
--- a/.github/releases/v0.4.1.md
+++ b/.github/releases/v0.4.1.md
@@ -1,0 +1,22 @@
+## `things-cli` v0.4.1 — fix Homebrew completion install
+
+Patch release. v0.4.0 added shell completions, but the Homebrew cask passed the
+shell name as `--shell=bash` (Homebrew's `:arg` format) while `things
+completions` takes the shell as a positional argument. The mismatch made
+`brew install` print "Failed to generate … completions" warnings and write no
+completion files.
+
+### Fix
+
+- The cask now calls `things completions bash|zsh|fish` with the shell as a bare
+  positional argument (Homebrew's default when `shell_parameter_format` is
+  omitted), matching the CLI. `brew install` / `brew upgrade` now generates the
+  bash, zsh, and fish completion files as intended.
+
+If you installed v0.4.0 from Homebrew, run `brew update && brew reinstall
+ryanlewis/tap/things` to pick up working completions.
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and
+Intel (`darwin_amd64`).

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,12 +56,13 @@ homebrew_casks:
     binaries:
       - things
     # Run `things completions <shell>` at cask install time to drop bash/zsh/fish
-    # completion scripts into the Homebrew prefix. `<shell>` is a positional arg
-    # (shell_parameter_format: arg) — matches the CLI added in #88 PR 1.
+    # completion scripts into the Homebrew prefix. The shell name is passed as a
+    # bare positional arg (`things completions bash`) — that's Homebrew's default
+    # when shell_parameter_format is omitted. Do NOT set it to `arg`: Homebrew's
+    # :arg emits `--shell=bash`, which our positional CLI rejects.
     generate_completions_from_executable:
       args: [completions]
       base_name: things
-      shell_parameter_format: arg
       shells: [bash, zsh, fish]
     repository:
       owner: ryanlewis


### PR DESCRIPTION
Fixes the completion install broken in v0.4.0. Cuts **v0.4.1**.

## Bug

v0.4.0's cask used `shell_parameter_format: arg`, so Homebrew invoked `things completions --shell=bash`. But `things completions` takes the shell as a **positional** arg, so Kong rejected the unknown `--shell` flag (exit 80) and `brew install` wrote no completion files — with three "Failed to generate … completions" warnings.

(The preflight quarantine fix from #95 worked — the binary *executed*; exit 80 is our own arg-parse error, not a Gatekeeper block.)

## Fix

Drop `shell_parameter_format` so Homebrew uses its default: a bare positional arg, `things completions bash`. The GoReleaser docs claim `arg` means positional, but Homebrew's `:arg` actually emits `--shell=<name>`; bare positional is the no-format default.

Generated cask now reads:
```ruby
generate_completions_from_executable "things", "completions",
  base_name: "things",
  shells: [:bash, :zsh, :fish]
```

## Verification

- `goreleaser check` ✅; snapshot cask omits `shell_parameter_format` ✅
- Against the **installed v0.4.0 binary**: `things completions --shell=bash` → exit 80 (reproduces the failure); `things completions bash` → exit 0 emitting `complete -C things things`; all of bash/zsh/fish exit 0 positionally ✅

After v0.4.1 releases: `brew update && brew reinstall ryanlewis/tap/things` should write the completion files with no warnings.