### PR TITLE
chore(ci): harden-runner egress audit on the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,14 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+      # Egress monitoring: this job holds the tap token, which can push
+      # formulae. Audit mode records every outbound connection per step
+      # (report linked from the run); flip to egress-policy: block with an
+      # allowed-endpoints list once a few releases have mapped the baseline.
+      - uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0


### PR DESCRIPTION
Adds `step-security/harden-runner` (SHA-pinned, v2.20.1) in **audit mode** as the first step of the goreleaser job — the one holding `HOMEBREW_TAP_GITHUB_TOKEN`, the estate's highest-value CI secret (formula push = code execution on anyone who `brew install`s).

Audit mode observes only: every outbound connection each step makes gets recorded, with the report linked from the run. Zero build risk. After a few releases have mapped the baseline endpoints, the follow-up is `egress-policy: block` + `allowed-endpoints`, at which point a compromised dependency trying to phone home gets its connection refused rather than discovered in a postmortem.

Scope note: public repos only (StepSecurity insights are free here); lobster-splash stays out deliberately.