### PR TITLE
fix: project, area, and tag filters under-report

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,28 @@ Filters:
 | `--to DATE` | Only tasks scheduled on or before the date |
 | `--include-completed` | On `today` only: also show completed/cancelled items Things hasn't logged out of Today yet |
 
-`-p`/`-a`/`-t` combine with any view. The date filters (`--on`, `--from`,
+`-p`/`-a`/`-t` name what to list, so on their own they cover every open
+task in the project, area, or tag — not just the ones scheduled for today.
+Name a view as well and the filter applies within that view, and the
+listing says which view it drew from:
+
+```sh
+things -p "Launch v2"                # every open task in the project
+things today -p "Launch v2"          # today's slice of it, labelled "view: today"
+things "Launch v2"                   # same as -p, project name as an argument
+```
+
+Tasks filed under a project heading count as part of the project, so they
+show up under `-p` and under the project's `-a` area, and carry the project
+name in `show` and JSON output.
+
+The date filters (`--on`, `--from`,
 `--to`) apply to date-filterable views — `today`, `upcoming`, `anytime`,
 `deadlines`, and project listings (`someday` items have no start date, so
 they can't be date-filtered) — and `--on` can't be combined with
-`--from`/`--to`. `--include-completed` applies to the `today` view only.
+`--from`/`--to`. `--include-completed` applies to the `today` view only, so
+with a filter it needs the view spelled out: `things today -p "Launch v2"
+--include-completed`.
 
 Examples:
 

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -146,7 +146,7 @@ func (c *ListCmd) Run(d *Deps) error {
 	// (including when a filter defaults today → project) rather than silently
 	// ignoring it, matching how --on/--from/--to reject views.
 	if c.IncludeCompleted && view != "today" {
-		return fmt.Errorf("--include-completed is only supported on the %q view", "today")
+		return fmt.Errorf("--include-completed is only supported on the %q view, not %q; name the view explicitly, e.g. `things today --project NAME`", "today", view)
 	}
 
 	filter := db.TaskFilter{

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -120,23 +120,31 @@ func (c *ListCmd) Run(d *Deps) error {
 	}
 
 	view := "today"
+	explicitView := false
 	project := c.Project
 	args := c.Args
 
 	if len(args) > 0 && db.ValidView(args[0]) {
 		view = args[0]
+		explicitView = true
 		args = args[1:]
 	}
 	if project == "" && len(args) > 0 {
 		project = strings.Join(args, " ")
-		if view == "today" {
-			view = "project"
-		}
+	}
+
+	// A filter names what to list, so on its own it covers every open task
+	// rather than the Today slice the bare `things` default would apply
+	// (issue #140). An explicit view still wins: `things today --project X`
+	// is today within X, and says so in the output.
+	filtered := project != "" || c.Area != "" || c.Tag != ""
+	if filtered && !explicitView {
+		view = "project"
 	}
 
 	// --include-completed only changes the today view. Reject it elsewhere
-	// (including when a trailing project name promotes today → project) rather
-	// than silently ignoring it, matching how --on/--from/--to reject views.
+	// (including when a filter defaults today → project) rather than silently
+	// ignoring it, matching how --on/--from/--to reject views.
 	if c.IncludeCompleted && view != "today" {
 		return fmt.Errorf("--include-completed is only supported on the %q view", "today")
 	}
@@ -156,7 +164,15 @@ func (c *ListCmd) Run(d *Deps) error {
 		return err
 	}
 	cacheTaskUUIDs(tasks)
-	return output.Print(d.Stdout, tasks, d.JSON)
+
+	// A filtered listing off a view is a slice of that view, not the whole
+	// project/area/tag — label it so the group header can't be read as the
+	// full set. The "project" view is that full set, so it needs no label.
+	viewLabel := ""
+	if filtered && view != "project" {
+		viewLabel = view
+	}
+	return output.PrintTaskList(d.Stdout, tasks, d.JSON, viewLabel)
 }
 
 func applyDateFilters(filter *db.TaskFilter, view, on, from, to string) error {

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"strings"
@@ -90,6 +92,21 @@ func seedFullDB(t *testing.T) *db.DB {
 		t.Fatalf("seed inbox task: %v", err)
 	}
 
+	// Heading in proj-1, plus an anytime task filed under it. The task has no
+	// project of its own and no start date, so it is outside the today view.
+	if _, err := sqlDB.Exec(
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, project, "index")
+		 VALUES ('head-1', 'Weekly', 2, 0, 0, 'proj-1', 2)`,
+	); err != nil {
+		t.Fatalf("seed heading: %v", err)
+	}
+	if _, err := sqlDB.Exec(
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, start, startBucket, heading, "index")
+		 VALUES ('task-3', 'Sweep floor', 0, 0, 0, 1, 0, 'head-1', 3)`,
+	); err != nil {
+		t.Fatalf("seed heading task: %v", err)
+	}
+
 	// Checklist item on task-1
 	if _, err := sqlDB.Exec(
 		`INSERT INTO TMChecklistItem (uuid, title, status, "index", task)
@@ -102,6 +119,14 @@ func seedFullDB(t *testing.T) *db.DB {
 }
 
 func runWith(t *testing.T, database *db.DB, args ...string) error {
+	t.Helper()
+	_, err := runOut(t, database, args...)
+	return err
+}
+
+// runOut parses args, runs the command against database, and returns whatever
+// the handler wrote to Deps.Stdout.
+func runOut(t *testing.T, database *db.DB, args ...string) (string, error) {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
 
@@ -119,12 +144,13 @@ func runWith(t *testing.T, database *db.DB, args ...string) error {
 	if err != nil {
 		t.Fatalf("parse %v: %v", args, err)
 	}
-	deps := &Deps{DB: database, JSON: cli.JSON, Stdout: io.Discard}
+	var buf bytes.Buffer
+	deps := &Deps{DB: database, JSON: cli.JSON, Stdout: &buf}
 	var runErr error
 	withSilentStdout(t, func() {
 		runErr = ctx.Run(deps)
 	})
-	return runErr
+	return buf.String(), runErr
 }
 
 func TestRunDispatchReadOnly(t *testing.T) {
@@ -212,10 +238,15 @@ func TestRunListIncludeCompletedRejectsView(t *testing.T) {
 		t.Fatalf("inbox: expected view-rejection error, got: %v", err)
 	}
 
-	// Trailing project name promotes today → project, which also rejects.
-	err = runWith(t, database, "list", "today", "Chores", "--include-completed")
+	// A filter with no explicit view lists the whole project, which also rejects.
+	err = runWith(t, database, "list", "Chores", "--include-completed")
 	if err == nil || !strings.Contains(err.Error(), "only supported on the \"today\" view") {
-		t.Fatalf("promoted project: expected view-rejection error, got: %v", err)
+		t.Fatalf("project filter: expected view-rejection error, got: %v", err)
+	}
+
+	// An explicit today view keeps the flag valid alongside a filter.
+	if err := runWith(t, database, "list", "today", "Chores", "--include-completed"); err != nil {
+		t.Fatalf("today + project filter: %v", err)
 	}
 }
 
@@ -369,5 +400,118 @@ func TestRunListThenResolveByIndex(t *testing.T) {
 	}
 	if len(got) == 0 {
 		t.Fatal("expected cached uuids")
+	}
+}
+
+// A filter with no explicit view lists the target's whole open set rather than
+// its Today slice — task-3 is an anytime task under a heading in Chores, so it
+// only shows up if both the default view and the heading join are right
+// (issues #139, #140).
+func TestRunListFilterDefaultsToAllOpenTasks(t *testing.T) {
+	database := seedFullDB(t)
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"project flag", []string{"list", "--project", "Chores"}},
+		{"project arg", []string{"list", "Chores"}},
+		{"area flag", []string{"list", "--area", "Home"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := runWith(t, database, tc.args...); err != nil {
+				t.Fatalf("run %v: %v", tc.args, err)
+			}
+			got, err := cache.ReadLastList()
+			if err != nil {
+				t.Fatalf("ReadLastList: %v", err)
+			}
+			want := map[string]bool{"task-1": true, "task-3": true}
+			if len(got) != len(want) {
+				t.Fatalf("got %v, want task-1 and task-3", got)
+			}
+			for _, uuid := range got {
+				if !want[uuid] {
+					t.Errorf("unexpected uuid %q in %v", uuid, got)
+				}
+			}
+		})
+	}
+}
+
+// An explicit view still wins over the filter default, and the listing says
+// which view it drew from so a short list can't read as the whole project
+// (issue #140).
+func TestRunListLabelsExplicitViewWhenFiltered(t *testing.T) {
+	database := seedFullDB(t)
+
+	out, err := runOut(t, database, "list", "today", "--project", "Chores")
+	if err != nil {
+		t.Fatalf("run list today --project Chores: %v", err)
+	}
+	if !strings.Contains(out, "view: today") {
+		t.Errorf("expected the today view labelled, got:\n%s", out)
+	}
+	if strings.Contains(out, "Sweep floor") {
+		t.Errorf("explicit today view should not list the anytime task, got:\n%s", out)
+	}
+
+	// The unfiltered default and the full-project listing carry no label.
+	out, err = runOut(t, database, "list", "--project", "Chores")
+	if err != nil {
+		t.Fatalf("run list --project Chores: %v", err)
+	}
+	if strings.Contains(out, "view:") {
+		t.Errorf("unlabelled listing expected, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Sweep floor") {
+		t.Errorf("expected the heading-nested task, got:\n%s", out)
+	}
+
+	out, err = runOut(t, database, "list", "today")
+	if err != nil {
+		t.Fatalf("run list today: %v", err)
+	}
+	if strings.Contains(out, "view:") {
+		t.Errorf("unfiltered today needs no label, got:\n%s", out)
+	}
+}
+
+// JSON output stays a bare task array — the view label is human output only.
+func TestRunListJSONIsUnlabelled(t *testing.T) {
+	database := seedFullDB(t)
+
+	out, err := runOut(t, database, "--json", "list", "today", "--project", "Chores")
+	if err != nil {
+		t.Fatalf("run --json list today --project Chores: %v", err)
+	}
+	var tasks []model.Task
+	if err := json.Unmarshal([]byte(out), &tasks); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if len(tasks) != 1 || tasks[0].UUID != "task-1" {
+		t.Errorf("got %d tasks, want [task-1]", len(tasks))
+	}
+}
+
+// A heading-nested task reports the project it sits in, so `things show` and
+// listings don't present it as a standalone task (issue #139).
+func TestRunListHeadingTaskShowsProject(t *testing.T) {
+	database := seedFullDB(t)
+
+	out, err := runOut(t, database, "--json", "show", "task-3")
+	if err != nil {
+		t.Fatalf("run show task-3: %v", err)
+	}
+	var task model.Task
+	if err := json.Unmarshal([]byte(out), &task); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if task.ProjectTitle != "Chores" {
+		t.Errorf("projectTitle = %q, want Chores", task.ProjectTitle)
+	}
+	if task.HeadingTitle != "Weekly" {
+		t.Errorf("headingTitle = %q, want Weekly", task.HeadingTitle)
 	}
 }

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -19,13 +19,20 @@ things <view>          # shortcut: things inbox, things today, etc.
 Available views: `today`, `inbox`, `upcoming`, `anytime`, `someday`,
 `logbook`, `trash`, `deadlines`.
 
-Filter any list with `-p/--project`, `-a/--area`, or `-t/--tag`:
+Filter any list with `-p/--project`, `-a/--area`, or `-t/--tag`. On their
+own the filters cover every open task in the project, area, or tag; add a
+view and the filter applies within it, with the view named in the output:
 
 ```sh
+things -p "Launch v2"                # every open task in the project
+things today -p "Launch v2"          # today's slice of it, labelled "view: today"
 things upcoming -t urgent
 things anytime --area "Side projects"
 things --json list today | jq '.[] | .title'
 ```
+
+Tasks filed under a project heading belong to that project, so they appear
+under `-p` and under the project's area.
 
 `things projects`, `things areas`, and `things tags` list the
 collections themselves. `things projects` accepts `--area` and

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -40,6 +40,13 @@ func DateFilterableView(view string) bool {
 	return dateFilterableViews[view]
 }
 
+// baseTaskQuery selects a task with its project, heading, area and tags.
+//
+// A task filed under a project heading carries t.heading and leaves t.project
+// NULL — the heading row (a TMTask) holds the project. Resolving p through
+// COALESCE(t.project, h.project) therefore folds heading-nested tasks into
+// their project, so they carry a project title in output and match the
+// --project and --area filters (issue #139).
 const baseTaskQuery = `
 SELECT
 	t.uuid,
@@ -64,8 +71,8 @@ SELECT
 	COALESCE(t."index", 0),
 	COALESCE(t.todayIndex, 0)
 FROM TMTask t
-LEFT JOIN TMTask p ON t.project = p.uuid
 LEFT JOIN TMTask h ON t.heading = h.uuid
+LEFT JOIN TMTask p ON p.uuid = COALESCE(t.project, h.project)
 LEFT JOIN TMArea a ON t.area = a.uuid
 LEFT JOIN TMArea pa ON p.area = pa.uuid
 LEFT JOIN TMTaskTag tt ON tt.tasks = t.uuid
@@ -149,7 +156,7 @@ var viewOrderBy = map[string]string{
 	// area come before area-only items in higher-index areas, matching the
 	// Things app. Within each group, sort by status (open before completed),
 	// then todayIndexReferenceDate DESC, then todayIndex ASC.
-	"today":   "ORDER BY CASE WHEN t.project IS NULL AND t.area IS NULL THEN 0 ELSE 1 END, COALESCE(a.\"index\", pa.\"index\", 0), COALESCE(p.\"index\", 0), t.status ASC, t.todayIndexReferenceDate DESC, t.todayIndex ASC",
+	"today":   "ORDER BY CASE WHEN p.uuid IS NULL AND t.area IS NULL THEN 0 ELSE 1 END, COALESCE(a.\"index\", pa.\"index\", 0), COALESCE(p.\"index\", 0), t.status ASC, t.todayIndexReferenceDate DESC, t.todayIndex ASC",
 	"project": "ORDER BY t.start ASC, t.\"index\" ASC",
 }
 

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -144,7 +144,10 @@ var viewFilters = map[string]string{
 	"logbook":   "t.status = 3 AND t.trashed = 0 AND t.type = 0",
 	"trash":     "t.trashed = 1 AND t.type = 0",
 	"deadlines": "t.deadline IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
-	"project":   "t.status = 0 AND t.trashed = 0 AND t.type = 0",
+	// The catch-all open set: also the default view for a bare --project/
+	// --area/--tag filter, so it has to exclude tasks living in a trashed
+	// project the way the today view does.
+	"project": "t.status = 0 AND t.trashed = 0 AND t.type = 0 AND COALESCE(p.trashed, 0) = 0",
 }
 
 var viewOrderBy = map[string]string{
@@ -156,8 +159,13 @@ var viewOrderBy = map[string]string{
 	// area come before area-only items in higher-index areas, matching the
 	// Things app. Within each group, sort by status (open before completed),
 	// then todayIndexReferenceDate DESC, then todayIndex ASC.
-	"today":   "ORDER BY CASE WHEN p.uuid IS NULL AND t.area IS NULL THEN 0 ELSE 1 END, COALESCE(a.\"index\", pa.\"index\", 0), COALESCE(p.\"index\", 0), t.status ASC, t.todayIndexReferenceDate DESC, t.todayIndex ASC",
-	"project": "ORDER BY t.start ASC, t.\"index\" ASC",
+	"today": "ORDER BY CASE WHEN p.uuid IS NULL AND t.area IS NULL THEN 0 ELSE 1 END, COALESCE(a.\"index\", pa.\"index\", 0), COALESCE(p.\"index\", 0), t.status ASC, t.todayIndexReferenceDate DESC, t.todayIndex ASC",
+	// Project view: a single-project listing keeps its start/index order (the
+	// area and project keys are constant across it), while a filter that spans
+	// projects — `things --area X`, `things --tag y` — groups by area then
+	// project so the rendered group headers stay contiguous instead of
+	// repeating as rows interleave by index.
+	"project": "ORDER BY COALESCE(a.\"index\", pa.\"index\", 0), COALESCE(p.\"index\", 0), t.start ASC, t.\"index\" ASC",
 }
 
 func ValidView(name string) bool {

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -662,3 +662,61 @@ func TestListTasksTagFilterIncludesHeadingTasks(t *testing.T) {
 		t.Errorf("tag filter: got %v, want [t-nested]", uuidsOf(got))
 	}
 }
+
+// The project view is the default for a bare --project/--area/--tag filter, so
+// it must hide tasks living in a trashed project the way the today view does.
+func TestListTasksProjectViewExcludesTrashedProject(t *testing.T) {
+	d := newTestDB(t)
+
+	mustExec(t, d, `INSERT INTO TMTag (uuid, title, "index") VALUES ('tg-u', 'urgent', 1)`)
+	mustExec(t, d, `INSERT INTO TMTask (uuid, title, type, status, trashed, "index") VALUES
+		('proj-gone', 'Trashed project', 1, 0, 1, 1)`)
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, project, "index") VALUES
+		('t-orphan', 'Child of trashed', 0, 0, 0, 1, 0, 'proj-gone', 1)`)
+	mustExec(t, d, `INSERT INTO TMTaskTag (tasks, tags) VALUES ('t-orphan', 'tg-u')`)
+
+	got, err := d.ListTasks("project", TaskFilter{Tag: "urgent"})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want no tasks from a trashed project", uuidsOf(got))
+	}
+}
+
+// A filter spanning several projects must keep each project's tasks contiguous,
+// otherwise the rendered group headers repeat as rows interleave by index.
+func TestListTasksProjectViewGroupsByProject(t *testing.T) {
+	d := newTestDB(t)
+
+	mustExec(t, d, `INSERT INTO TMArea (uuid, title, visible, "index") VALUES ('ar-h', 'Home', 1, 1)`)
+	mustExec(t, d, `INSERT INTO TMTask (uuid, title, type, status, trashed, area, "index") VALUES
+		('proj-a', 'Project A', 1, 0, 0, 'ar-h', 1),
+		('proj-b', 'Project B', 1, 0, 0, 'ar-h', 2)`)
+	// Interleaved task indexes: index order alone would alternate A, B, A, B.
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, project, "index") VALUES
+		('a1', 'A one', 0, 0, 0, 1, 0, 'proj-a', 1),
+		('b1', 'B one', 0, 0, 0, 1, 0, 'proj-b', 2),
+		('a2', 'A two', 0, 0, 0, 1, 0, 'proj-a', 3),
+		('b2', 'B two', 0, 0, 0, 1, 0, 'proj-b', 4)`)
+
+	got, err := d.ListTasks("project", TaskFilter{Area: "Home"})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	var order []string
+	for _, task := range got {
+		order = append(order, task.UUID)
+	}
+	want := []string{"a1", "a2", "b1", "b2"}
+	if len(order) != len(want) {
+		t.Fatalf("got %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("got %v, want %v", order, want)
+		}
+	}
+}

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -543,3 +543,122 @@ func sameSet(a, b []string) bool {
 	}
 	return true
 }
+
+// seedHeadingTasks builds a project with a heading, holding one task directly
+// on the project and one under the heading. The heading-nested task leaves
+// t.project NULL, as Things does — the heading row carries the project.
+func seedHeadingTasks(t *testing.T, d *DB) {
+	t.Helper()
+
+	mustExec(t, d, `INSERT INTO TMArea (uuid, title, visible, "index") VALUES
+		('area-launch', 'Launch', 1, 1)`)
+	mustExec(t, d, `INSERT INTO TMTask (uuid, title, type, status, trashed, area, "index") VALUES
+		('proj-h', 'Ship v2', 1, 0, 0, 'area-launch', 1)`)
+	// Heading (type=2) belonging to proj-h.
+	mustExec(t, d, `INSERT INTO TMTask (uuid, title, type, status, trashed, project, "index") VALUES
+		('head-1', 'Phase one', 2, 0, 0, 'proj-h', 2)`)
+	mustExec(t, d, `INSERT INTO TMTag (uuid, title, "index") VALUES ('tg-ship', 'ship', 1)`)
+
+	today := int64(model.ThingsDateFromTime(time.Now()))
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, startDate, project, heading, "index") VALUES
+		('t-direct',  'Direct task',  0, 0, 0, 1, 0, ?,    'proj-h', NULL,     3),
+		('t-nested',  'Nested task',  0, 0, 0, 1, 0, NULL, NULL,     'head-1', 4),
+		('t-loose',   'Loose task',   0, 0, 0, 1, 0, NULL, NULL,     NULL,     5)`,
+		today)
+	mustExec(t, d, `INSERT INTO TMTaskTag (tasks, tags) VALUES ('t-nested', 'tg-ship')`)
+}
+
+// Tasks filed under a project heading have no t.project of their own; the
+// project filter has to reach it through the heading row (issue #139).
+func TestListTasksProjectFilterIncludesHeadingTasks(t *testing.T) {
+	d := newTestDB(t)
+	seedHeadingTasks(t, d)
+
+	for _, filter := range []string{"proj-h", "Ship v2"} {
+		got, err := d.ListTasks("project", TaskFilter{Project: filter})
+		if err != nil {
+			t.Fatalf("ListTasks(project, %q): %v", filter, err)
+		}
+		if !sameSet(uuidsOf(got), []string{"t-direct", "t-nested"}) {
+			t.Errorf("project filter %q: got %v, want [t-direct t-nested]", filter, uuidsOf(got))
+		}
+	}
+}
+
+// The area comes from the project, so a heading-nested task has to inherit it
+// through the heading too.
+func TestListTasksAreaFilterIncludesHeadingTasks(t *testing.T) {
+	d := newTestDB(t)
+	seedHeadingTasks(t, d)
+
+	got, err := d.ListTasks("project", TaskFilter{Area: "Launch"})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if !sameSet(uuidsOf(got), []string{"t-direct", "t-nested"}) {
+		t.Errorf("area filter: got %v, want [t-direct t-nested]", uuidsOf(got))
+	}
+}
+
+// A heading-nested task reports its project in output, so it can't be mistaken
+// for a standalone task (issue #139).
+func TestHeadingTaskCarriesProject(t *testing.T) {
+	d := newTestDB(t)
+	seedHeadingTasks(t, d)
+
+	task, err := d.GetTaskByUUID("t-nested")
+	if err != nil {
+		t.Fatalf("GetTaskByUUID: %v", err)
+	}
+	if task == nil {
+		t.Fatal("t-nested not found")
+	}
+	if task.ProjectUUID != "proj-h" || task.ProjectTitle != "Ship v2" {
+		t.Errorf("project = %q/%q, want proj-h/Ship v2", task.ProjectUUID, task.ProjectTitle)
+	}
+	if task.HeadingUUID != "head-1" || task.HeadingTitle != "Phase one" {
+		t.Errorf("heading = %q/%q, want head-1/Phase one", task.HeadingUUID, task.HeadingTitle)
+	}
+	if task.AreaUUID != "area-launch" || task.AreaTitle != "Launch" {
+		t.Errorf("area = %q/%q, want area-launch/Launch", task.AreaUUID, task.AreaTitle)
+	}
+}
+
+// The project view is the whole open set, so a project filter run against it
+// returns tasks the today view would have hidden (issue #140).
+func TestListTasksProjectViewIsNotATodaySlice(t *testing.T) {
+	d := newTestDB(t)
+	seedHeadingTasks(t, d)
+
+	today, err := d.ListTasks("today", TaskFilter{Project: "Ship v2"})
+	if err != nil {
+		t.Fatalf("ListTasks(today): %v", err)
+	}
+	if !sameSet(uuidsOf(today), []string{"t-direct"}) {
+		t.Fatalf("today slice: got %v, want [t-direct]", uuidsOf(today))
+	}
+
+	all, err := d.ListTasks("project", TaskFilter{Project: "Ship v2"})
+	if err != nil {
+		t.Fatalf("ListTasks(project): %v", err)
+	}
+	if !sameSet(uuidsOf(all), []string{"t-direct", "t-nested"}) {
+		t.Errorf("project view: got %v, want [t-direct t-nested]", uuidsOf(all))
+	}
+}
+
+// Tags live on the task itself, but the tag filter still has to work on a
+// heading-nested task now that the project join reaches through the heading.
+func TestListTasksTagFilterIncludesHeadingTasks(t *testing.T) {
+	d := newTestDB(t)
+	seedHeadingTasks(t, d)
+
+	got, err := d.ListTasks("project", TaskFilter{Tag: "ship"})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if !sameSet(uuidsOf(got), []string{"t-nested"}) {
+		t.Errorf("tag filter: got %v, want [t-nested]", uuidsOf(got))
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -34,6 +34,21 @@ func Print(w io.Writer, v any, asJSON bool) error {
 	}
 }
 
+// PrintTaskList renders a task listing. When view is non-empty it prefixes a
+// line naming the view the listing was drawn from, so a filtered slice of a
+// view is not mistaken for the filter target's full contents (issue #140).
+// JSON output is the plain task array either way.
+func PrintTaskList(w io.Writer, tasks []model.Task, asJSON bool, view string) error {
+	if asJSON {
+		return printJSON(w, tasks)
+	}
+	tw := newWriter(w)
+	if view != "" {
+		fmt.Fprintf(tw, "    %s\n", dimStyle.Render("view: "+view))
+	}
+	return printTasks(tw, tasks)
+}
+
 func PrintTaskWithChecklist(w io.Writer, t *model.Task, items []model.ChecklistItem, asJSON bool) error {
 	if asJSON {
 		type taskWithChecklist struct {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -305,3 +305,56 @@ func TestProjectIconBuckets(t *testing.T) {
 		}
 	}
 }
+
+func TestPrintTaskListViewLabel(t *testing.T) {
+	tasks := []model.Task{{
+		UUID: "u1", Title: "Buy milk", Status: model.StatusOpen,
+		ProjectUUID: "p1", ProjectTitle: "Chores",
+	}}
+
+	var labelled bytes.Buffer
+	if err := PrintTaskList(&labelled, tasks, false, "today"); err != nil {
+		t.Fatalf("PrintTaskList: %v", err)
+	}
+	out := labelled.String()
+	if !strings.Contains(out, "view: today") {
+		t.Errorf("missing view label:\n%s", out)
+	}
+	if !strings.Contains(out, "Chores") || !strings.Contains(out, "Buy milk") {
+		t.Errorf("missing task rows:\n%s", out)
+	}
+
+	var plain bytes.Buffer
+	if err := PrintTaskList(&plain, tasks, false, ""); err != nil {
+		t.Fatalf("PrintTaskList: %v", err)
+	}
+	if strings.Contains(plain.String(), "view:") {
+		t.Errorf("unexpected view label:\n%s", plain.String())
+	}
+
+	// An empty listing still says which view it came from.
+	var empty bytes.Buffer
+	if err := PrintTaskList(&empty, nil, false, "today"); err != nil {
+		t.Fatalf("PrintTaskList: %v", err)
+	}
+	if !strings.Contains(empty.String(), "view: today") {
+		t.Errorf("empty listing lost its label:\n%s", empty.String())
+	}
+}
+
+// The view label is human output only — JSON stays a bare task array so
+// existing consumers keep parsing it.
+func TestPrintTaskListJSONIgnoresViewLabel(t *testing.T) {
+	tasks := []model.Task{{UUID: "u1", Title: "Buy milk", Status: model.StatusOpen}}
+	var buf bytes.Buffer
+	if err := PrintTaskList(&buf, tasks, true, "today"); err != nil {
+		t.Fatalf("PrintTaskList: %v", err)
+	}
+	var got []model.Task
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", buf.String(), err)
+	}
+	if len(got) != 1 || got[0].UUID != "u1" {
+		t.Errorf("got %+v, want one task u1", got)
+	}
+}

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -23,6 +23,12 @@ Human output is styled with colors and aligned columns. Color auto-disables when
 things list [view] [--project P] [--area A] [--tag T] [--on D | --from D --to D] [--include-completed]
     # views: today, inbox, upcoming, anytime, someday, logbook, trash, deadlines
     # shortcut: `things today`, `things inbox`, etc.
+    # No view: bare `things` is today, but --project/--area/--tag on their own
+    # list every open task in that project/area/tag. Name a view to scope the
+    # filter to it (`things today --project X`); human output then prints a
+    # `view: <name>` line so a slice isn't read as the whole project.
+    # Tasks under a project heading belong to that project — they match
+    # --project and the project's --area, and report projectTitle.
     # --on / --from / --to take YYYY-MM-DD (or RFC3339). They filter startDate
     # on most views and `deadline` on the `deadlines` view. Not supported on
     # inbox/trash/logbook/someday (someday items have no start date).


### PR DESCRIPTION
Two separate causes behind the same symptom: a filter names a project, area, or tag and gets back fewer tasks than are really there.

Closes #139
Closes #140

## What changed

**Heading-nested tasks belong to their project (#139).** A task filed under a project heading leaves `TMTask.project` NULL — the heading row holds the project — so the project join never matched it. Those tasks dropped out of any project listing, reported no project of their own, and inherited none of the project's area. The join now resolves the project through `COALESCE(t.project, h.project)`, which fixes the `--project` filter, the `--area` filter (area is inherited from the project), and the project shown by `show` and JSON output.

**Filters no longer inherit the Today view (#140).** `things list --project X` defaulted to the today view and applied the filter on top of it, so it returned the project's Today slice under a header that read as the whole project. A filter now names what to list: with no view given, `--project`/`--area`/`--tag` cover every open task in that project, area, or tag. An explicit view still wins, and a filtered listing drawn off a view prints a `view: <name>` line so a slice cannot be mistaken for the full set. JSON output is unchanged — still a bare task array.

Two consequences of the project view becoming the default for a bare filter, both handled here:

- It gained the trashed-project guard the today view already had. Things does not cascade `trashed` onto a project's children, so without it a filter would list tasks out of a trashed project — three such tasks exist in the database this was tested against.
- Its ordering now groups by area then project. Ordering by start and index alone was fine while the view only ever served one project; a filter spanning projects interleaved them and the rendered group headers repeated. A single-project listing is unaffected, because both new keys are constant across it.

`--include-completed` stays today-only, so a filtered listing that wants it has to name the view: `things today --project X --include-completed`. That case previously worked by accident and now errors; the error names the view it landed on and shows the fix.

## Why

From #140: a bulk reorganisation was planned against a reported 8 open tasks across two projects when there were 59. The wrong answer is plausible — a short list from a named project looks like a tidy project, not a broken query.

## How tested

`make fmt`, `make lint`, and `make test` pass.

New tests:

- `internal/db` — project and area filters match a heading-nested task; a heading-nested task carries its project, heading, and inherited area; the project view returns tasks the today view hides; the project view excludes tasks in a trashed project; a cross-project filter returns each project's tasks contiguously.
- `cmd/things` — a filter with no view returns the whole open set (flag, positional, and area forms); an explicit view is honoured and labelled while the unfiltered default is not; JSON stays unlabelled; a heading-nested task reports its project through `show`.
- `internal/output` — `PrintTaskList` labels the view when given one, including on an empty listing, and never in JSON.

Checked against a real Things database: `--tag AFC` went from 0 to 15 results, `--area LHV` from 0 to 91, and a heading-nested task that previously reported no project now shows `Raspberry Pi` / `Personal`. Unfiltered views are byte-identical apart from the project and area now populated on heading-nested tasks.

## Docs

README, the site command reference, and the bundled skill all describe how view defaults interact with the filter flags, and that heading-nested tasks count as part of their project.