### PR TITLE
fix(release): allow goreleaser.com in egress allowlist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
             fulcio.githubapp.com:443
             github.com:443
             go.dev:443
+            goreleaser.com:443
             objects.githubusercontent.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443


### PR DESCRIPTION
The v0.5.3 release run failed at the goreleaser-action step: it resolves `version: ~> v2` against goreleaser.com, which wasn't in the reconstructed egress allowlist ([harden-runner report](https://app.stepsecurity.io/github/ryanlewis/things-cli/actions/runs/32799920828) shows it as the only blocked endpoint). Adding it deliberately, per the allowlist's own comment.