### PR TITLE
docs(release): unwrap v0.5.3 header prose for GitHub rendering

### DIFF
--- a/.github/releases/v0.5.3.md
+++ b/.github/releases/v0.5.3.md
@@ -4,21 +4,11 @@ Infra release: no CLI changes. The binaries themselves are the feature.
 
 ### Release pipeline
 
-- **Darwin binaries are now Developer ID–signed and notarized by Apple.**
-  Both architectures are signed and notarized before archiving, so the
-  tarballs, checksums, and provenance attestations all cover the signed
-  Mach-O. Gatekeeper accepts the binary without any quarantine workaround —
-  the cask's `xattr -d com.apple.quarantine` hack is gone. (#130)
-- **Release job egress is now blocked by default** with an explicit
-  endpoint allowlist (previously audit-only), limiting what a compromised
-  dependency or action could exfiltrate — the job holds signing keys now.
-  (#130)
+- **Darwin binaries are now Developer ID–signed and notarized by Apple.** Both architectures are signed and notarized before archiving, so the tarballs, checksums, and provenance attestations all cover the signed Mach-O. Gatekeeper accepts the binary without any quarantine workaround — the cask's `xattr -d com.apple.quarantine` hack is gone. (#130)
+- **Release job egress is now blocked by default** with an explicit endpoint allowlist (previously audit-only), limiting what a compromised dependency or action could exfiltrate — the job holds signing keys now. (#130)
 
-One caveat: bare Mach-O binaries can't have the notarization ticket
-stapled, so Gatekeeper does an online check on first run. Fine for normal
-installs; only bites a fully-offline first run.
+One caveat: bare Mach-O binaries can't have the notarization ticket stapled, so Gatekeeper does an online check on first run. Fine for normal installs; only bites a fully-offline first run.
 
 ### Requirements
 
-macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and
-Intel (`darwin_amd64`).
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).


### PR DESCRIPTION
GitHub release bodies treat single newlines as `<br>`, so the hard-wrapped header rendered with ragged mid-sentence line breaks. The live v0.5.3 body is already fixed in place via `gh release edit`; this unwraps the checked-in source to match. (The local /release skill now carries a no-hard-wrapping rule for future drafts.)