### PR TITLE
fix(when): stop rejecting weekday names like "monday"

### DIFF
--- a/internal/things/dates.go
+++ b/internal/things/dates.go
@@ -9,8 +9,21 @@ import (
 
 var whenKeywords = []string{"today", "tomorrow", "evening", "anytime", "someday"}
 
+// weekdayWords are natural-language day names Things accepts verbatim. They are
+// allowlisted so the typo detector never mistakes them for a keyword — e.g.
+// "monday" is Levenshtein distance 2 from "today" and would otherwise be
+// rejected as a typo. Abbreviations are included for the same reason.
+var weekdayWords = []string{
+	"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+	"mon", "tue", "tues", "wed", "thu", "thur", "thurs", "fri", "sat", "sun",
+}
+
 func isWhenKeyword(s string) bool {
 	return slices.Contains(whenKeywords, s)
+}
+
+func isWeekdayWord(s string) bool {
+	return slices.Contains(weekdayWords, s)
 }
 
 // NormalizeWhen validates and canonicalises a --when value.
@@ -36,6 +49,9 @@ func NormalizeWhen(s string) (string, error) {
 	}
 	if t, ok := parseISO8601(v); ok {
 		return t.Format("2006-01-02") + "@" + t.Format("15:04"), nil
+	}
+	if isWeekdayWord(strings.ToLower(v)) {
+		return v, nil
 	}
 	if k, ok := nearKeyword(v); ok {
 		return "", fmt.Errorf("unrecognised --when value %q (did you mean %q? valid keywords: %s)", v, k, strings.Join(whenKeywords, ", "))

--- a/internal/things/dates_test.go
+++ b/internal/things/dates_test.go
@@ -25,6 +25,11 @@ func TestNormalizeWhen(t *testing.T) {
 		{"21:30", "21:30"},
 		{"next friday", "next friday"},
 		{"friday", "friday"},
+		{"monday", "monday"}, // dist 2 from "today" — must not be flagged as a typo
+		{"Monday", "Monday"}, // case preserved for NL pass-through
+		{"tuesday", "tuesday"},
+		{"sunday", "sunday"},
+		{"mon", "mon"},
 		{"tonight", "tonight"},
 		{"noon", "noon"},
 		{"2026-03-10T14:30:00Z", "2026-03-10@14:30"},


### PR DESCRIPTION
## The bug

`--when monday` was rejected client-side with *"did you mean today?"*. The `--when` handler runs a typo detector that flags any input within Levenshtein distance 2 of a keyword — and `levenshtein("monday", "today") == 2`, so `monday` was swallowed as a "typo" of `today`.

`monday` is the only weekday that collides (the rest are distance ≥3 from every keyword), which is why it slipped through. It also directly contradicts `SKILL.md`, which advertises:

```
things edit 3 --when monday              # weekday names work
```

## The fix

Add a weekday allowlist (`monday`…`sunday` plus `mon`/`tue`/`wed`/… abbreviations) checked **before** the typo detector in `NormalizeWhen`. Weekday names are valid natural-language values Things accepts verbatim, so they pass through with original casing.

- `internal/things/dates.go` — `weekdayWords` allowlist + `isWeekdayWord` guard
- `internal/things/dates_test.go` — cases for `monday`, `Monday`, `tuesday`, `sunday`, `mon`

## Verification

- `gofmt` clean
- `go test -race ./internal/things/` — 76 passed
- `go build ./cmd/things` — OK
- `golangci-lint run` — no issues
- Typo detector still rejects genuine typos (`tommorrow`, `evning`, …) — existing test unchanged and passing