### PR TITLE
docs(release): add v0.5.2 release notes header

### DIFF
--- a/.github/releases/v0.5.2.md
+++ b/.github/releases/v0.5.2.md
@@ -1,0 +1,22 @@
+## `things-cli` v0.5.2 — timestamps back from 2057
+
+Patch release: one bug fix.
+
+### Fixes
+
+- **`creationDate` and `stopDate` are no longer 31 years in the future.**
+  Things stores its absolute timestamps (task creation, task and checklist
+  completion) as Unix-epoch seconds, but they were decoded against Apple's
+  Core Data reference date (2001-01-01) — so a task created on
+  2026-08-09 reported `"creationDate": "2057-08-09T…"` in `--json` output.
+  Anything sorting or filtering on those fields downstream would misbehave.
+  Scheduling fields (`startDate`, `deadline`) use a different encoding and
+  were always correct. (#127)
+
+No CLI surface changes — if you parse `creationDate`/`stopDate` from
+`--json` output, the values are simply right now.
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and
+Intel (`darwin_amd64`).


### PR DESCRIPTION
Release header for v0.5.2 — required at the tagged commit by .goreleaser.yaml (readFile). Content approved in-session.