### PR TITLE
fix(release): narrow S3 egress wildcards to Apple notary bucket

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
             github.com:443
             go.dev:443
             goreleaser.com:443
+            notary-submissions-prod.s3.us-west-2.amazonaws.com:443
             objects.githubusercontent.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443
@@ -47,8 +48,6 @@ jobs:
             tuf-repo-cdn.sigstore.dev:443
             uploads.github.com:443
             *.actions.githubusercontent.com:443
-            *.s3.amazonaws.com:443
-            *.s3.us-west-2.amazonaws.com:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## What

Replaces the two wildcard S3 entries in the goreleaser job's harden-runner allowlist with the one specific hostname a release actually contacts:

- Removed: `*.s3.amazonaws.com:443`, `*.s3.us-west-2.amazonaws.com:443`
- Added: `notary-submissions-prod.s3.us-west-2.amazonaws.com:443`

## Why

The wildcards resolve to *any* S3 bucket, including one an attacker controls. This job holds the macOS signing P12, the notary key, and the Homebrew tap token — the workflow's own comment calls it the prime exfiltration target. Every other allowlist entry is a specific host; these two were the only general-purpose outbound write path left open, so a compromised dependency could `PUT` to an arbitrary bucket and the egress policy would allow it.

Both wildcards were added preemptively in #130 rather than from observed traffic. The harden-runner log from the successful v0.5.3 run ([32801379092](https://github.com/ryanlewis/things-cli/actions/runs/32801379092)) shows the only S3 host contacted is `notary-submissions-prod.s3.us-west-2.amazonaws.com` — quill's upload to Apple's notary submission bucket. Nothing ever matched the `*.s3.amazonaws.com` global wildcard. The bucket-specific host closes the exfil path: the hostname pins the bucket, and that bucket is Apple's.

## Caveat

This job only fires on `v*` tags, so CI on this PR cannot exercise the change. If Apple ever moves the notary bucket (or quill switches to the global/accelerate S3 endpoint), the next release fails loudly on a blocked connection and the harden-runner report names the endpoint to re-add — the same discipline already written into the workflow comment. Worth cutting the next release soon after merging to confirm.