### PR TITLE
fix(today): exclude completed tasks by default, add --include-completed

### DIFF
--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -106,9 +106,11 @@ type ListCmd struct {
 	Project string   `help:"Filter by project name or UUID." short:"p"`
 	Area    string   `help:"Filter by area name or UUID." short:"a"`
 	Tag     string   `help:"Filter by tag name." short:"t"`
-	On      string   `help:"Only tasks scheduled on YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline. Mutually exclusive with --from/--to."`
-	From    string   `help:"Only tasks scheduled on or after YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline."`
-	To      string   `help:"Only tasks scheduled on or before YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline."`
+
+	IncludeCompleted bool   `help:"On 'today', also show completed/cancelled items Things hasn't logged out of Today yet (UI-parity). No effect on other views."`
+	On               string `help:"Only tasks scheduled on YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline. Mutually exclusive with --from/--to."`
+	From             string `help:"Only tasks scheduled on or after YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline."`
+	To               string `help:"Only tasks scheduled on or before YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline."`
 }
 
 func (c *ListCmd) Run(d *Deps) error {
@@ -133,9 +135,10 @@ func (c *ListCmd) Run(d *Deps) error {
 	}
 
 	filter := db.TaskFilter{
-		Project: project,
-		Area:    c.Area,
-		Tag:     c.Tag,
+		Project:          project,
+		Area:             c.Area,
+		Tag:              c.Tag,
+		IncludeCompleted: c.IncludeCompleted,
 	}
 	if err := applyDateFilters(&filter, view, c.On, c.From, c.To); err != nil {
 		return err

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -107,7 +107,7 @@ type ListCmd struct {
 	Area    string   `help:"Filter by area name or UUID." short:"a"`
 	Tag     string   `help:"Filter by tag name." short:"t"`
 
-	IncludeCompleted bool   `help:"On 'today', also show completed/cancelled items Things hasn't logged out of Today yet (UI-parity). No effect on other views."`
+	IncludeCompleted bool   `help:"On the today view, also show completed/cancelled items Things hasn't logged out of Today yet (UI-parity). Not supported on other views."`
 	On               string `help:"Only tasks scheduled on YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline. Mutually exclusive with --from/--to."`
 	From             string `help:"Only tasks scheduled on or after YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline."`
 	To               string `help:"Only tasks scheduled on or before YYYY-MM-DD (or RFC3339). On 'deadlines', filters by deadline."`
@@ -132,6 +132,13 @@ func (c *ListCmd) Run(d *Deps) error {
 		if view == "today" {
 			view = "project"
 		}
+	}
+
+	// --include-completed only changes the today view. Reject it elsewhere
+	// (including when a trailing project name promotes today → project) rather
+	// than silently ignoring it, matching how --on/--from/--to reject views.
+	if c.IncludeCompleted && view != "today" {
+		return fmt.Errorf("--include-completed is only supported on the %q view", "today")
 	}
 
 	filter := db.TaskFilter{

--- a/cmd/things/main_test.go
+++ b/cmd/things/main_test.go
@@ -51,6 +51,18 @@ func TestKongListView(t *testing.T) {
 	}
 }
 
+func TestKongListIncludeCompleted(t *testing.T) {
+	cli, _ := parse(t, "list", "today", "--include-completed")
+	if !cli.List.IncludeCompleted {
+		t.Errorf("IncludeCompleted = %v, want true", cli.List.IncludeCompleted)
+	}
+
+	cli, _ = parse(t, "list", "today")
+	if cli.List.IncludeCompleted {
+		t.Errorf("IncludeCompleted defaulted to %v, want false", cli.List.IncludeCompleted)
+	}
+}
+
 func TestKongAddFlags(t *testing.T) {
 	cli, ctx := parse(t,
 		"add", "Buy milk",

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -203,6 +203,22 @@ func TestRunListDateFilterRejectsView(t *testing.T) {
 	}
 }
 
+func TestRunListIncludeCompletedRejectsView(t *testing.T) {
+	database := seedFullDB(t)
+
+	// Non-today view: the flag is rejected rather than silently ignored.
+	err := runWith(t, database, "list", "inbox", "--include-completed")
+	if err == nil || !strings.Contains(err.Error(), "only supported on the \"today\" view") {
+		t.Fatalf("inbox: expected view-rejection error, got: %v", err)
+	}
+
+	// Trailing project name promotes today → project, which also rejects.
+	err = runWith(t, database, "list", "today", "Chores", "--include-completed")
+	if err == nil || !strings.Contains(err.Error(), "only supported on the \"today\" view") {
+		t.Fatalf("promoted project: expected view-rejection error, got: %v", err)
+	}
+}
+
 func TestRunListDateFilterRejectsOnWithRange(t *testing.T) {
 	database := seedFullDB(t)
 	err := runWith(t, database, "list", "upcoming", "--on", "2026-05-09", "--from", "2026-05-09")

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -13,6 +13,11 @@ type TaskFilter struct {
 	Area    string
 	Tag     string
 
+	// IncludeCompleted keeps completed/cancelled items in the today view that
+	// Things has not yet logged out of Today (UI-parity). Without it, today
+	// returns only open tasks. Ignored by every other view.
+	IncludeCompleted bool
+
 	On   *model.ThingsDate
 	From *model.ThingsDate
 	To   *model.ThingsDate
@@ -111,8 +116,20 @@ func scanTask(row interface{ Scan(...any) error }) (model.Task, error) {
 	return t, nil
 }
 
+// todayWhere builds the today view's WHERE clause. By default only open tasks
+// are returned. With includeCompleted, completed/cancelled items are kept while
+// Things still shows them in Today — i.e. until "Log Completed Now" bumps
+// TMSettings.manualLogDate past their stopDate (UI-parity, see issue #106).
+func todayWhere(includeCompleted bool) string {
+	status := "t.status = 0"
+	if includeCompleted {
+		status = "(t.status = 0 OR (t.status IN (2, 3) AND t.stopDate > COALESCE((SELECT manualLogDate FROM TMSettings LIMIT 1), 0)))"
+	}
+	return "t.start = 1 AND t.startBucket IN (0, 1) AND t.startDate IS NOT NULL AND " + status + " AND t.trashed = 0 AND COALESCE(p.trashed, 0) = 0 AND t.type = 0"
+}
+
 var viewFilters = map[string]string{
-	"today":     "t.start = 1 AND t.startBucket IN (0, 1) AND t.startDate IS NOT NULL AND (t.status = 0 OR (t.status IN (2, 3) AND t.stopDate > COALESCE((SELECT manualLogDate FROM TMSettings LIMIT 1), 0))) AND t.trashed = 0 AND COALESCE(p.trashed, 0) = 0 AND t.type = 0",
+	"today":     todayWhere(false),
 	"inbox":     "t.start = 0 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
 	"upcoming":  "t.start = 2 AND t.startDate IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
 	"anytime":   "t.start = 1 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
@@ -145,6 +162,9 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 	where, ok := viewFilters[view]
 	if !ok {
 		return nil, fmt.Errorf("unknown view: %s", view)
+	}
+	if view == "today" && opts.IncludeCompleted {
+		where = todayWhere(true)
 	}
 
 	var args []any

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -132,8 +132,10 @@ func TestListTasksTodayCompletedItemFiltering(t *testing.T) {
 	d := newTestDB(t)
 	seedTasks(t, d)
 
+	// AddDate keeps the ThingsDate valid across month boundaries; raw bit
+	// subtraction would underflow the day field to 0 on the 1st.
 	today := int64(model.ThingsDateFromTime(time.Now()))
-	yesterday := today - (1 << 7) // ThingsDate encodes the day in bits 7..11
+	yesterday := int64(model.ThingsDateFromTime(time.Now().AddDate(0, 0, -1)))
 	stopToday := model.TimeToCoreData(time.Now().Add(-1 * time.Minute))
 	stopYesterday := model.TimeToCoreData(time.Now().Add(-25 * time.Hour))
 
@@ -151,6 +153,14 @@ func TestListTasksTodayCompletedItemFiltering(t *testing.T) {
 		VALUES ('t-done-yesterday', 'Done yesterday', 0, 3, 0, 1, 0, ?, ?, ?, 21)`,
 		today, yesterday, stopYesterday)
 
+	// Cancelled today, not yet logged — exercises the status=2 branch of
+	// `status IN (2, 3)`, which the completed (status=3) fixtures don't cover.
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, startDate,
+		 todayIndexReferenceDate, stopDate, "index")
+		VALUES ('t-cancelled-today', 'Cancelled today', 0, 2, 0, 1, 0, ?, ?, ?, 22)`,
+		today, today, stopToday)
+
 	// Default: completed/cancelled items are excluded outright.
 	got, err := d.ListTasks("today", TaskFilter{})
 	if err != nil {
@@ -160,12 +170,12 @@ func TestListTasksTodayCompletedItemFiltering(t *testing.T) {
 		t.Fatalf("default: expected {t-today, t-evening}, got %v", uuidsOf(got))
 	}
 
-	// IncludeCompleted (pre-log): unlogged completed items reappear.
+	// IncludeCompleted (pre-log): unlogged completed and cancelled items reappear.
 	got, err = d.ListTasks("today", TaskFilter{IncludeCompleted: true})
 	if err != nil {
 		t.Fatalf("ListTasks today --include-completed: %v", err)
 	}
-	want := []string{"t-today", "t-evening", "t-just-done", "t-done-yesterday"}
+	want := []string{"t-today", "t-evening", "t-just-done", "t-done-yesterday", "t-cancelled-today"}
 	if !sameSet(want, uuidsOf(got)) {
 		t.Fatalf("pre-log: expected %v, got %v", want, uuidsOf(got))
 	}

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -122,10 +122,12 @@ func TestListTasksViews(t *testing.T) {
 	}
 }
 
-// Completed items remain in Today until "Log Completed Now" bumps
-// TMSettings.manualLogDate past their stopDate. Items completed on previous
-// days are still visible (matching the Things app, which keeps them on screen
-// regardless of todayIndexReferenceDate until the user explicitly logs).
+// By default the today view returns only open tasks (issue #106) — completed
+// and cancelled items never appear, even before Things logs them out of Today.
+// With IncludeCompleted, those items remain visible until "Log Completed Now"
+// bumps TMSettings.manualLogDate past their stopDate, matching the Things app
+// (which keeps them on screen regardless of todayIndexReferenceDate until the
+// user explicitly logs).
 func TestListTasksTodayCompletedItemFiltering(t *testing.T) {
 	d := newTestDB(t)
 	seedTasks(t, d)
@@ -135,24 +137,33 @@ func TestListTasksTodayCompletedItemFiltering(t *testing.T) {
 	stopToday := model.TimeToCoreData(time.Now().Add(-1 * time.Minute))
 	stopYesterday := model.TimeToCoreData(time.Now().Add(-25 * time.Hour))
 
-	// Completed today, not yet logged → should appear.
+	// Completed today, not yet logged.
 	mustExec(t, d, `INSERT INTO TMTask
 		(uuid, title, type, status, trashed, start, startBucket, startDate,
 		 todayIndexReferenceDate, stopDate, "index")
 		VALUES ('t-just-done', 'Just done', 0, 3, 0, 1, 0, ?, ?, ?, 20)`,
 		today, today, stopToday)
 
-	// Completed yesterday but not yet logged → still appears in Today, even
-	// though todayIndexReferenceDate is stale. This matches the Things app.
+	// Completed yesterday but not yet logged.
 	mustExec(t, d, `INSERT INTO TMTask
 		(uuid, title, type, status, trashed, start, startBucket, startDate,
 		 todayIndexReferenceDate, stopDate, "index")
 		VALUES ('t-done-yesterday', 'Done yesterday', 0, 3, 0, 1, 0, ?, ?, ?, 21)`,
 		today, yesterday, stopYesterday)
 
+	// Default: completed/cancelled items are excluded outright.
 	got, err := d.ListTasks("today", TaskFilter{})
 	if err != nil {
 		t.Fatalf("ListTasks today: %v", err)
+	}
+	if !sameSet([]string{"t-today", "t-evening"}, uuidsOf(got)) {
+		t.Fatalf("default: expected {t-today, t-evening}, got %v", uuidsOf(got))
+	}
+
+	// IncludeCompleted (pre-log): unlogged completed items reappear.
+	got, err = d.ListTasks("today", TaskFilter{IncludeCompleted: true})
+	if err != nil {
+		t.Fatalf("ListTasks today --include-completed: %v", err)
 	}
 	want := []string{"t-today", "t-evening", "t-just-done", "t-done-yesterday"}
 	if !sameSet(want, uuidsOf(got)) {
@@ -163,9 +174,9 @@ func TestListTasksTodayCompletedItemFiltering(t *testing.T) {
 	future := model.TimeToCoreData(time.Now().Add(1 * time.Minute))
 	mustExec(t, d, `INSERT INTO TMSettings (uuid, manualLogDate) VALUES ('s', ?)`, future)
 
-	got, err = d.ListTasks("today", TaskFilter{})
+	got, err = d.ListTasks("today", TaskFilter{IncludeCompleted: true})
 	if err != nil {
-		t.Fatalf("ListTasks today: %v", err)
+		t.Fatalf("ListTasks today --include-completed: %v", err)
 	}
 	if !sameSet([]string{"t-today", "t-evening"}, uuidsOf(got)) {
 		t.Fatalf("post-log: expected {t-today, t-evening}, got %v", uuidsOf(got))

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -18,12 +18,14 @@ Human output is styled with colors and aligned columns. Color auto-disables when
 ## Core commands
 
 ```
-things list [view] [--project P] [--area A] [--tag T] [--on D | --from D --to D]
+things list [view] [--project P] [--area A] [--tag T] [--on D | --from D --to D] [--include-completed]
     # views: today, inbox, upcoming, anytime, someday, logbook, trash, deadlines
     # shortcut: `things today`, `things inbox`, etc.
     # --on / --from / --to take YYYY-MM-DD (or RFC3339). They filter startDate
     # on most views and `deadline` on the `deadlines` view. Not supported on
     # inbox/trash/logbook. --on is mutually exclusive with --from/--to.
+    # today shows only open tasks; --include-completed also lists completed/
+    # cancelled items Things hasn't logged out of Today yet (today only).
 
 things show <task>              # task detail
 things projects [--area A] [--completed]


### PR DESCRIPTION
## What

`things today` now returns **only open tasks** by default. Completed/cancelled items that Things keeps on screen until it logs them out of Today are available behind a new opt-in flag:

```
things today                      # open tasks only (new default)
things today --include-completed  # + completed/cancelled not yet logged (UI-parity)
```

Closes #106.

## Why

The `today` view kept completed/cancelled items visible until Things logged them out of Today (UI-parity, added in #74). For automation this over-reports: "in today" stopped meaning "still to do", and consumers had to filter on the bare `status: 3` themselves. Defaulting to open tasks is the least-surprising behaviour; `--include-completed` restores the UI-parity view for anyone who wants it.

## How

- `internal/db`: `TaskFilter.IncludeCompleted` + a `todayWhere(includeCompleted)` helper. Default `today` filters `status = 0`; with the flag it keeps `status IN (2,3)` items whose `stopDate` post-dates `manualLogDate` (the same logged-out signal as before).
- `cmd/things`: `--include-completed` flag. It only affects `today`, so it's **rejected with an error** on any other view (including when a trailing project name promotes `today → project`), matching how `--on/--from/--to` reject unsupported views — no silent no-ops.
- `internal/skill/SKILL.md`: documented the new default and flag.

## Tests

- DB: default excludes completed **and** cancelled; `--include-completed` surfaces unlogged completed + cancelled items pre-log, then drops them once `manualLogDate` advances.
- CLI: flag parses; rejected on non-today views and on the promoted-project path.

## Review

Ran `/code-review --fix` (xhigh). Applied: the non-today rejection, a `start=1` cancelled (`status=2`) fixture closing a coverage gap, and month-boundary-safe date arithmetic in the test helper.

Knowingly **not** changed (out of scope / pre-existing):
- `--on/--from/--to` filter `--include-completed` items by `startDate`, not completion date — consistent date-filter semantics across all views.
- `TMSettings LIMIT 1` (no `ORDER BY`) and the `NULL` `stopDate` three-valued-logic drop are carried over verbatim from the prior inline clause; not introduced here.
