### PR TITLE
feat(tags): warn on unknown tags and add --strict-tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ project.
 | `--heading NAME` | ✓ | — | Heading within the project |
 | `--list NAME` | ✓ | — | List (project or area) name |
 | `--area NAME` | — | ✓ | Area to file the project under |
+| `--strict-tags` | ✓ | ✓ | Fail instead of writing when a tag does not exist (see [Tags must already exist](#tags-must-already-exist)) |
 
 Examples:
 
@@ -254,6 +255,7 @@ stay untouched. An empty value clears the field (e.g. `--deadline ""`).
 | `--cancel` | ✓ | ✓ | Mark as canceled (not with `--complete`) |
 | `--duplicate` | ✓ | ✓ | Duplicate before applying edits |
 | `--reveal` | ✓ | ✓ | Reveal in Things after editing |
+| `--strict-tags` | ✓ | ✓ | Fail instead of writing when a tag does not exist (see [Tags must already exist](#tags-must-already-exist)) |
 
 > **Repeating items:** Things refuses `--when`, `--deadline`, `--complete`,
 > `--cancel`, and `--duplicate` on repeating to-dos and projects, and drops the
@@ -270,6 +272,35 @@ things edit "Buy milk" --add-tags urgent --deadline 2026-05-01
 things edit "Old idea" --deadline ""              # clear the deadline
 things project edit "Launch" --append-notes "Beta cut on Friday"
 ```
+
+### Tags must already exist
+
+Things applies only tags that already exist. A tag it doesn't recognise is
+dropped silently — the task is still created or updated, minus the tag, and
+the command exits 0. The CLI cannot create tags: the URL scheme has no way
+to, and there is no `things tag add` command.
+
+To stop that being invisible, every write that carries tags (`add`,
+`project add`, `edit`, `project edit`, `import`) first checks them against
+the Things database and warns on stderr about any it cannot find:
+
+```
+$ things add "Review the flags" --tags "Work,cifas-auto-reject"
+warning: these tags do not exist in Things and will be ignored: cifas-auto-reject
+warning: Things only applies tags that already exist — create them in Things first, or use --strict-tags to fail instead of dropping them
+```
+
+The write still goes ahead. Pass `--strict-tags` to refuse it instead:
+
+```
+$ things add "Review the flags" --tags "Work,cifas-auto-reject" --strict-tags
+Error: these tags do not exist in Things: cifas-auto-reject — create them in Things first, or drop --strict-tags to write anyway
+```
+
+Nothing is written in that case, and the exit status is non-zero. Tag names
+are matched case-insensitively, the way Things treats them. If the database
+can't be read, the check is skipped with a warning — unless `--strict-tags`
+is set, which then fails rather than write unchecked.
 
 ### Completing, cancelling, logging
 
@@ -347,6 +378,7 @@ for create-only payloads).
 | --- | --- |
 | `-f, --file PATH` | Read JSON payload from this file instead of stdin |
 | `--reveal` | Reveal the first created/updated item in Things after import |
+| `--strict-tags` | Fail instead of importing when a tag in the payload does not exist (see [Tags must already exist](#tags-must-already-exist)) |
 
 ```sh
 things import < payload.json

--- a/README.md
+++ b/README.md
@@ -299,8 +299,10 @@ Error: these tags do not exist in Things: cifas-auto-reject — create them in T
 
 Nothing is written in that case, and the exit status is non-zero. Tag names
 are matched case-insensitively, the way Things treats them. If the database
-can't be read, the check is skipped with a warning — unless `--strict-tags`
-is set, which then fails rather than write unchecked.
+can't be read, `add` and `project add` skip the check with a warning — unless
+`--strict-tags` is set, which then fails rather than write unchecked. `edit`,
+`project edit` and `import` need the database for other reasons and fail
+either way.
 
 ### Completing, cancelling, logging
 

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -65,9 +65,19 @@ type Deps struct {
 	DBPath string
 	JSON   bool
 	Stdout io.Writer
+	Stderr io.Writer
 
 	// NoVerify skips the post-write read-back on complete/cancel.
 	NoVerify bool
+}
+
+// errOut is where warnings go. Tests leave Stderr nil and capture os.Stderr,
+// or set it to a buffer to assert on the text.
+func (d *Deps) errOut() io.Writer {
+	if d.Stderr == nil {
+		return os.Stderr
+	}
+	return d.Stderr
 }
 
 // Database returns the lazily-opened DB. Subsequent calls return the same
@@ -294,9 +304,14 @@ type AddCmd struct {
 	Project   string `help:"Project name or UUID."`
 	Heading   string `help:"Heading within project."`
 	List      string `help:"List (project or area) name."`
+
+	StrictTags
 }
 
-func (c *AddCmd) Run(_ *Deps) error {
+func (c *AddCmd) Run(d *Deps) error {
+	if err := verifyTagStrings(d, c.StrictTags.StrictTags, &c.Tags); err != nil {
+		return err
+	}
 	list := c.List
 	if list == "" {
 		list = c.Project
@@ -326,9 +341,14 @@ type ProjectAddCmd struct {
 	Tags     string `help:"Comma-separated tags."`
 	Area     string `help:"Area name or UUID."`
 	Todos    string `help:"Newline-separated initial to-dos."`
+
+	StrictTags
 }
 
-func (c *ProjectAddCmd) Run(_ *Deps) error {
+func (c *ProjectAddCmd) Run(d *Deps) error {
+	if err := verifyTagStrings(d, c.StrictTags.StrictTags, &c.Tags); err != nil {
+		return err
+	}
 	return things.AddProject(things.AddProjectParams{
 		Title:    c.Title,
 		Notes:    c.Notes,
@@ -362,6 +382,8 @@ type ProjectEditCmd struct {
 	Cancel    bool `help:"Mark the project as canceled." xor:"status"`
 	Duplicate bool `help:"Duplicate the project before applying edits."`
 	Reveal    bool `help:"Reveal the project in Things after editing."`
+
+	StrictTags
 }
 
 func (c *ProjectEditCmd) Run(d *Deps) error {
@@ -376,8 +398,12 @@ func (c *ProjectEditCmd) Run(d *Deps) error {
 	if project.Type != model.TypeProject {
 		return fmt.Errorf("not a project: %s", project.Title)
 	}
-
 	if err := checkRepeating(project, restrictedEdits(c.When, c.Deadline, c.Complete, c.Cancel, c.Duplicate)); err != nil {
+		return err
+	}
+	// After checkRepeating: no point warning about tags on an edit Things
+	// is going to refuse anyway.
+	if err := verifyTagStrings(d, c.StrictTags.StrictTags, c.Tags, c.AddTags); err != nil {
 		return err
 	}
 
@@ -433,6 +459,8 @@ type EditCmd struct {
 	Cancel    bool `help:"Mark the task as canceled." xor:"status"`
 	Duplicate bool `help:"Duplicate the task before applying edits."`
 	Reveal    bool `help:"Reveal the task in Things after editing."`
+
+	StrictTags
 }
 
 func (c *EditCmd) Run(d *Deps) error {
@@ -444,8 +472,12 @@ func (c *EditCmd) Run(d *Deps) error {
 	if err != nil {
 		return err
 	}
-
 	if err := checkRepeating(task, restrictedEdits(c.When, c.Deadline, c.Complete, c.Cancel, c.Duplicate)); err != nil {
+		return err
+	}
+	// After checkRepeating: no point warning about tags on an edit Things
+	// is going to refuse anyway.
+	if err := verifyTagStrings(d, c.StrictTags.StrictTags, c.Tags, c.AddTags); err != nil {
 		return err
 	}
 
@@ -668,6 +700,8 @@ func (c *SkillListCmd) Run(d *Deps) error {
 type ImportCmd struct {
 	File   string `help:"Read JSON payload from this file instead of stdin." short:"f" type:"existingfile"`
 	Reveal bool   `help:"Reveal the first created/updated item in Things after import."`
+
+	StrictTags
 }
 
 func (c *ImportCmd) Run(d *Deps) error {
@@ -693,12 +727,15 @@ func (c *ImportCmd) Run(d *Deps) error {
 	if err := validateImportJSON(data); err != nil {
 		return err
 	}
+	if err := verifyTags(d, c.StrictTags.StrictTags, importTags(data)); err != nil {
+		return err
+	}
 	token, err := database.GetAuthToken()
 	if err != nil {
 		// Don't fail the import — the payload may be create-only and not need
 		// the token at all — but surface the read error so users debugging an
 		// `operation: update` failure aren't left guessing.
-		fmt.Fprintf(os.Stderr, "warning: could not read Things auth token: %v\n", err)
+		fmt.Fprintf(d.errOut(), "warning: could not read Things auth token: %v\n", err)
 	}
 	return things.ImportJSON(string(data), token, c.Reveal)
 }
@@ -806,7 +843,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	deps := &Deps{DBPath: cli.DB, JSON: cli.JSON, Stdout: os.Stdout, NoVerify: cli.NoVerify}
+	deps := &Deps{DBPath: cli.DB, JSON: cli.JSON, Stdout: os.Stdout, Stderr: os.Stderr, NoVerify: cli.NoVerify}
 	defer deps.Close()
 
 	if err := ctx.Run(deps); err != nil {

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -62,6 +62,13 @@ func seedFullDB(t *testing.T) *db.DB {
 		t.Fatalf("seed project: %v", err)
 	}
 
+	// URL-scheme auth token, required by the update/update-project commands.
+	if _, err := sqlDB.Exec(
+		`INSERT INTO TMSettings (uuid, uriSchemeAuthenticationToken) VALUES ('s1', 'test-token')`,
+	); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
 	// Tag
 	if _, err := sqlDB.Exec(
 		`INSERT INTO TMTag (uuid, title, "index") VALUES ('tag-1', 'urgent', 0)`,
@@ -128,6 +135,22 @@ func runWith(t *testing.T, database *db.DB, args ...string) error {
 // the handler wrote to Deps.Stdout.
 func runOut(t *testing.T, database *db.DB, args ...string) (string, error) {
 	t.Helper()
+	stdout, _, err := runStreams(t, database, args...)
+	return stdout, err
+}
+
+// runCapturingStderr is runOut for the warning stream — what the handler wrote
+// to Deps.Stderr — instead of stdout.
+func runCapturingStderr(t *testing.T, database *db.DB, args ...string) (string, error) {
+	t.Helper()
+	_, stderr, err := runStreams(t, database, args...)
+	return stderr, err
+}
+
+// runStreams parses args, runs the command against database, and returns both
+// of the handler's output streams.
+func runStreams(t *testing.T, database *db.DB, args ...string) (string, string, error) {
+	t.Helper()
 	t.Setenv("HOME", t.TempDir())
 
 	var cli CLI
@@ -144,13 +167,13 @@ func runOut(t *testing.T, database *db.DB, args ...string) (string, error) {
 	if err != nil {
 		t.Fatalf("parse %v: %v", args, err)
 	}
-	var buf bytes.Buffer
-	deps := &Deps{DB: database, JSON: cli.JSON, Stdout: &buf, NoVerify: cli.NoVerify}
+	var stdout, stderr bytes.Buffer
+	deps := &Deps{DB: database, JSON: cli.JSON, Stdout: &stdout, Stderr: &stderr, NoVerify: cli.NoVerify}
 	var runErr error
 	withSilentStdout(t, func() {
 		runErr = ctx.Run(deps)
 	})
-	return buf.String(), runErr
+	return stdout.String(), stderr.String(), runErr
 }
 
 func TestRunDispatchReadOnly(t *testing.T) {

--- a/cmd/things/tags.go
+++ b/cmd/things/tags.go
@@ -86,7 +86,10 @@ func walkImportTags(node any, names *[]string) {
 	switch v := node.(type) {
 	case map[string]any:
 		if attrs, ok := v["attributes"].(map[string]any); ok {
+			// `add-tags` is the additive form used by `operation: update`
+			// items; it carries tag names just like `tags` does.
 			*names = append(*names, jsonTagValues(attrs["tags"])...)
+			*names = append(*names, jsonTagValues(attrs["add-tags"])...)
 		}
 		for _, child := range v {
 			walkImportTags(child, names)
@@ -98,15 +101,22 @@ func walkImportTags(node any, names *[]string) {
 	}
 }
 
-// jsonTagValues reads the `tags` attribute, which Things documents as an array
-// of strings but also accepts as a single comma-separated string.
+// jsonTagValues reads a tag attribute, which Things documents as an array of
+// strings but also accepts as a single comma-separated string. Array entries
+// are taken verbatim — the array form is what lets a payload name a tag that
+// contains a comma, so splitting them would invent unknown tags and, under
+// --strict-tags, refuse an import that Things would have applied fine.
 func jsonTagValues(node any) []string {
 	switch v := node.(type) {
 	case []any:
 		var out []string
 		for _, item := range v {
-			if s, ok := item.(string); ok {
-				out = append(out, things.SplitTags(s)...)
+			s, ok := item.(string)
+			if !ok {
+				continue
+			}
+			if s = strings.TrimSpace(s); s != "" {
+				out = append(out, s)
 			}
 		}
 		return out

--- a/cmd/things/tags.go
+++ b/cmd/things/tags.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ryanlewis/things-cli/internal/things"
+)
+
+// StrictTags is embedded in every write command that accepts tags. The Things
+// URL scheme applies only tags that already exist and ignores the rest without
+// reporting it, so by default we warn and let the write through; --strict-tags
+// turns that warning into a refusal.
+type StrictTags struct {
+	StrictTags bool `help:"Fail instead of writing when a tag does not exist in Things." name:"strict-tags"`
+}
+
+// verifyTags checks requested tag names against the tags in the Things
+// database and reports the ones that don't exist. Without strict it warns on
+// stderr and returns nil so the write still happens; with strict it returns an
+// error and the caller writes nothing.
+func verifyTags(d *Deps, strict bool, names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+
+	unavailable := func(err error) error {
+		if strict {
+			return fmt.Errorf("--strict-tags: cannot check tags against the Things database: %w", err)
+		}
+		fmt.Fprintf(d.errOut(), "warning: could not check tags against the Things database: %v\n", err)
+		fmt.Fprintf(d.errOut(), "warning: tags that do not already exist in Things will be dropped without notice\n")
+		return nil
+	}
+
+	database, err := d.Database()
+	if err != nil {
+		return unavailable(err)
+	}
+	unknown, err := database.UnknownTags(names)
+	if err != nil {
+		return unavailable(err)
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+
+	list := strings.Join(unknown, ", ")
+	if strict {
+		return fmt.Errorf("these tags do not exist in Things: %s — create them in Things first, or drop --strict-tags to write anyway", list)
+	}
+	fmt.Fprintf(d.errOut(), "warning: these tags do not exist in Things and will be ignored: %s\n", list)
+	fmt.Fprintf(d.errOut(), "warning: Things only applies tags that already exist — create them in Things first, or use --strict-tags to fail instead of dropping them\n")
+	return nil
+}
+
+// verifyTagStrings checks comma-separated tag values (as passed to --tags /
+// --add-tags). nil pointers and empty strings contribute nothing.
+func verifyTagStrings(d *Deps, strict bool, values ...*string) error {
+	var names []string
+	for _, v := range values {
+		if v != nil {
+			names = append(names, things.SplitTags(*v)...)
+		}
+	}
+	return verifyTags(d, strict, names)
+}
+
+// importTags collects every tag named anywhere in a Things JSON payload. Tags
+// live under an item's `attributes`, and items nest (a project carries
+// `items`), so this walks the whole decoded tree. The payload has already
+// been validated as JSON by the caller; anything unparseable yields no tags
+// and the import proceeds as before.
+func importTags(data []byte) []string {
+	var payload any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil
+	}
+	var names []string
+	walkImportTags(payload, &names)
+	return names
+}
+
+func walkImportTags(node any, names *[]string) {
+	switch v := node.(type) {
+	case map[string]any:
+		if attrs, ok := v["attributes"].(map[string]any); ok {
+			*names = append(*names, jsonTagValues(attrs["tags"])...)
+		}
+		for _, child := range v {
+			walkImportTags(child, names)
+		}
+	case []any:
+		for _, child := range v {
+			walkImportTags(child, names)
+		}
+	}
+}
+
+// jsonTagValues reads the `tags` attribute, which Things documents as an array
+// of strings but also accepts as a single comma-separated string.
+func jsonTagValues(node any) []string {
+	switch v := node.(type) {
+	case []any:
+		var out []string
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, things.SplitTags(s)...)
+			}
+		}
+		return out
+	case string:
+		return things.SplitTags(v)
+	}
+	return nil
+}

--- a/cmd/things/tags_test.go
+++ b/cmd/things/tags_test.go
@@ -123,6 +123,17 @@ func TestImportTags(t *testing.T) {
 		{"array", `[{"type":"to-do","attributes":{"title":"x","tags":["work","urgent"]}}]`, []string{"work", "urgent"}},
 		{"commaString", `[{"type":"to-do","attributes":{"title":"x","tags":"work, urgent"}}]`, []string{"work", "urgent"}},
 		{
+			"addTags",
+			`[{"type":"to-do","operation":"update","id":"u1","attributes":{"add-tags":["work"]}}]`,
+			[]string{"work"},
+		},
+		{
+			// An array entry is one tag name, commas included.
+			"arrayEntryKeepsComma",
+			`[{"type":"to-do","attributes":{"title":"x","tags":["a, b"]}}]`,
+			[]string{"a, b"},
+		},
+		{
 			"nestedItems",
 			`[{"type":"project","attributes":{"title":"p","tags":["outer"],
 			  "items":[{"type":"to-do","attributes":{"title":"t","tags":["inner"]}}]}}]`,

--- a/cmd/things/tags_test.go
+++ b/cmd/things/tags_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTagDeps(t *testing.T) (*Deps, *bytes.Buffer) {
+	t.Helper()
+	var stderr bytes.Buffer
+	return &Deps{DB: seedFullDB(t), Stdout: io.Discard, Stderr: &stderr}, &stderr
+}
+
+func TestVerifyTagsAllKnown(t *testing.T) {
+	deps, stderr := newTagDeps(t)
+	// seedFullDB creates the tag "urgent".
+	if err := verifyTags(deps, false, []string{"urgent"}); err != nil {
+		t.Fatalf("verifyTags: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("expected no warning, got %q", stderr.String())
+	}
+}
+
+func TestVerifyTagsWarnsOnUnknown(t *testing.T) {
+	deps, stderr := newTagDeps(t)
+	if err := verifyTags(deps, false, []string{"urgent", "cifas-auto-reject"}); err != nil {
+		t.Fatalf("verifyTags: %v", err)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "cifas-auto-reject") {
+		t.Errorf("warning does not name the unknown tag: %q", out)
+	}
+	if !strings.Contains(out, "do not exist in Things") {
+		t.Errorf("warning does not explain the problem: %q", out)
+	}
+	if strings.Contains(out, "urgent") {
+		t.Errorf("warning names a tag that does exist: %q", out)
+	}
+}
+
+func TestVerifyTagsStrictFails(t *testing.T) {
+	deps, stderr := newTagDeps(t)
+	err := verifyTags(deps, true, []string{"cifas-auto-reject"})
+	if err == nil {
+		t.Fatal("expected an error under --strict-tags")
+	}
+	if !strings.Contains(err.Error(), "cifas-auto-reject") {
+		t.Errorf("error does not name the unknown tag: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("strict mode should not also warn: %q", stderr.String())
+	}
+}
+
+func TestVerifyTagsNoNamesSkipsDatabase(t *testing.T) {
+	// No DB handle and an unopenable path: verifyTags must not touch the
+	// database when there are no tags to check, so `things add` keeps working
+	// without a readable Things database.
+	var stderr bytes.Buffer
+	deps := &Deps{DBPath: filepath.Join(t.TempDir(), "missing.sqlite"), Stdout: io.Discard, Stderr: &stderr}
+	if err := verifyTags(deps, true, nil); err != nil {
+		t.Fatalf("verifyTags with no tags: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("expected no output, got %q", stderr.String())
+	}
+}
+
+func TestVerifyTagsDatabaseUnavailable(t *testing.T) {
+	newDeps := func() (*Deps, *bytes.Buffer) {
+		var stderr bytes.Buffer
+		path := filepath.Join(t.TempDir(), "missing.sqlite")
+		if err := os.WriteFile(path, []byte("not a database"), 0o600); err != nil {
+			t.Fatalf("write stub db: %v", err)
+		}
+		return &Deps{DBPath: path, Stdout: io.Discard, Stderr: &stderr}, &stderr
+	}
+
+	// Default: the check is skipped with a warning and the write proceeds.
+	deps, stderr := newDeps()
+	if err := verifyTags(deps, false, []string{"anything"}); err != nil {
+		t.Fatalf("verifyTags: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "could not check tags") {
+		t.Errorf("expected a skip warning, got %q", stderr.String())
+	}
+
+	// Strict: an unverifiable tag is a failure, not a warning.
+	deps, _ = newDeps()
+	err := verifyTags(deps, true, []string{"anything"})
+	if err == nil || !strings.Contains(err.Error(), "--strict-tags") {
+		t.Fatalf("expected a strict failure, got %v", err)
+	}
+}
+
+func TestVerifyTagStrings(t *testing.T) {
+	deps, stderr := newTagDeps(t)
+	tags := "urgent, nope"
+	addTags := "also-nope"
+	if err := verifyTagStrings(deps, false, &tags, nil, &addTags); err != nil {
+		t.Fatalf("verifyTagStrings: %v", err)
+	}
+	out := stderr.String()
+	for _, want := range []string{"nope", "also-nope"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("warning missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestImportTags(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    []string
+	}{
+		{"none", `[{"type":"to-do","attributes":{"title":"x"}}]`, nil},
+		{"array", `[{"type":"to-do","attributes":{"title":"x","tags":["work","urgent"]}}]`, []string{"work", "urgent"}},
+		{"commaString", `[{"type":"to-do","attributes":{"title":"x","tags":"work, urgent"}}]`, []string{"work", "urgent"}},
+		{
+			"nestedItems",
+			`[{"type":"project","attributes":{"title":"p","tags":["outer"],
+			  "items":[{"type":"to-do","attributes":{"title":"t","tags":["inner"]}}]}}]`,
+			[]string{"outer", "inner"},
+		},
+		{"invalidJSON", `not json`, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := importTags([]byte(c.payload))
+			if len(got) != len(c.want) {
+				t.Fatalf("importTags = %v, want %v", got, c.want)
+			}
+			// Map order makes the walk order of sibling keys unstable, so
+			// compare as a set.
+			seen := map[string]bool{}
+			for _, g := range got {
+				seen[g] = true
+			}
+			for _, w := range c.want {
+				if !seen[w] {
+					t.Errorf("importTags = %v, missing %q", got, w)
+				}
+			}
+		})
+	}
+}
+
+func TestRunAddWarnsOnUnknownTag(t *testing.T) {
+	database := seedFullDB(t)
+	captured := stubExec(t)
+
+	stderr, err := runCapturingStderr(t, database, "add", "Buy milk", "--tags", "urgent,nope")
+	if err != nil {
+		t.Fatalf("run add: %v", err)
+	}
+	if !strings.Contains(stderr, "nope") {
+		t.Errorf("expected a warning naming the unknown tag, got %q", stderr)
+	}
+	if len(*captured) == 0 {
+		t.Error("expected the add to still be written")
+	}
+}
+
+func TestRunAddStrictTagsRefusesToWrite(t *testing.T) {
+	database := seedFullDB(t)
+	captured := stubExec(t)
+
+	stderr, err := runCapturingStderr(t, database, "add", "Buy milk", "--tags", "urgent,nope", "--strict-tags")
+	if err == nil || !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("expected a strict-tags failure, got %v", err)
+	}
+	if len(*captured) != 0 {
+		t.Errorf("nothing should have been written, got %v", *captured)
+	}
+	if stderr != "" {
+		t.Errorf("expected no warning alongside the error, got %q", stderr)
+	}
+}
+
+func TestRunAddKnownTagIsSilent(t *testing.T) {
+	database := seedFullDB(t)
+	stubExec(t)
+
+	stderr, err := runCapturingStderr(t, database, "add", "Buy milk", "--tags", "urgent", "--strict-tags")
+	if err != nil {
+		t.Fatalf("run add: %v", err)
+	}
+	if stderr != "" {
+		t.Errorf("expected no warning for a known tag, got %q", stderr)
+	}
+}
+
+func TestRunEditStrictTagsRefusesToWrite(t *testing.T) {
+	database := seedFullDB(t)
+	captured := stubExec(t)
+
+	_, err := runCapturingStderr(t, database, "edit", "task-1", "--add-tags", "nope", "--strict-tags")
+	if err == nil || !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("expected a strict-tags failure, got %v", err)
+	}
+	if len(*captured) != 0 {
+		t.Errorf("nothing should have been written, got %v", *captured)
+	}
+}
+
+func TestRunProjectAddStrictTagsRefusesToWrite(t *testing.T) {
+	database := seedFullDB(t)
+	captured := stubExec(t)
+
+	_, err := runCapturingStderr(t, database, "project", "add", "New project", "--tags", "nope", "--strict-tags")
+	if err == nil || !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("expected a strict-tags failure, got %v", err)
+	}
+	if len(*captured) != 0 {
+		t.Errorf("nothing should have been written, got %v", *captured)
+	}
+}
+
+func TestRunProjectEditWarnsOnUnknownTag(t *testing.T) {
+	database := seedFullDB(t)
+	stubExec(t)
+
+	stderr, err := runCapturingStderr(t, database, "project", "edit", "Chores", "--tags", "nope")
+	if err != nil {
+		t.Fatalf("run project edit: %v", err)
+	}
+	if !strings.Contains(stderr, "nope") {
+		t.Errorf("expected a warning naming the unknown tag, got %q", stderr)
+	}
+}
+
+func TestRunImportStrictTagsRefusesToWrite(t *testing.T) {
+	database := seedFullDB(t)
+	captured := stubExec(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "payload.json")
+	payload := `[{"type":"to-do","attributes":{"title":"Hi","tags":["nope"]}}]`
+	if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	_, err := runCapturingStderr(t, database, "import", "--file", path, "--strict-tags")
+	if err == nil || !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("expected a strict-tags failure, got %v", err)
+	}
+	if len(*captured) != 0 {
+		t.Errorf("nothing should have been imported, got %v", *captured)
+	}
+}
+
+func TestRunImportWarnsOnUnknownTag(t *testing.T) {
+	database := seedFullDB(t)
+	captured := stubExec(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "payload.json")
+	payload := `[{"type":"to-do","attributes":{"title":"Hi","tags":["urgent","nope"]}}]`
+	if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	stderr, err := runCapturingStderr(t, database, "import", "--file", path)
+	if err != nil {
+		t.Fatalf("run import: %v", err)
+	}
+	if !strings.Contains(stderr, "nope") {
+		t.Errorf("expected a warning naming the unknown tag, got %q", stderr)
+	}
+	if len(*captured) == 0 {
+		t.Error("expected the import to still be dispatched")
+	}
+}

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -94,6 +94,20 @@ things edit 3 --complete                 # also: --cancel, --duplicate, --reveal
 `--area`/`--area-id` to move the project. It has no checklist or
 heading flags.
 
+## Tags must already exist
+
+Things applies only tags that already exist and drops the rest without
+saying so. Every write that carries tags (`add`, `project add`, `edit`,
+`project edit`, `import`) checks them against the database first and warns:
+
+```sh
+things add "Review the flags" --tags "Work,cifas-auto-reject"
+# warning: these tags do not exist in Things and will be ignored: cifas-auto-reject
+```
+
+The write still happens. Add `--strict-tags` to fail and write nothing
+instead. The CLI cannot create tags — create them in Things first.
+
 ## Completing and cancelling
 
 ```sh

--- a/internal/db/tags.go
+++ b/internal/db/tags.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/ryanlewis/things-cli/internal/model"
 )
@@ -45,4 +46,47 @@ func (d *DB) ListTags() ([]model.Tag, error) {
 		tags = append(tags, t)
 	}
 	return tags, rows.Err()
+}
+
+// UnknownTags returns the requested names that have no matching tag in the
+// Things database, preserving the caller's order and dropping duplicates.
+//
+// The Things URL scheme applies only tags that already exist and silently
+// ignores the rest, so callers use this to warn before a write. Matching is
+// case-insensitive: Things treats tag names that differ only in case as the
+// same tag, and a false "unknown tag" would be worse than a missed warning.
+func (d *DB) UnknownTags(names []string) ([]string, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+	tags, err := d.ListTags()
+	if err != nil {
+		return nil, err
+	}
+	existing := make(map[string]struct{}, len(tags))
+	for _, t := range tags {
+		existing[foldTag(t.Title)] = struct{}{}
+	}
+
+	var unknown []string
+	seen := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		key := foldTag(n)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		if _, ok := existing[key]; !ok {
+			unknown = append(unknown, n)
+		}
+	}
+	return unknown, nil
+}
+
+func foldTag(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
 }

--- a/internal/db/tags_test.go
+++ b/internal/db/tags_test.go
@@ -61,3 +61,52 @@ func TestListTagsEmpty(t *testing.T) {
 		t.Fatalf("expected empty, got %d", len(tags))
 	}
 }
+
+func TestUnknownTags(t *testing.T) {
+	d := newTestDB(t)
+	mustExec(t, d, `INSERT INTO TMTag (uuid, title, "index") VALUES
+		('t1', 'urgent', 0),
+		('t2', 'Work',   1)`)
+
+	cases := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{"allKnown", []string{"urgent", "Work"}, nil},
+		{"someUnknown", []string{"urgent", "cifas-auto-reject"}, []string{"cifas-auto-reject"}},
+		{"allUnknown", []string{"nope", "nada"}, []string{"nope", "nada"}},
+		{"caseInsensitive", []string{"URGENT", "work"}, nil},
+		{"dedupes", []string{"nope", "NOPE", "nope"}, []string{"nope"}},
+		{"trimsWhitespace", []string{"  urgent  "}, nil},
+		{"skipsEmpty", []string{"", "   "}, nil},
+		{"none", nil, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := d.UnknownTags(c.input)
+			if err != nil {
+				t.Fatalf("UnknownTags: %v", err)
+			}
+			if len(got) != len(c.want) {
+				t.Fatalf("UnknownTags(%v) = %v, want %v", c.input, got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("UnknownTags(%v)[%d] = %q, want %q", c.input, i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestUnknownTagsEmptyDatabase(t *testing.T) {
+	d := newTestDB(t)
+	got, err := d.UnknownTags([]string{"anything"})
+	if err != nil {
+		t.Fatalf("UnknownTags: %v", err)
+	}
+	if len(got) != 1 || got[0] != "anything" {
+		t.Errorf("got %v, want [anything]", got)
+	}
+}

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -46,10 +46,10 @@ things areas
 things tags
 things search <query>
 
-things add <title> [--notes --when --deadline --tags --checklist --project --heading --list]
-things project add <title> [--notes --when --deadline --tags --area --todos]
-things project edit <project> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --area --area-id --complete --cancel --duplicate --reveal]
-things edit <task> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --checklist --prepend-checklist --append-checklist --list --list-id --heading --heading-id --complete --cancel --duplicate --reveal]
+things add <title> [--notes --when --deadline --tags --checklist --project --heading --list --strict-tags]
+things project add <title> [--notes --when --deadline --tags --area --todos --strict-tags]
+things project edit <project> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --area --area-id --complete --cancel --duplicate --reveal --strict-tags]
+things edit <task> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --checklist --prepend-checklist --append-checklist --list --list-id --heading --heading-id --complete --cancel --duplicate --reveal --strict-tags]
 things complete <task>          # task or project; project completion asks to confirm
 things cancel <task>            # task or project; project cancellation asks to confirm
 things log                      # move Today → Logbook
@@ -60,7 +60,7 @@ things open [<ref>] [-p P | -a A | -t T | -q Q] [--filter T1,T2] [--background]
     # exactly one of <ref> / -p / -a / -t / -q is required
     # --filter narrows the opened list by tags; --background keeps focus elsewhere
 
-things import [--file F] [--reveal] < payload.json
+things import [--file F] [--reveal] [--strict-tags] < payload.json
     # batch create/update via the Things JSON URL scheme
     # payload is the array documented at culturedcode.com/things/support/articles/2803573/
 ```
@@ -75,6 +75,16 @@ on repeating to-dos and drops the request silently (…). Change it in the Thing
 ```
 
 There is no CLI workaround — the user has to make the change in the Things app. Every other attribute (`--title`, `--notes`, `--tags`, `--list`, …) edits normally.
+
+### Tags must already exist
+
+Things applies only tags that already exist and ignores the rest without saying so. Before any write that carries tags, the CLI checks them against the database and warns on stderr about ones it cannot find:
+
+```
+warning: these tags do not exist in Things and will be ignored: cifas-auto-reject
+```
+
+The write still goes ahead. Pass `--strict-tags` to fail before writing instead. There is no way to create a tag from the CLI — create it in Things first, then re-run.
 
 ### Task reference forms
 

--- a/internal/things/limits.go
+++ b/internal/things/limits.go
@@ -55,8 +55,7 @@ func validateTags(field, v string) error {
 	if v == "" {
 		return nil
 	}
-	for _, t := range strings.Split(v, ",") {
-		t = strings.TrimSpace(t)
+	for _, t := range SplitTags(v) {
 		if c := utf8.RuneCountInString(t); c > MaxStringLen {
 			return fmt.Errorf("%s: tag %q (%d characters) exceeds the %d-character limit", field, truncate(t), c, MaxStringLen)
 		}

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -63,6 +63,22 @@ func setNonEmpty(v url.Values, key, value string) {
 	}
 }
 
+// SplitTags splits the comma-separated tag syntax the Things URL scheme uses
+// into individual names, trimming surrounding whitespace and dropping empty
+// entries. Things has no escape for a comma inside a tag name.
+func SplitTags(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var tags []string
+	for _, t := range strings.Split(s, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			tags = append(tags, t)
+		}
+	}
+	return tags
+}
+
 // BuiltinLists are the navigable list IDs the Things URL scheme accepts
 // verbatim as `id=…`. Some (e.g. repeating, all-projects) have no direct
 // DB equivalent — they're app-side views only.

--- a/internal/things/urlscheme_test.go
+++ b/internal/things/urlscheme_test.go
@@ -713,3 +713,29 @@ func TestAddTaskCommandFails(t *testing.T) {
 		t.Errorf("error should mention URL scheme: %v", err)
 	}
 }
+
+func TestSplitTags(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"work", []string{"work"}},
+		{"work,urgent", []string{"work", "urgent"}},
+		{" work , urgent ", []string{"work", "urgent"}},
+		{"work,,urgent", []string{"work", "urgent"}},
+		{"two words,x", []string{"two words", "x"}},
+	}
+	for _, c := range cases {
+		got := SplitTags(c.in)
+		if len(got) != len(c.want) {
+			t.Fatalf("SplitTags(%q) = %v, want %v", c.in, got, c.want)
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("SplitTags(%q)[%d] = %q, want %q", c.in, i, got[i], c.want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Tags that don't exist in Things are no longer lost without a word.

The Things URL scheme applies only tags that already exist and ignores the rest — no error, no warning, exit 0. So `things add "x" --tags "Work,cifas-auto-reject"` created the task with `Work` and quietly dropped the other tag.

Every write that carries tags (`add`, `project add`, `edit`, `project edit`, `import`) now diffs the requested names against the tags in the read-only database before writing:

```
$ things add "Review the flags" --tags "Work,cifas-auto-reject"
warning: these tags do not exist in Things and will be ignored: cifas-auto-reject
warning: Things only applies tags that already exist — create them in Things first, or use --strict-tags to fail instead of dropping them
```

The write still goes ahead. The new `--strict-tags` flag turns that into a refusal, and nothing is written:

```
$ things add "Review the flags" --tags "Work,cifas-auto-reject" --strict-tags
Error: these tags do not exist in Things: cifas-auto-reject — create them in Things first, or drop --strict-tags to write anyway
```

Details worth knowing:

- Matching is case-insensitive, which is how Things treats tag names. A false "unknown tag" would be worse than a missed warning, since under `--strict-tags` it would block a write that would have worked.
- `things add` with no tags never opens the database, so it still works without a readable Things database. When there are tags and the database can't be read, `add` / `project add` skip the check with a warning; `--strict-tags` fails instead. `edit`, `project edit` and `import` need the database for other reasons and fail either way.
- For `import`, the payload is walked for `tags` and `add-tags` on every item, including items nested inside a project. A `tags` array entry is one tag name (commas and all); the single-string form is comma-split.

This is option (1) from #102. Option (2) — creating missing tags, via `things tag add` or a `--create-tags` flag using AppleScript — is **not** implemented here and remains open. The issue's acceptance criteria around a working way to create a tag are still outstanding; this PR documents the existing-tags-only behaviour in the README instead.

## Why

Silent data loss. Tagging a task from a project whose tag doesn't exist yet gives you a task without the tag and a shell prompt that looks like success. There's currently no way to create a tag from the CLI, so this is easy to hit and easy to miss.

## How tested

`make fmt`, `make lint` and `make test` all pass.

New tests:

- `internal/db` — `UnknownTags` over seeded `TMTag` rows: known/unknown mixes, case-insensitive matching, de-duplication, whitespace trimming, empty input, empty database.
- `internal/things` — `SplitTags` covering whitespace, empty entries and multi-word tags.
- `cmd/things` — `verifyTags` warning text and the strict error; the no-tags fast path proving the database isn't opened; the database-unavailable paths in both modes; `importTags` extraction across array, comma-string, `add-tags` and nested-item payloads; and end-to-end runs of `add`, `edit`, `project add`, `project edit` and `import` asserting that the strict path writes nothing (the stubbed `open`/`osascript` is never invoked) while the default path still writes.

`internal/skill/SKILL.md`, the README and the docs site page are updated for the new flag and the warning behaviour.

## Review

`/code-review --fix` found three things, all fixed in 1c29f9d: import payloads using `add-tags` skipped the check entirely; `tags` array entries were being comma-split, inventing unknown tags for names containing a comma; and the README overstated which commands skip the check when the database can't be read.

Closes #102
