### PR TITLE
feat(install): verify build provenance via gh attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,15 @@ curl -fsSL https://raw.githubusercontent.com/ryanlewis/things-cli/main/install.s
   | INSTALL_DIR="$HOME/bin" VERSION=v0.1.0 sh
 ```
 
+When the [GitHub CLI](https://cli.github.com) is installed and logged in, the
+installer also verifies [build provenance](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) —
+cryptographic proof that the tarball was built by this repository's release
+workflow. You can check any release artifact yourself:
+
+```sh
+gh attestation verify things_<version>_darwin_arm64.tar.gz -R ryanlewis/things-cli
+```
+
 Or download a prebuilt binary manually from the
 [latest release](https://github.com/ryanlewis/things-cli/releases/latest)
 (`darwin_arm64` for Apple Silicon, `darwin_amd64` for Intel):

--- a/install.sh
+++ b/install.sh
@@ -60,6 +60,30 @@ EXPECTED=$(awk -v f="$TARBALL" '$2 == f {print $1}' "$TMP/checksums.txt")
 ACTUAL=$(shasum -a 256 "$TMP/$TARBALL" | awk '{print $1}')
 [ "$EXPECTED" = "$ACTUAL" ] || err "checksum mismatch (expected $EXPECTED, got $ACTUAL)"
 
+# Verify build provenance when the GitHub CLI is available: proves the tarball
+# was built by this repo's release workflow, not just that it downloaded
+# intact. Skipped (with a note) when gh is missing or logged out, since the
+# checksum has already passed. Releases before v0.5.1 predate attestations, so
+# "no attestations found" warns rather than fails. Opt out with SKIP_ATTESTATION=1.
+if [ -n "${SKIP_ATTESTATION:-}" ]; then
+	printf 'Note: provenance verification skipped (SKIP_ATTESTATION set).\n'
+elif command -v gh >/dev/null 2>&1; then
+	printf 'Verifying build provenance...\n'
+	if ATTEST_OUT=$(gh attestation verify "$TMP/$TARBALL" --repo "$REPO" 2>&1); then
+		printf 'Provenance verified: built by the %s release workflow.\n' "$REPO"
+	elif ! gh auth status >/dev/null 2>&1; then
+		printf 'Note: skipping provenance check (gh is not logged in).\n'
+	elif printf '%s' "$ATTEST_OUT" | grep -Eqi 'no attestations found|HTTP 404.*attestations'; then
+		printf 'Note: no provenance attestation for %s (releases before v0.5.1 predate attestations).\n' "$VERSION"
+	else
+		err "build provenance verification FAILED for $TARBALL — refusing to install.
+This artifact does not verify as built by the ${REPO} release workflow.
+(To bypass at your own risk: SKIP_ATTESTATION=1)"
+	fi
+else
+	printf 'Note: install gh (https://cli.github.com) to enable build provenance verification.\n'
+fi
+
 tar -xzf "$TMP/$TARBALL" -C "$TMP"
 [ -f "$TMP/$BIN" ] || err "archive did not contain expected binary: $BIN"
 


### PR DESCRIPTION
Closes the loop on the attestations shipped in #122 — the installer now consumes them.

- `install.sh` runs `gh attestation verify` on the downloaded tarball when `gh` is available and logged in
- **Failed verification is fatal** (refuses to install; `SKIP_ATTESTATION=1` to bypass)
- Missing attestation (releases ≤ v0.5.0, which predate #122) warns and continues
- gh absent or logged out: notes and continues — checksum verification has already passed by then
- README documents the automatic check and the manual `gh attestation verify` command

Tested against the live v0.5.0 release: warn-and-install path, skip path, and shellcheck-clean. The fatal path will be exercised for real once v0.5.1 ships with attestations.