### PR TITLE
fix(release): allow Sigstore public-good endpoints for attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,17 +31,20 @@ jobs:
             codeload.github.com:443
             dl.google.com:443
             fulcio.githubapp.com:443
+            fulcio.sigstore.dev:443
             github.com:443
             go.dev:443
             goreleaser.com:443
             objects.githubusercontent.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443
+            rekor.sigstore.dev:443
             release-assets.githubusercontent.com:443
             storage.googleapis.com:443
             sum.golang.org:443
             timestamp.apple.com:80
             timestamp.githubapp.com:443
+            tuf-repo-cdn.sigstore.dev:443
             uploads.github.com:443
             *.actions.githubusercontent.com:443
             *.s3.amazonaws.com:443


### PR DESCRIPTION
Fourth v0.5.3 run: goreleaser published successfully (signed + notarized), but `actions/attest-build-provenance` failed — public repos attest via the Sigstore public-good instance (`fulcio.sigstore.dev`, blocked per the [harden-runner report](https://app.stepsecurity.io/github/ryanlewis/things-cli/actions/runs/32800761293)), not `fulcio.githubapp.com`. Adds fulcio, rekor, and the TUF CDN.