### PR TITLE
chore: adopt the shared Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
-    "group:allNonMajor"
+    "github>ryanlewis/renovate-config",
+    ":preserveSemverRanges"
   ],
-  "labels": ["dependencies"],
-  "minimumReleaseAge": "5 days",
-  "vulnerabilityAlerts": {
-    "minimumReleaseAge": "0 days"
-  },
   "packageRules": [
     {
+      "description": "Pin Ruby to 3.x while jekyll-theme-chirpy 7.x requires Ruby ~> 3.1",
       "matchPackageNames": ["ruby"],
-      "allowedVersions": "<4",
-      "description": "Pin Ruby to 3.x while jekyll-theme-chirpy 7.x requires Ruby ~> 3.1"
+      "allowedVersions": "<4"
     }
   ]
 }


### PR DESCRIPTION
Same migration as ryanlewis/rlew.io#35 and ryanlewis/shout-sh#9, config-only.

## What changes

- **`osvVulnerabilityAlerts: true`** — the missing feed; alerts were already on here, and the old config already had the correct zero-cooldown `vulnerabilityAlerts` block that could never fire (the shout-sh shape)
- Cooldown stays 5 days; grouping/labels subsumed by the preset (`config:best-practices` ⊂ preset's extends)
- Open renovate PR #118 (non-major group) will re-render under the preset's schedule

## What's preserved

- **`":preserveSemverRanges"`** — this repo is consumed by others (`go install github.com/ryanlewis/things-cli/cmd/things@latest`, `brew install ryanlewis/tap/things`). For go.mod it's technically a no-op, but it also stops the preset pinning the docs site's `Gemfile` ranges (`jekyll-theme-chirpy ~> 7.2`, lockfile-less) to exact versions
- **The Ruby `<4` guard** — jekyll-theme-chirpy 7.x requires Ruby ~> 3.1, and Renovate has offered Ruby 4 before (#66)

## No `.npmrc` here

CI is pure Go (`ci.yml`: setup-go, build, test -race); docs build with bundler. No npm anywhere.

https://claude.ai/code/session_01KpxDfrqPwQAYb2RT6mi1qW