### PR TITLE
docs(release): add v0.5.0 release notes header

### DIFF
--- a/.github/releases/v0.5.0.md
+++ b/.github/releases/v0.5.0.md
@@ -1,0 +1,29 @@
+## `things-cli` v0.5.0 — clearer JSON status, leaner `today`
+
+Minor release. Two behaviour changes worth a look before you upgrade any
+automation, plus dependency maintenance.
+
+### Behaviour changes
+
+- **JSON `status` is now a string.** `Task`, `Project`, and `ChecklistItem`
+  `status` fields render as `"open"` / `"cancelled"` / `"completed"` in JSON
+  instead of the raw Things integers (`0` / `2` / `3`). The bare ints were an
+  implementation detail that read like a rank. Plain-text output is unchanged.
+  The decoder still accepts both the string name and the legacy integer, and
+  any unrecognised code round-trips as its number — but consumers that parse
+  our JSON `status` as a number will need to read it as a string.
+  (#107, closes #105)
+- **`things today` excludes completed tasks by default.** It now returns only
+  open tasks; completed/cancelled items Things still shows in Today are
+  available behind a new `--include-completed` flag (UI-parity). For
+  automation, "in today" now means "still to do". (#109, closes #106)
+
+### Maintenance
+
+- Bumped `lipgloss`, `golang.org/x/term`, `golang.org/x/sys`, and
+  `modernc.org/sqlite`; `actions/checkout` → v7 in CI. (#100, #108)
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and
+Intel (`darwin_amd64`).


### PR DESCRIPTION
Release-notes header for the upcoming `v0.5.0` tag (required at the tagged commit by `.goreleaser.yaml`).

Covers the two behaviour changes in this release:
- JSON `status` now emits a string instead of the raw int (#107, closes #105)
- `things today` excludes completed by default; `--include-completed` restores UI-parity (#109, closes #106)

Plus dependency maintenance (#100, #108).

Part of cutting v0.5.0 via `/release minor`.