### PR TITLE
fix(release): allow timestamp.apple.com:80 in egress allowlist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
             release-assets.githubusercontent.com:443
             storage.googleapis.com:443
             sum.golang.org:443
+            timestamp.apple.com:80
             timestamp.githubapp.com:443
             uploads.github.com:443
             *.actions.githubusercontent.com:443


### PR DESCRIPTION
Third v0.5.3 attempt got into actual signing and hit the last missing endpoint: quill requests an RFC3161 timestamp from `http://timestamp.apple.com/ts01` (plain HTTP — the tokens are signed, this is how Apple's TSA works). The rest of the sign/notarize/publish flow is already allowlisted (appstoreconnect, notary S3 wildcards, uploads.github.com).