### PR TITLE
docs(release): add v0.4.2 release notes header

### DIFF
--- a/.github/releases/v0.4.2.md
+++ b/.github/releases/v0.4.2.md
@@ -1,0 +1,20 @@
+## `things-cli` v0.4.2 — fix `--when` rejecting weekday names
+
+Patch release. `things add --when monday` was incorrectly rejected with
+"did you mean today?". The `--when` typo detector flags any value within
+Levenshtein distance 2 of a keyword, and `monday` is exactly distance 2
+from `today` — so it was mistaken for a typo despite being a valid
+natural-language date Things accepts.
+
+### Fix
+
+- Weekday names and their abbreviations (`monday`…`sunday`, plus `mon`,
+  `tue`, `wed`, `thu`, `fri`, `sat`, `sun` and common variants) now bypass
+  the typo detector and pass through to Things verbatim. Verified against
+  Things3 that each resolves to the correct upcoming scheduled date.
+- Genuine typos (`tommorrow`, `evning`, …) are still rejected as before.
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`)
+and Intel (`darwin_amd64`).


### PR DESCRIPTION
Release notes header for **v0.4.2**, required at the tagged commit by `.goreleaser.yaml` (`readFile`).

v0.4.2 is a patch release shipping the `--when` weekday fix from #103: `things add --when monday` was wrongly rejected as a typo of `today` (Levenshtein distance 2). Weekday names and abbreviations now pass through to Things, verified against Things3.

Merge → then tag `v0.4.2`.