### PR TITLE
fix(cancel): route projects through project-capable AppleScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $ things
 | Command | Description |
 | --- | --- |
 | `things show <task>` | Show a task's detail (with checklist) |
-| `things projects [--area NAME] [--completed]` | List projects |
+| `things projects [-a NAME] [--completed]` | List projects |
 | `things areas` | List areas |
 | `things tags` | List tags |
 | `things search <query>` | Full-text search across titles and notes |
@@ -245,7 +245,7 @@ things project edit "Launch" --append-notes "Beta cut on Friday"
 | Command | Description |
 | --- | --- |
 | `things complete <task>` | Mark a task or project as completed (project completion is confirmed interactively) |
-| `things cancel <task>` | Cancel a task |
+| `things cancel <task>` | Cancel a task or project (project cancellation is confirmed interactively) |
 | `things log` | Move today's done/cancelled items to the Logbook (Items → Log Completed) |
 
 `log` is the housekeeping action; `logbook` (above) is the *view* of

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -43,8 +43,8 @@ type CLI struct {
 	Add      AddCmd      `cmd:"" help:"Create a new task."`
 	Project  ProjectCmd  `cmd:"" help:"Manage projects."`
 	Edit     EditCmd     `cmd:"" help:"Edit a task via the Things URL scheme."`
-	Complete CompleteCmd `cmd:"" help:"Mark a task as completed."`
-	Cancel   CancelCmd   `cmd:"" help:"Cancel a task."`
+	Complete CompleteCmd `cmd:"" help:"Mark a task or project as completed."`
+	Cancel   CancelCmd   `cmd:"" help:"Cancel a task or project."`
 	Search   SearchCmd   `cmd:"" help:"Search tasks by title or notes."`
 	Log      LogCmd      `cmd:"" help:"Move completed and cancelled items from Today to the Logbook (Items → Log Completed)."`
 	Open     OpenCmd     `cmd:"" help:"Reveal a task, project, area, tag, or built-in list in Things3."`
@@ -199,7 +199,7 @@ func applyDateFilters(filter *db.TaskFilter, view, on, from, to string) error {
 }
 
 type ProjectsCmd struct {
-	Area      string `help:"Filter by area name or UUID."`
+	Area      string `help:"Filter by area name or UUID." short:"a"`
 	Completed bool   `help:"Include completed projects." default:"false"`
 }
 
@@ -244,7 +244,7 @@ func (c *TagsCmd) Run(d *Deps) error {
 }
 
 type ShowCmd struct {
-	Task string `arg:"" required:"" help:"Task title or UUID."`
+	Task string `arg:"" required:"" help:"Task title, UUID, or numeric index from last list."`
 }
 
 func (c *ShowCmd) Run(d *Deps) error {
@@ -444,7 +444,7 @@ func (c *EditCmd) Run(d *Deps) error {
 }
 
 type CompleteCmd struct {
-	Task string `arg:"" required:"" help:"Task title or UUID."`
+	Task string `arg:"" required:"" help:"Task title, UUID, or numeric index from last list."`
 }
 
 func (c *CompleteCmd) Run(d *Deps) error {
@@ -466,7 +466,7 @@ func (c *CompleteCmd) Run(d *Deps) error {
 }
 
 type CancelCmd struct {
-	Task string `arg:"" required:"" help:"Task title or UUID."`
+	Task string `arg:"" required:"" help:"Task title, UUID, or numeric index from last list."`
 }
 
 func (c *CancelCmd) Run(d *Deps) error {
@@ -477,6 +477,12 @@ func (c *CancelCmd) Run(d *Deps) error {
 	task, err := resolveTask(c.Task, database)
 	if err != nil {
 		return err
+	}
+	if task.Type == model.TypeProject {
+		if !confirmAction(fmt.Sprintf("Cancel project %q? This will also cancel all its tasks.", task.Title)) {
+			return fmt.Errorf("cancelled")
+		}
+		return things.CancelProject(task.UUID)
 	}
 	return things.CancelTask(task.UUID)
 }

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -330,6 +330,26 @@ func TestConfirmActionNonInteractive(t *testing.T) {
 	}
 }
 
+// Cancelling a project must route through the project branch (confirmation
+// prompt + CancelProject), not the task AppleScript path — which can't
+// address projects and fails with a raw osascript error. Non-interactively
+// the confirmation declines, proving the branch was taken.
+func TestRunCancelProjectRequiresConfirmation(t *testing.T) {
+	database := seedFullDB(t)
+	err := runWith(t, database, "cancel", "Chores")
+	if err == nil || !strings.Contains(err.Error(), "cancelled") {
+		t.Fatalf("expected confirmation-declined error, got: %v", err)
+	}
+}
+
+func TestRunCompleteProjectRequiresConfirmation(t *testing.T) {
+	database := seedFullDB(t)
+	err := runWith(t, database, "complete", "Chores")
+	if err == nil || !strings.Contains(err.Error(), "cancelled") {
+		t.Fatalf("expected confirmation-declined error, got: %v", err)
+	}
+}
+
 func TestIsInteractiveStdinPipe(t *testing.T) {
 	// In `go test`, stdin is typically not a TTY. Just call it for coverage;
 	// don't assert on the result since test runners vary.

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -30,7 +30,7 @@ things list [view] [--project P] [--area A] [--tag T] [--on D | --from D --to D]
     # cancelled items Things hasn't logged out of Today yet (today only).
 
 things show <task>              # task detail
-things projects [--area A] [--completed]
+things projects [-a|--area A] [--completed]
 things areas
 things tags
 things search <query>
@@ -39,8 +39,8 @@ things add <title> [--notes --when --deadline --tags --checklist --project --hea
 things project add <title> [--notes --when --deadline --tags --area --todos]
 things project edit <project> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --area --area-id --complete --cancel --duplicate --reveal]
 things edit <task> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --checklist --prepend-checklist --append-checklist --list --list-id --heading --heading-id --complete --cancel --duplicate --reveal]
-things complete <task>
-things cancel <task>
+things complete <task>          # task or project; project completion asks to confirm
+things cancel <task>            # task or project; project cancellation asks to confirm
 things log                      # move Today → Logbook
 things open [<ref>] [-p P | -a A | -t T | -q Q] [--filter T1,T2] [--background]
     # ref: task/project UUID, numeric list index, title, or built-in list name

--- a/internal/things/applescript.go
+++ b/internal/things/applescript.go
@@ -41,3 +41,10 @@ set theToDo to to do id "%s"
 set status of theToDo to canceled
 end tell`, uuid), "cancelling task")
 }
+
+func CancelProject(uuid string) error {
+	return runAppleScript(fmt.Sprintf(`tell application "Things3"
+set theProject to project id "%s"
+set status of theProject to canceled
+end tell`, uuid), "cancelling project")
+}

--- a/internal/things/applescript_test.go
+++ b/internal/things/applescript_test.go
@@ -80,6 +80,22 @@ func TestCancelTaskScript(t *testing.T) {
 	}
 }
 
+func TestCancelProjectScript(t *testing.T) {
+	script := applescriptStub(t, "")
+
+	if err := CancelProject("PRJ-2"); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`project id "PRJ-2"`,
+		`set status of theProject to canceled`,
+	} {
+		if !strings.Contains(*script, want) {
+			t.Errorf("script missing %q:\n%s", want, *script)
+		}
+	}
+}
+
 func TestLogCompletedScript(t *testing.T) {
 	script := applescriptStub(t, "")
 


### PR DESCRIPTION
Second of the v0.5.1 scout findings.

`things cancel <project>` resolved the reference then unconditionally called `CancelTask`, whose AppleScript addresses `to do id "<uuid>"` — which cannot name a project — so cancelling a project died with a raw osascript error. `complete` has had the proper project branch (via `project id`) all along; `cancel` never got one.

- New `things.CancelProject`, mirroring `CompleteProject`
- `CancelCmd` now branches on `model.TypeProject` with the same interactive confirmation `complete` uses (cancelling cascades to the project's tasks)
- Tests: AppleScript script-shape test + cmd-layer tests proving both project branches route through confirmation
- SKILL.md + README updated (cancel works on projects; confirmation noted)

Ride-alongs:
- `show`/`complete`/`cancel` help now documents the numeric-index reference form (`resolveTask` has always accepted it; only `edit` said so)
- `things projects` gains the `-a` short flag for `--area`, matching `list`/`open`