### PR TITLE
ci(security): hardening — provenance, scanning, workflow lockdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,28 @@ jobs:
       - name: Coverage summary
         run: go tool cover -func=coverage.out
 
+      # Exit-code gate: a reachable vulnerability fails this job and blocks
+      # the merge. The govulncheck-sarif job below is the same scan for the
+      # Security tab — SARIF mode never fails the build, hence both.
       - name: govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  govulncheck-sarif:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
+        with:
+          go-version-file: go.mod
+          output-format: sarif
+          output-file: govulncheck.sarif
+
+      - uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: govulncheck.sarif
+          category: govulncheck
 
   dependency-review:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    # Weekly govulncheck run so new advisories surface without waiting for a push.
+    - cron: "17 6 * * 1"
 
 permissions:
   contents: read
@@ -13,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -32,3 +37,16 @@ jobs:
 
       - name: Coverage summary
         run: go tool cover -func=coverage.out
+
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -31,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
@@ -44,9 +44,10 @@ jobs:
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Build site
-        run: bundle exec jekyll build -d "_site${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build -d "_site${BASE_PATH}"
         env:
           JEKYLL_ENV: production
+          BASE_PATH: ${{ steps.pages.outputs.base_path }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
@@ -59,6 +60,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,16 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    # Protected environment restricted to v* tags — release secrets live there,
+    # so they are never exposed to workflow runs on other refs.
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       # Egress monitoring: this job holds the tap token, which can push
       # formulae. Audit mode records every outbound connection per step
@@ -23,11 +27,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-          cache: true
+          # No cache in the release build — a poisoned cache entry written from
+          # another ref would flow straight into published artifacts.
+          cache: false
 
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
@@ -37,3 +44,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/checksums.txt

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported versions
+
+Only the [latest release](https://github.com/ryanlewis/things-cli/releases/latest) is supported with security fixes.
+
+## Reporting a vulnerability
+
+Please report vulnerabilities privately via [GitHub Security Advisories](https://github.com/ryanlewis/things-cli/security/advisories/new) — do not open a public issue. You should get a response within a week.
+
+## Verifying releases
+
+Release artifacts are checksummed (`checksums.txt`, verified automatically by `install.sh`) and carry [build provenance attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations):
+
+```sh
+gh attestation verify things_<version>_darwin_arm64.tar.gz -R ryanlewis/things-cli
+```


### PR DESCRIPTION
Implements the free tier of the security hardening checklist. Rebased over #114–#121, which landed some of it in parallel (digest updates, read-only default token, harden-runner egress audit).

## Workflow changes
- **Provenance attestation**: release tarballs + `checksums.txt` now get build provenance via `actions/attest-build-provenance`; verify with `gh attestation verify <tarball> -R ryanlewis/things-cli`
- **Release environment**: goreleaser job runs in the `release` environment (tag-restricted via deployment branch policy) so release secrets are never exposed to non-tag runs
- **govulncheck**, twice by design:
  - exit-code step in `check` — fails CI and blocks merges on reachable vulnerabilities
  - `govulncheck-sarif` job — same scan uploaded to the Security tab as code-scanning alerts (SARIF mode never fails the build, hence both); weekly `schedule:` cron keeps alerts fresh between pushes
- **dependency-review** job on PRs
- **zizmor findings fixed**: `persist-credentials: false` everywhere, job-level permissions in pages/release, no Go cache in the release build, env-var indirection for the Jekyll base_path

## Also
- `SECURITY.md` — private reporting via GitHub advisories + release verification docs

## Applied via API alongside this PR (already live)
- `protect-main` branch ruleset: PR + green `check` required, no force-push/deletion
- `protect-release-tags` tag ruleset on `v*` (admin bypass for `/release`)
- Tag-restricted `release` environment, private vulnerability reporting, CodeQL default setup, required SHA pinning for actions

## Manual follow-ups (owner only)
- Move `HOMEBREW_TAP_GITHUB_TOKEN` into the `release` environment, delete the repo-level copy
- Confirm the tap PAT is fine-grained (homebrew-tap, Contents-only, expiry)
- On next release: verify the tag-ruleset admin bypass and run `gh attestation verify` on a published artifact