### PR TITLE
docs(release): unwrap older release header prose

### DIFF
--- a/.github/releases/v0.4.0.md
+++ b/.github/releases/v0.4.0.md
@@ -1,34 +1,20 @@
 ## `things-cli` v0.4.0 — shell completions
 
-`things <TAB>` now completes subcommands, flags, and enum values in bash, zsh,
-and fish. Homebrew sets it up for you; everyone else runs one line.
+`things <TAB>` now completes subcommands, flags, and enum values in bash, zsh, and fish. Homebrew sets it up for you; everyone else runs one line.
 
 ### Headline
 
-- **Shell completions** for bash, zsh, and fish (#94, #95). The Homebrew cask
-  generates them on install, so `brew install ryanlewis/tap/things` gives you
-  `things <TAB>` with no extra steps. On other install paths, load them
-  yourself — `source <(things completions bash)`, `source <(things completions
-  zsh)`, or `things completions fish | source`. Completions are driven from the
-  live command tree, so they never drift from the CLI: subcommand names, flag
-  names, and enum values like `--color auto|always|never`.
+- **Shell completions** for bash, zsh, and fish (#94, #95). The Homebrew cask generates them on install, so `brew install ryanlewis/tap/things` gives you `things <TAB>` with no extra steps. On other install paths, load them yourself — `source <(things completions bash)`, `source <(things completions zsh)`, or `things completions fish | source`. Completions are driven from the live command tree, so they never drift from the CLI: subcommand names, flag names, and enum values like `--color auto|always|never`.
 
 ### Under the hood
 
-- Migrated styling to [lipgloss v2](https://github.com/charmbracelet/lipgloss)
-  (`charm.land/lipgloss/v2`) (#93). No visible change to `list`/`show` output;
-  JSON (`-j`) stays script-stable.
+- Migrated styling to [lipgloss v2](https://github.com/charmbracelet/lipgloss) (`charm.land/lipgloss/v2`) (#93). No visible change to `list`/`show` output; JSON (`-j`) stays script-stable.
 - Routine dependency updates (#83, #91, #92).
 
 ### Docs
 
-- The bundled agent skill (`things skill show` / installed `SKILL.md`) now spells
-  out every `things open` flag (`-p`/`-a`/`-t`/`-q`/`--filter`/`--background`)
-  and the `edit` / `project edit` prepend/append/checklist/`*-id` flags instead
-  of trailing `...` (#89). Reinstall it (`things skill install claude`, `…codex`,
-  `…pi`) to pick up the new text.
+- The bundled agent skill (`things skill show` / installed `SKILL.md`) now spells out every `things open` flag (`-p`/`-a`/`-t`/`-q`/`--filter`/`--background`) and the `edit` / `project edit` prepend/append/checklist/`*-id` flags instead of trailing `...` (#89). Reinstall it (`things skill install claude`, `…codex`, `…pi`) to pick up the new text.
 
 ### Requirements
 
-macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and
-Intel (`darwin_amd64`).
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).

--- a/.github/releases/v0.4.1.md
+++ b/.github/releases/v0.4.1.md
@@ -1,22 +1,13 @@
 ## `things-cli` v0.4.1 — fix Homebrew completion install
 
-Patch release. v0.4.0 added shell completions, but the Homebrew cask passed the
-shell name as `--shell=bash` (Homebrew's `:arg` format) while `things
-completions` takes the shell as a positional argument. The mismatch made
-`brew install` print "Failed to generate … completions" warnings and write no
-completion files.
+Patch release. v0.4.0 added shell completions, but the Homebrew cask passed the shell name as `--shell=bash` (Homebrew's `:arg` format) while `things completions` takes the shell as a positional argument. The mismatch made `brew install` print "Failed to generate … completions" warnings and write no completion files.
 
 ### Fix
 
-- The cask now calls `things completions bash|zsh|fish` with the shell as a bare
-  positional argument (Homebrew's default when `shell_parameter_format` is
-  omitted), matching the CLI. `brew install` / `brew upgrade` now generates the
-  bash, zsh, and fish completion files as intended.
+- The cask now calls `things completions bash|zsh|fish` with the shell as a bare positional argument (Homebrew's default when `shell_parameter_format` is omitted), matching the CLI. `brew install` / `brew upgrade` now generates the bash, zsh, and fish completion files as intended.
 
-If you installed v0.4.0 from Homebrew, run `brew update && brew reinstall
-ryanlewis/tap/things` to pick up working completions.
+If you installed v0.4.0 from Homebrew, run `brew update && brew reinstall ryanlewis/tap/things` to pick up working completions.
 
 ### Requirements
 
-macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and
-Intel (`darwin_amd64`).
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).

--- a/.github/releases/v0.4.2.md
+++ b/.github/releases/v0.4.2.md
@@ -1,20 +1,12 @@
 ## `things-cli` v0.4.2 — fix `--when` rejecting weekday names
 
-Patch release. `things add --when monday` was incorrectly rejected with
-"did you mean today?". The `--when` typo detector flags any value within
-Levenshtein distance 2 of a keyword, and `monday` is exactly distance 2
-from `today` — so it was mistaken for a typo despite being a valid
-natural-language date Things accepts.
+Patch release. `things add --when monday` was incorrectly rejected with "did you mean today?". The `--when` typo detector flags any value within Levenshtein distance 2 of a keyword, and `monday` is exactly distance 2 from `today` — so it was mistaken for a typo despite being a valid natural-language date Things accepts.
 
 ### Fix
 
-- Weekday names and their abbreviations (`monday`…`sunday`, plus `mon`,
-  `tue`, `wed`, `thu`, `fri`, `sat`, `sun` and common variants) now bypass
-  the typo detector and pass through to Things verbatim. Verified against
-  Things3 that each resolves to the correct upcoming scheduled date.
+- Weekday names and their abbreviations (`monday`…`sunday`, plus `mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun` and common variants) now bypass the typo detector and pass through to Things verbatim. Verified against Things3 that each resolves to the correct upcoming scheduled date.
 - Genuine typos (`tommorrow`, `evning`, …) are still rejected as before.
 
 ### Requirements
 
-macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`)
-and Intel (`darwin_amd64`).
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).

--- a/.github/releases/v0.5.0.md
+++ b/.github/releases/v0.5.0.md
@@ -1,29 +1,16 @@
 ## `things-cli` v0.5.0 — clearer JSON status, leaner `today`
 
-Minor release. Two behaviour changes worth a look before you upgrade any
-automation, plus dependency maintenance.
+Minor release. Two behaviour changes worth a look before you upgrade any automation, plus dependency maintenance.
 
 ### Behaviour changes
 
-- **JSON `status` is now a string.** `Task`, `Project`, and `ChecklistItem`
-  `status` fields render as `"open"` / `"cancelled"` / `"completed"` in JSON
-  instead of the raw Things integers (`0` / `2` / `3`). The bare ints were an
-  implementation detail that read like a rank. Plain-text output is unchanged.
-  The decoder still accepts both the string name and the legacy integer, and
-  any unrecognised code round-trips as its number — but consumers that parse
-  our JSON `status` as a number will need to read it as a string.
-  (#107, closes #105)
-- **`things today` excludes completed tasks by default.** It now returns only
-  open tasks; completed/cancelled items Things still shows in Today are
-  available behind a new `--include-completed` flag (UI-parity). For
-  automation, "in today" now means "still to do". (#109, closes #106)
+- **JSON `status` is now a string.** `Task`, `Project`, and `ChecklistItem` `status` fields render as `"open"` / `"cancelled"` / `"completed"` in JSON instead of the raw Things integers (`0` / `2` / `3`). The bare ints were an implementation detail that read like a rank. Plain-text output is unchanged. The decoder still accepts both the string name and the legacy integer, and any unrecognised code round-trips as its number — but consumers that parse our JSON `status` as a number will need to read it as a string. (#107, closes #105)
+- **`things today` excludes completed tasks by default.** It now returns only open tasks; completed/cancelled items Things still shows in Today are available behind a new `--include-completed` flag (UI-parity). For automation, "in today" now means "still to do". (#109, closes #106)
 
 ### Maintenance
 
-- Bumped `lipgloss`, `golang.org/x/term`, `golang.org/x/sys`, and
-  `modernc.org/sqlite`; `actions/checkout` → v7 in CI. (#100, #108)
+- Bumped `lipgloss`, `golang.org/x/term`, `golang.org/x/sys`, and `modernc.org/sqlite`; `actions/checkout` → v7 in CI. (#100, #108)
 
 ### Requirements
 
-macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and
-Intel (`darwin_amd64`).
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).

--- a/.github/releases/v0.5.1.md
+++ b/.github/releases/v0.5.1.md
@@ -1,44 +1,23 @@
 ## `things-cli` v0.5.1 — cancel projects, honest empty JSON
 
-Patch release: two bug fixes with a supply-chain hardening pass riding
-underneath.
+Patch release: two bug fixes with a supply-chain hardening pass riding underneath.
 
 ### Fixes
 
-- **`things cancel` now works on projects.** It previously routed every
-  reference through the task-only AppleScript path, so cancelling a project
-  failed with a raw osascript error. Projects now cancel properly, behind the
-  same interactive confirmation `complete` uses — cancelling a project
-  cascades to its tasks. (#125)
-- **Empty `--json` results emit `[]`, not `null`.** All list-shaped commands
-  (`list`, `search`, `projects`, `areas`, `tags`) returned `null` for an empty
-  result, which breaks `jq '.[]'` pipelines — including the ones documented in
-  the bundled agent skill. (#124)
-- **Date filters on `someday` are rejected instead of silently matching
-  nothing.** Someday items have no start date, so `--on`/`--from`/`--to`
-  could never match; the CLI now says so instead of returning empty output,
-  and the README no longer advertises the impossible combination. (#124)
+- **`things cancel` now works on projects.** It previously routed every reference through the task-only AppleScript path, so cancelling a project failed with a raw osascript error. Projects now cancel properly, behind the same interactive confirmation `complete` uses — cancelling a project cascades to its tasks. (#125)
+- **Empty `--json` results emit `[]`, not `null`.** All list-shaped commands (`list`, `search`, `projects`, `areas`, `tags`) returned `null` for an empty result, which breaks `jq '.[]'` pipelines — including the ones documented in the bundled agent skill. (#124)
+- **Date filters on `someday` are rejected instead of silently matching nothing.** Someday items have no start date, so `--on`/`--from`/`--to` could never match; the CLI now says so instead of returning empty output, and the README no longer advertises the impossible combination. (#124)
 
 ### Small improvements
 
-- `show`, `complete`, and `cancel` help text now documents the numeric-index
-  reference form (`things list today; things complete 3`) — it always worked,
-  but only `edit` admitted it. (#125)
-- `things projects` gains the `-a` short flag for `--area`, matching `list`
-  and `open`. (#125)
+- `show`, `complete`, and `cancel` help text now documents the numeric-index reference form (`things list today; things complete 3`) — it always worked, but only `edit` admitted it. (#125)
+- `things projects` gains the `-a` short flag for `--area`, matching `list` and `open`. (#125)
 
 ### Supply chain
 
-- Release artifacts now carry [build provenance attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations).
-  `install.sh` verifies them automatically when the GitHub CLI is present
-  (and refuses to install on a failed verification); check any artifact
-  yourself with
-  `gh attestation verify things_<version>_darwin_arm64.tar.gz -R ryanlewis/things-cli`.
-  (#122, #123)
-- CI hardening: govulncheck (gating + weekly Security-tab scan), CodeQL,
-  dependency review, and a locked-down release pipeline. (#122)
+- Release artifacts now carry [build provenance attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations). `install.sh` verifies them automatically when the GitHub CLI is present (and refuses to install on a failed verification); check any artifact yourself with `gh attestation verify things_<version>_darwin_arm64.tar.gz -R ryanlewis/things-cli`. (#122, #123)
+- CI hardening: govulncheck (gating + weekly Security-tab scan), CodeQL, dependency review, and a locked-down release pipeline. (#122)
 
 ### Requirements
 
-macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and
-Intel (`darwin_amd64`).
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).

--- a/.github/releases/v0.5.2.md
+++ b/.github/releases/v0.5.2.md
@@ -4,19 +4,10 @@ Patch release: one bug fix.
 
 ### Fixes
 
-- **`creationDate` and `stopDate` are no longer 31 years in the future.**
-  Things stores its absolute timestamps (task creation, task and checklist
-  completion) as Unix-epoch seconds, but they were decoded against Apple's
-  Core Data reference date (2001-01-01) — so a task created on
-  2026-08-09 reported `"creationDate": "2057-08-09T…"` in `--json` output.
-  Anything sorting or filtering on those fields downstream would misbehave.
-  Scheduling fields (`startDate`, `deadline`) use a different encoding and
-  were always correct. (#127)
+- **`creationDate` and `stopDate` are no longer 31 years in the future.** Things stores its absolute timestamps (task creation, task and checklist completion) as Unix-epoch seconds, but they were decoded against Apple's Core Data reference date (2001-01-01) — so a task created on 2026-08-09 reported `"creationDate": "2057-08-09T…"` in `--json` output. Anything sorting or filtering on those fields downstream would misbehave. Scheduling fields (`startDate`, `deadline`) use a different encoding and were always correct. (#127)
 
-No CLI surface changes — if you parse `creationDate`/`stopDate` from
-`--json` output, the values are simply right now.
+No CLI surface changes — if you parse `creationDate`/`stopDate` from `--json` output, the values are simply right now.
 
 ### Requirements
 
-macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and
-Intel (`darwin_amd64`).
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).


### PR DESCRIPTION
Companion to #136: the live release bodies of v0.4.0–v0.5.2 have been unwrapped in place with `gh release edit`; this syncs the checked-in header sources. v0.1.0–v0.3.1 were never hard-wrapped and are untouched.