### PR TITLE
docs(release): add v0.5.1 release notes header

### DIFF
--- a/.github/releases/v0.5.1.md
+++ b/.github/releases/v0.5.1.md
@@ -1,0 +1,44 @@
+## `things-cli` v0.5.1 — cancel projects, honest empty JSON
+
+Patch release: two bug fixes with a supply-chain hardening pass riding
+underneath.
+
+### Fixes
+
+- **`things cancel` now works on projects.** It previously routed every
+  reference through the task-only AppleScript path, so cancelling a project
+  failed with a raw osascript error. Projects now cancel properly, behind the
+  same interactive confirmation `complete` uses — cancelling a project
+  cascades to its tasks. (#125)
+- **Empty `--json` results emit `[]`, not `null`.** All list-shaped commands
+  (`list`, `search`, `projects`, `areas`, `tags`) returned `null` for an empty
+  result, which breaks `jq '.[]'` pipelines — including the ones documented in
+  the bundled agent skill. (#124)
+- **Date filters on `someday` are rejected instead of silently matching
+  nothing.** Someday items have no start date, so `--on`/`--from`/`--to`
+  could never match; the CLI now says so instead of returning empty output,
+  and the README no longer advertises the impossible combination. (#124)
+
+### Small improvements
+
+- `show`, `complete`, and `cancel` help text now documents the numeric-index
+  reference form (`things list today; things complete 3`) — it always worked,
+  but only `edit` admitted it. (#125)
+- `things projects` gains the `-a` short flag for `--area`, matching `list`
+  and `open`. (#125)
+
+### Supply chain
+
+- Release artifacts now carry [build provenance attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations).
+  `install.sh` verifies them automatically when the GitHub CLI is present
+  (and refuses to install on a failed verification); check any artifact
+  yourself with
+  `gh attestation verify things_<version>_darwin_arm64.tar.gz -R ryanlewis/things-cli`.
+  (#122, #123)
+- CI hardening: govulncheck (gating + weekly Security-tab scan), CodeQL,
+  dependency review, and a locked-down release pipeline. (#122)
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and
+Intel (`darwin_amd64`).


### PR DESCRIPTION
Release notes for v0.5.1. Merge after #123/#124/#125 — goreleaser reads this file at tag time (`readFile .github/releases/v0.5.1.md`), so it must be on main before the tag is pushed.