### PR TITLE
docs(release): add v0.5.3 release notes header

### DIFF
--- a/.github/releases/v0.5.3.md
+++ b/.github/releases/v0.5.3.md
@@ -1,0 +1,24 @@
+## `things-cli` v0.5.3 — signed and notarized binaries
+
+Infra release: no CLI changes. The binaries themselves are the feature.
+
+### Release pipeline
+
+- **Darwin binaries are now Developer ID–signed and notarized by Apple.**
+  Both architectures are signed and notarized before archiving, so the
+  tarballs, checksums, and provenance attestations all cover the signed
+  Mach-O. Gatekeeper accepts the binary without any quarantine workaround —
+  the cask's `xattr -d com.apple.quarantine` hack is gone. (#130)
+- **Release job egress is now blocked by default** with an explicit
+  endpoint allowlist (previously audit-only), limiting what a compromised
+  dependency or action could exfiltrate — the job holds signing keys now.
+  (#130)
+
+One caveat: bare Mach-O binaries can't have the notarization ticket
+stapled, so Gatekeeper does an online check on first run. Fine for normal
+installs; only bites a fully-offline first run.
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and
+Intel (`darwin_amd64`).


### PR DESCRIPTION
Release header for v0.5.3 (signed + notarized binaries, #130). Required by goreleaser's readFile at tag time.