### PR TITLE
fix: refuse writes Things drops on repeating items, and verify status changes landed

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ stay untouched. An empty value clears the field (e.g. `--deadline ""`).
 | `--heading-id UUID` | ✓ | — | Set heading within project by UUID |
 | `--area NAME` | — | ✓ | Move project to area by name |
 | `--area-id UUID` | — | ✓ | Move project to area by UUID |
-| `--complete` | ✓ | ✓ | Mark as completed |
-| `--cancel` | ✓ | ✓ | Mark as canceled |
+| `--complete` | ✓ | ✓ | Mark as completed (not with `--cancel`) |
+| `--cancel` | ✓ | ✓ | Mark as canceled (not with `--complete`) |
 | `--duplicate` | ✓ | ✓ | Duplicate before applying edits |
 | `--reveal` | ✓ | ✓ | Reveal in Things after editing |
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ in follow-up commands like `show`, `edit`, `complete`, and `cancel`.
 | --- | --- | --- |
 | `-j, --json` | Output as JSON instead of plain text | `false` |
 | `--db PATH` | Override the Things3 SQLite database path | auto-detected |
+| `--no-verify` | Skip the read-back that confirms a `complete`/`cancel` actually landed | `false` |
 | `-v, --version` | Print version, commit, and build date and exit (same as `things version`) | — |
 
 ### Listing tasks
@@ -175,6 +176,11 @@ Checklist:
   [ ] Tag and push
 ```
 
+`things show` prints a `Repeats:` line for repeating to-dos and projects, and
+JSON output carries `"repeating": true` for them (the field is omitted
+otherwise). Things blocks several kinds of edit on those — see the note under
+[Editing](#editing-tasks-and-projects).
+
 `things projects` renders a one-line-per-project list; the leading glyph
 shows completion progress (`○` empty, `◔ ◑ ◕` partial, `●` done, `◌`
 cancelled):
@@ -249,6 +255,13 @@ stay untouched. An empty value clears the field (e.g. `--deadline ""`).
 | `--duplicate` | ✓ | ✓ | Duplicate before applying edits |
 | `--reveal` | ✓ | ✓ | Reveal in Things after editing |
 
+> **Repeating items:** Things refuses `--when`, `--deadline`, `--complete`,
+> `--cancel`, and `--duplicate` on repeating to-dos and projects, and drops the
+> request silently instead of reporting an error
+> ([docs](https://culturedcode.com/things/support/articles/2803573/)). The CLI
+> checks first and exits non-zero with an explanation. Every other flag works
+> normally; the restricted changes have to be made in the Things app.
+
 Examples:
 
 ```sh
@@ -274,6 +287,22 @@ things complete 3
 things cancel "Old idea"
 things log
 ```
+
+After a `complete` or `cancel` the CLI reads the item back from the database
+and exits non-zero if the status did not change. Things has no callback for
+writes, so without this check a request it silently dropped is
+indistinguishable from one it applied. Repeating items are refused up front
+(see the note under [Editing](#editing-tasks-and-projects)); the read-back
+catches anything else — for example Things not running.
+
+```text
+$ things cancel W1gBDJPFpwUQrdP5Am5K7J
+Error: status change did not apply: "Renew insurance" (W1gBDJPFpwUQrdP5Am5K7J) is still open after 10s. Things accepted the command and then dropped it silently — check that Things3 is running, or make the change in the app
+$ echo $?
+1
+```
+
+Pass `--no-verify` to skip the check when you do not want to wait for it.
 
 ### Revealing items in Things3
 
@@ -446,6 +475,11 @@ embedded in the binary — so a plain `things` upgrade refreshes it; re-run
   URL schemes for creating and editing tasks, and through AppleScript for
   completing and cancelling them. This is the same interface Things exposes
   to Shortcuts and automation tools.
+- **Write confirmation**: `complete` and `cancel` poll the database after
+  writing until the status changes, up to 10 seconds, and fail if it never
+  does. Repeating items — which Things refuses to complete, cancel,
+  reschedule, or duplicate — are detected from the recurrence rule in the
+  database and rejected before any write is issued.
 - **Task resolution** accepts a UUID, a title (with interactive
   disambiguation when multiple tasks match) or a numeric index into the last
   listing.

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -35,6 +35,8 @@ type CLI struct {
 	DB      string           `help:"Override database path." type:"existingfile"`
 	Version kong.VersionFlag `help:"Print version and exit." short:"v"`
 
+	NoVerify bool `help:"Skip the read-back that confirms a complete/cancel actually landed." name:"no-verify" default:"false"`
+
 	List     ListCmd     `cmd:"" help:"List tasks (today,inbox,upcoming,anytime,someday,logbook,trash,deadlines). Use as: things today, things inbox, etc." default:"withargs"`
 	Projects ProjectsCmd `cmd:"" help:"List projects."`
 	Areas    AreasCmd    `cmd:"" help:"List areas."`
@@ -63,6 +65,9 @@ type Deps struct {
 	DBPath string
 	JSON   bool
 	Stdout io.Writer
+
+	// NoVerify skips the post-write read-back on complete/cancel.
+	NoVerify bool
 }
 
 // Database returns the lazily-opened DB. Subsequent calls return the same
@@ -372,25 +377,32 @@ func (c *ProjectEditCmd) Run(d *Deps) error {
 		return fmt.Errorf("not a project: %s", project.Title)
 	}
 
+	if err := checkRepeating(project, restrictedEdits(c.When, c.Deadline, c.Complete, c.Cancel, c.Duplicate)); err != nil {
+		return err
+	}
+
 	token, _ := database.GetAuthToken()
-	return things.UpdateProject(things.UpdateProjectParams{
-		ID:           project.UUID,
-		AuthToken:    token,
-		Title:        c.Title,
-		Notes:        c.Notes,
-		PrependNotes: c.PrependNotes,
-		AppendNotes:  c.AppendNotes,
-		When:         c.When,
-		Deadline:     c.Deadline,
-		Tags:         c.Tags,
-		AddTags:      c.AddTags,
-		Area:         c.Area,
-		AreaID:       c.AreaID,
-		Completed:    c.Complete,
-		Canceled:     c.Cancel,
-		Duplicate:    c.Duplicate,
-		Reveal:       c.Reveal,
-	})
+	update := func() error {
+		return things.UpdateProject(things.UpdateProjectParams{
+			ID:           project.UUID,
+			AuthToken:    token,
+			Title:        c.Title,
+			Notes:        c.Notes,
+			PrependNotes: c.PrependNotes,
+			AppendNotes:  c.AppendNotes,
+			When:         c.When,
+			Deadline:     c.Deadline,
+			Tags:         c.Tags,
+			AddTags:      c.AddTags,
+			Area:         c.Area,
+			AreaID:       c.AreaID,
+			Completed:    c.Complete,
+			Canceled:     c.Cancel,
+			Duplicate:    c.Duplicate,
+			Reveal:       c.Reveal,
+		})
+	}
+	return applyEditStatusWrite(d, database, project, c.Complete, c.Cancel, c.Duplicate, update)
 }
 
 type EditCmd struct {
@@ -433,30 +445,37 @@ func (c *EditCmd) Run(d *Deps) error {
 		return err
 	}
 
+	if err := checkRepeating(task, restrictedEdits(c.When, c.Deadline, c.Complete, c.Cancel, c.Duplicate)); err != nil {
+		return err
+	}
+
 	token, _ := database.GetAuthToken()
-	return things.UpdateTask(things.UpdateParams{
-		ID:               task.UUID,
-		AuthToken:        token,
-		Title:            c.Title,
-		Notes:            c.Notes,
-		PrependNotes:     c.PrependNotes,
-		AppendNotes:      c.AppendNotes,
-		When:             c.When,
-		Deadline:         c.Deadline,
-		Tags:             c.Tags,
-		AddTags:          c.AddTags,
-		Checklist:        expandNewlinesPtr(c.Checklist),
-		PrependChecklist: expandNewlinesPtr(c.PrependChecklist),
-		AppendChecklist:  expandNewlinesPtr(c.AppendChecklist),
-		List:             c.List,
-		ListID:           c.ListID,
-		Heading:          c.Heading,
-		HeadingID:        c.HeadingID,
-		Completed:        c.Complete,
-		Canceled:         c.Cancel,
-		Duplicate:        c.Duplicate,
-		Reveal:           c.Reveal,
-	})
+	update := func() error {
+		return things.UpdateTask(things.UpdateParams{
+			ID:               task.UUID,
+			AuthToken:        token,
+			Title:            c.Title,
+			Notes:            c.Notes,
+			PrependNotes:     c.PrependNotes,
+			AppendNotes:      c.AppendNotes,
+			When:             c.When,
+			Deadline:         c.Deadline,
+			Tags:             c.Tags,
+			AddTags:          c.AddTags,
+			Checklist:        expandNewlinesPtr(c.Checklist),
+			PrependChecklist: expandNewlinesPtr(c.PrependChecklist),
+			AppendChecklist:  expandNewlinesPtr(c.AppendChecklist),
+			List:             c.List,
+			ListID:           c.ListID,
+			Heading:          c.Heading,
+			HeadingID:        c.HeadingID,
+			Completed:        c.Complete,
+			Canceled:         c.Cancel,
+			Duplicate:        c.Duplicate,
+			Reveal:           c.Reveal,
+		})
+	}
+	return applyEditStatusWrite(d, database, task, c.Complete, c.Cancel, c.Duplicate, update)
 }
 
 type CompleteCmd struct {
@@ -472,13 +491,20 @@ func (c *CompleteCmd) Run(d *Deps) error {
 	if err != nil {
 		return err
 	}
+	if err := checkRepeating(task, []string{"completed"}); err != nil {
+		return err
+	}
 	if task.Type == model.TypeProject {
 		if !confirmAction(fmt.Sprintf("Complete project %q? This will also complete all its tasks.", task.Title)) {
 			return fmt.Errorf("cancelled")
 		}
-		return things.CompleteProject(task.UUID)
+		return applyStatusWrite(d, database, task, model.StatusCompleted, func() error {
+			return things.CompleteProject(task.UUID)
+		})
 	}
-	return things.CompleteTask(task.UUID)
+	return applyStatusWrite(d, database, task, model.StatusCompleted, func() error {
+		return things.CompleteTask(task.UUID)
+	})
 }
 
 type CancelCmd struct {
@@ -494,13 +520,20 @@ func (c *CancelCmd) Run(d *Deps) error {
 	if err != nil {
 		return err
 	}
+	if err := checkRepeating(task, []string{"canceled"}); err != nil {
+		return err
+	}
 	if task.Type == model.TypeProject {
 		if !confirmAction(fmt.Sprintf("Cancel project %q? This will also cancel all its tasks.", task.Title)) {
 			return fmt.Errorf("cancelled")
 		}
-		return things.CancelProject(task.UUID)
+		return applyStatusWrite(d, database, task, model.StatusCancelled, func() error {
+			return things.CancelProject(task.UUID)
+		})
 	}
-	return things.CancelTask(task.UUID)
+	return applyStatusWrite(d, database, task, model.StatusCancelled, func() error {
+		return things.CancelTask(task.UUID)
+	})
 }
 
 type SearchCmd struct {
@@ -779,7 +812,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	deps := &Deps{DBPath: cli.DB, JSON: cli.JSON, Stdout: os.Stdout}
+	deps := &Deps{DBPath: cli.DB, JSON: cli.JSON, Stdout: os.Stdout, NoVerify: cli.NoVerify}
 	defer deps.Close()
 
 	if err := ctx.Run(deps); err != nil {

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -358,8 +358,8 @@ type ProjectEditCmd struct {
 	Area   *string `help:"Move to area by name."`
 	AreaID *string `help:"Move to area by UUID." name:"area-id"`
 
-	Complete  bool `help:"Mark the project as completed."`
-	Cancel    bool `help:"Mark the project as canceled."`
+	Complete  bool `help:"Mark the project as completed." xor:"status"`
+	Cancel    bool `help:"Mark the project as canceled." xor:"status"`
 	Duplicate bool `help:"Duplicate the project before applying edits."`
 	Reveal    bool `help:"Reveal the project in Things after editing."`
 }
@@ -429,8 +429,8 @@ type EditCmd struct {
 	Heading   *string `help:"Set heading within project by name."`
 	HeadingID *string `help:"Set heading by UUID." name:"heading-id"`
 
-	Complete  bool `help:"Mark the task as completed."`
-	Cancel    bool `help:"Mark the task as canceled."`
+	Complete  bool `help:"Mark the task as completed." xor:"status"`
+	Cancel    bool `help:"Mark the task as canceled." xor:"status"`
 	Duplicate bool `help:"Duplicate the task before applying edits."`
 	Reveal    bool `help:"Reveal the task in Things after editing."`
 }
@@ -494,17 +494,14 @@ func (c *CompleteCmd) Run(d *Deps) error {
 	if err := checkRepeating(task, []string{"completed"}); err != nil {
 		return err
 	}
+	write := func() error { return things.CompleteTask(task.UUID) }
 	if task.Type == model.TypeProject {
 		if !confirmAction(fmt.Sprintf("Complete project %q? This will also complete all its tasks.", task.Title)) {
 			return fmt.Errorf("cancelled")
 		}
-		return applyStatusWrite(d, database, task, model.StatusCompleted, func() error {
-			return things.CompleteProject(task.UUID)
-		})
+		write = func() error { return things.CompleteProject(task.UUID) }
 	}
-	return applyStatusWrite(d, database, task, model.StatusCompleted, func() error {
-		return things.CompleteTask(task.UUID)
-	})
+	return applyStatusWrite(d, database, task, model.StatusCompleted, write)
 }
 
 type CancelCmd struct {
@@ -523,17 +520,14 @@ func (c *CancelCmd) Run(d *Deps) error {
 	if err := checkRepeating(task, []string{"canceled"}); err != nil {
 		return err
 	}
+	write := func() error { return things.CancelTask(task.UUID) }
 	if task.Type == model.TypeProject {
 		if !confirmAction(fmt.Sprintf("Cancel project %q? This will also cancel all its tasks.", task.Title)) {
 			return fmt.Errorf("cancelled")
 		}
-		return applyStatusWrite(d, database, task, model.StatusCancelled, func() error {
-			return things.CancelProject(task.UUID)
-		})
+		write = func() error { return things.CancelProject(task.UUID) }
 	}
-	return applyStatusWrite(d, database, task, model.StatusCancelled, func() error {
-		return things.CancelTask(task.UUID)
-	})
+	return applyStatusWrite(d, database, task, model.StatusCancelled, write)
 }
 
 type SearchCmd struct {

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -145,7 +145,7 @@ func runOut(t *testing.T, database *db.DB, args ...string) (string, error) {
 		t.Fatalf("parse %v: %v", args, err)
 	}
 	var buf bytes.Buffer
-	deps := &Deps{DB: database, JSON: cli.JSON, Stdout: &buf}
+	deps := &Deps{DB: database, JSON: cli.JSON, Stdout: &buf, NoVerify: cli.NoVerify}
 	var runErr error
 	withSilentStdout(t, func() {
 		runErr = ctx.Run(deps)

--- a/cmd/things/verify.go
+++ b/cmd/things/verify.go
@@ -64,20 +64,25 @@ func restrictedEdits(when, deadline *string, complete, cancel, duplicate bool) [
 // verifyStatus re-reads the item until its status matches want, and reports an
 // error if it never does. Without this a write Things ignored is
 // indistinguishable from one it applied.
+//
+// A failed read is retried rather than returned: Things is writing to the same
+// database while we poll, and a transient SQLITE_BUSY there must not turn a
+// write that landed into a reported failure. A read that keeps failing is
+// surfaced once the deadline passes.
 func verifyStatus(database *db.DB, task *model.Task, want model.Status) error {
 	deadline := time.Now().Add(verifyTimeout)
 	for {
 		current, err := database.GetTaskByUUID(task.UUID)
-		if err != nil {
-			return fmt.Errorf("verifying status change: %w", err)
-		}
-		if current == nil {
+		switch {
+		case err != nil:
+			if !time.Now().Before(deadline) {
+				return fmt.Errorf("verifying status change: %w", err)
+			}
+		case current == nil:
 			return fmt.Errorf("verifying status change: %s no longer exists in the Things database", task.UUID)
-		}
-		if current.Status == want {
+		case current.Status == want:
 			return nil
-		}
-		if !time.Now().Before(deadline) {
+		case !time.Now().Before(deadline):
 			return fmt.Errorf("status change did not apply: %q (%s) is still %s after %s. Things accepted the command and then dropped it silently — check that Things3 is running, or make the change in the app",
 				task.Title, task.UUID, current.Status, verifyTimeout)
 		}

--- a/cmd/things/verify.go
+++ b/cmd/things/verify.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ryanlewis/things-cli/internal/db"
+	"github.com/ryanlewis/things-cli/internal/model"
+)
+
+// repeatingDocsURL documents which attributes Things refuses to update on
+// repeating items.
+const repeatingDocsURL = "https://culturedcode.com/things/support/articles/2803573/"
+
+// Read-back tuning. Things gives write commands no callback (issue #19), so
+// the only confirmation available is re-reading the database until the change
+// lands. Vars rather than consts so tests can shrink them.
+var (
+	verifyTimeout  = 10 * time.Second
+	verifyInterval = 100 * time.Millisecond
+	verifySleep    = time.Sleep
+)
+
+// checkRepeating refuses a write that Things would silently drop. Things
+// rejects status, when, deadline and duplicate changes on repeating to-dos and
+// projects without reporting an error, so an attempt would look like success.
+// blocked lists the attributes this command is about to change; it is empty
+// when nothing restricted was requested.
+func checkRepeating(task *model.Task, blocked []string) error {
+	if !task.Repeating || len(blocked) == 0 {
+		return nil
+	}
+	kind := "to-do"
+	if task.Type == model.TypeProject {
+		kind = "project"
+	}
+	return fmt.Errorf("%q is a repeating %s — Things does not allow %s to be changed on repeating %ss and drops the request silently (%s). Change it in the Things app instead",
+		task.Title, kind, strings.Join(blocked, ", "), kind, repeatingDocsURL)
+}
+
+// restrictedEdits names the requested attributes Things refuses on repeating
+// items, in the order they appear in the docs.
+func restrictedEdits(when, deadline *string, complete, cancel, duplicate bool) []string {
+	var blocked []string
+	if when != nil {
+		blocked = append(blocked, "when")
+	}
+	if deadline != nil {
+		blocked = append(blocked, "deadline")
+	}
+	if complete {
+		blocked = append(blocked, "completed")
+	}
+	if cancel {
+		blocked = append(blocked, "canceled")
+	}
+	if duplicate {
+		blocked = append(blocked, "duplicate")
+	}
+	return blocked
+}
+
+// verifyStatus re-reads the item until its status matches want, and reports an
+// error if it never does. Without this a write Things ignored is
+// indistinguishable from one it applied.
+func verifyStatus(database *db.DB, task *model.Task, want model.Status) error {
+	deadline := time.Now().Add(verifyTimeout)
+	for {
+		current, err := database.GetTaskByUUID(task.UUID)
+		if err != nil {
+			return fmt.Errorf("verifying status change: %w", err)
+		}
+		if current == nil {
+			return fmt.Errorf("verifying status change: %s no longer exists in the Things database", task.UUID)
+		}
+		if current.Status == want {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("status change did not apply: %q (%s) is still %s after %s. Things accepted the command and then dropped it silently — check that Things3 is running, or make the change in the app",
+				task.Title, task.UUID, current.Status, verifyTimeout)
+		}
+		verifySleep(verifyInterval)
+	}
+}
+
+// applyStatusWrite runs a status-changing write and confirms it landed, unless
+// verification is switched off with --no-verify.
+func applyStatusWrite(d *Deps, database *db.DB, task *model.Task, want model.Status, write func() error) error {
+	if err := write(); err != nil {
+		return err
+	}
+	if d.NoVerify {
+		return nil
+	}
+	return verifyStatus(database, task, want)
+}
+
+// applyEditStatusWrite runs an `edit` / `project edit` update and, when it
+// asked for a status transition, confirms the transition landed. A --duplicate
+// edit is exempt: Things applies the attributes to the copy, so the original's
+// status is expected to stay put.
+func applyEditStatusWrite(d *Deps, database *db.DB, task *model.Task, complete, cancel, duplicate bool, update func() error) error {
+	want := model.StatusOpen
+	switch {
+	case complete:
+		want = model.StatusCompleted
+	case cancel:
+		want = model.StatusCancelled
+	}
+	if want == model.StatusOpen || duplicate {
+		return update()
+	}
+	return applyStatusWrite(d, database, task, want, update)
+}

--- a/cmd/things/verify_test.go
+++ b/cmd/things/verify_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"database/sql"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ryanlewis/things-cli/internal/db"
+	"github.com/ryanlewis/things-cli/internal/db/dbtest"
+	"github.com/ryanlewis/things-cli/internal/things"
+)
+
+// fastVerify shrinks the read-back poll so failure cases don't spend ten
+// seconds waiting for a status that will never change.
+func fastVerify(t *testing.T) {
+	t.Helper()
+	timeout, interval, sleep := verifyTimeout, verifyInterval, verifySleep
+	verifyTimeout = 20 * time.Millisecond
+	verifyInterval = time.Millisecond
+	verifySleep = func(time.Duration) {}
+	t.Cleanup(func() {
+		verifyTimeout, verifyInterval, verifySleep = timeout, interval, sleep
+	})
+}
+
+// seedWritable returns an in-memory DB holding one repeating and one ordinary
+// open to-do, plus the auth token `edit` needs, and the raw handle so a test
+// can simulate Things applying a write.
+func seedWritable(t *testing.T) (*db.DB, *sql.DB) {
+	t.Helper()
+	sqlDB := dbtest.NewSQL(t)
+	stmts := []string{
+		`INSERT INTO TMSettings (uuid, uriSchemeAuthenticationToken) VALUES ('s1', 'tok')`,
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, start, rt1_recurrenceRule)
+		 VALUES ('rep-1', 'Water plants', 0, 0, 0, 2, x'0102')`,
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, start)
+		 VALUES ('one-1', 'Post letter', 0, 0, 0, 2)`,
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, rt1_recurrenceRule)
+		 VALUES ('repproj-1', 'Weekly review', 1, 0, 0, x'0102')`,
+	}
+	for _, s := range stmts {
+		if _, err := sqlDB.Exec(s); err != nil {
+			t.Fatalf("seed %q: %v", s, err)
+		}
+	}
+	return db.NewFromSQL(sqlDB), sqlDB
+}
+
+// stubExecApplying mocks the write command and, as Things would, moves the
+// task to the given status so the read-back finds the change.
+func stubExecApplying(t *testing.T, sqlDB *sql.DB, uuid string, status int) {
+	t.Helper()
+	prev := things.SetExecCommandForTest(func(string, ...string) *exec.Cmd {
+		if _, err := sqlDB.Exec(`UPDATE TMTask SET status = ? WHERE uuid = ?`, status, uuid); err != nil {
+			t.Errorf("simulating Things write: %v", err)
+		}
+		return exec.Command("true")
+	})
+	t.Cleanup(func() { things.SetExecCommandForTest(prev) })
+}
+
+// stubExecFailing mocks a write that reports success but changes nothing —
+// exactly what Things does when it drops a status update (issue #129).
+func stubExecDropping(t *testing.T) *int {
+	t.Helper()
+	calls := 0
+	prev := things.SetExecCommandForTest(func(string, ...string) *exec.Cmd {
+		calls++
+		return exec.Command("true")
+	})
+	t.Cleanup(func() { things.SetExecCommandForTest(prev) })
+	return &calls
+}
+
+func TestRepeatingWritesAreRefusedUpFront(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"complete", []string{"complete", "rep-1"}, "completed"},
+		{"cancel", []string{"cancel", "rep-1"}, "canceled"},
+		{"editComplete", []string{"edit", "rep-1", "--complete"}, "completed"},
+		{"editCancel", []string{"edit", "rep-1", "--cancel"}, "canceled"},
+		{"editWhen", []string{"edit", "rep-1", "--when", "today"}, "when"},
+		{"editDeadline", []string{"edit", "rep-1", "--deadline", "2026-05-01"}, "deadline"},
+		{"editDuplicate", []string{"edit", "rep-1", "--duplicate"}, "duplicate"},
+		{"projectEditCancel", []string{"project", "edit", "repproj-1", "--cancel"}, "canceled"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fastVerify(t)
+			database, _ := seedWritable(t)
+			calls := stubExecDropping(t)
+
+			err := runWith(t, database, tc.args...)
+			if err == nil {
+				t.Fatalf("run %v: expected a repeating-item error", tc.args)
+			}
+			if !strings.Contains(err.Error(), "repeating") || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %v, want it to mention %q on a repeating item", err, tc.want)
+			}
+			if *calls != 0 {
+				t.Errorf("issued %d write(s); a refused command must not reach Things", *calls)
+			}
+		})
+	}
+}
+
+// A repeating to-do can still be retitled or retagged — only the documented
+// attributes are blocked.
+func TestRepeatingAllowsUnrestrictedEdits(t *testing.T) {
+	database, _ := seedWritable(t)
+	stubExec(t)
+
+	if err := runWith(t, database, "edit", "rep-1", "--title", "Water the plants"); err != nil {
+		t.Fatalf("edit --title on a repeating to-do: %v", err)
+	}
+}
+
+func TestCompleteVerifiesStatusLanded(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	stubExecApplying(t, sqlDB, "one-1", 3)
+
+	if err := runWith(t, database, "complete", "one-1"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+}
+
+func TestCancelVerifiesStatusLanded(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	stubExecApplying(t, sqlDB, "one-1", 2)
+
+	if err := runWith(t, database, "cancel", "one-1"); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+}
+
+// The core of issue #129: a write Things accepts and then ignores must not be
+// reported as success.
+func TestSilentlyDroppedWriteFails(t *testing.T) {
+	cases := [][]string{
+		{"complete", "one-1"},
+		{"cancel", "one-1"},
+		{"edit", "one-1", "--cancel"},
+		{"edit", "one-1", "--complete"},
+	}
+	for _, args := range cases {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			fastVerify(t)
+			database, _ := seedWritable(t)
+			stubExecDropping(t)
+
+			err := runWith(t, database, args...)
+			if err == nil {
+				t.Fatalf("run %v: expected a verification failure", args)
+			}
+			if !strings.Contains(err.Error(), "did not apply") {
+				t.Errorf("error = %v, want it to report the change was not applied", err)
+			}
+		})
+	}
+}
+
+func TestNoVerifySkipsReadBack(t *testing.T) {
+	fastVerify(t)
+	database, _ := seedWritable(t)
+	stubExecDropping(t)
+
+	if err := runWith(t, database, "--no-verify", "complete", "one-1"); err != nil {
+		t.Fatalf("complete --no-verify: %v", err)
+	}
+}
+
+// --duplicate leaves the original untouched, so there is no status change to
+// verify on it.
+func TestEditDuplicateSkipsVerification(t *testing.T) {
+	fastVerify(t)
+	database, _ := seedWritable(t)
+	stubExecDropping(t)
+
+	if err := runWith(t, database, "edit", "one-1", "--complete", "--duplicate"); err != nil {
+		t.Fatalf("edit --complete --duplicate: %v", err)
+	}
+}
+
+func TestVerifyStatusTaskDisappeared(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	task, err := database.GetTaskByUUID("one-1")
+	if err != nil {
+		t.Fatalf("GetTaskByUUID: %v", err)
+	}
+	if _, err := sqlDB.Exec(`DELETE FROM TMTask WHERE uuid = 'one-1'`); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	err = verifyStatus(database, task, 3)
+	if err == nil || !strings.Contains(err.Error(), "no longer exists") {
+		t.Fatalf("verifyStatus after delete = %v, want a not-found error", err)
+	}
+}

--- a/cmd/things/verify_test.go
+++ b/cmd/things/verify_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alecthomas/kong"
+
 	"github.com/ryanlewis/things-cli/internal/db"
 	"github.com/ryanlewis/things-cli/internal/db/dbtest"
+	"github.com/ryanlewis/things-cli/internal/skill"
 	"github.com/ryanlewis/things-cli/internal/things"
 )
 
@@ -61,7 +64,7 @@ func stubExecApplying(t *testing.T, sqlDB *sql.DB, uuid string, status int) {
 	t.Cleanup(func() { things.SetExecCommandForTest(prev) })
 }
 
-// stubExecFailing mocks a write that reports success but changes nothing —
+// stubExecDropping mocks a write that reports success but changes nothing —
 // exactly what Things does when it drops a status update (issue #129).
 func stubExecDropping(t *testing.T) *int {
 	t.Helper()
@@ -202,5 +205,51 @@ func TestVerifyStatusTaskDisappeared(t *testing.T) {
 	err = verifyStatus(database, task, 3)
 	if err == nil || !strings.Contains(err.Error(), "no longer exists") {
 		t.Fatalf("verifyStatus after delete = %v, want a not-found error", err)
+	}
+}
+
+// A read that keeps failing has to surface once the deadline passes rather
+// than loop forever — the retry only covers transient errors.
+func TestVerifyStatusPersistentReadErrorSurfaces(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	task, err := database.GetTaskByUUID("one-1")
+	if err != nil {
+		t.Fatalf("GetTaskByUUID: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	err = verifyStatus(database, task, 3)
+	if err == nil || !strings.Contains(err.Error(), "verifying status change") {
+		t.Fatalf("verifyStatus with an unreadable database = %v, want a read error", err)
+	}
+}
+
+// --complete and --cancel ask for two different end states, so the read-back
+// could not know which one to wait for. Kong rejects the pair at parse time.
+func TestEditRejectsCompleteAndCancelTogether(t *testing.T) {
+	cases := [][]string{
+		{"edit", "one-1", "--complete", "--cancel"},
+		{"project", "edit", "repproj-1", "--complete", "--cancel"},
+	}
+	for _, args := range cases {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var cli CLI
+			parser, err := kong.New(&cli, kong.Name("things"),
+				kong.Vars{
+					"builtin_lists": strings.Join(things.BuiltinLists, ", "),
+					"skill_agents":  skill.AgentNames(),
+				},
+			)
+			if err != nil {
+				t.Fatalf("kong.New: %v", err)
+			}
+			_, err = parser.Parse(args)
+			if err == nil || !strings.Contains(err.Error(), "can't be used together") {
+				t.Fatalf("parse %v = %v, want a mutual-exclusion error", args, err)
+			}
+		})
 	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -13,10 +13,11 @@ import (
 type DB struct {
 	db *sql.DB
 
-	// repeatSQL caches the probed recurrence-column expression; see
-	// (*DB).repeatingExpr.
-	repeatOnce sync.Once
-	repeatSQL  string
+	// repeatSQL caches the probed recurrence-column expression and
+	// repeatQuery the task query built from it; see (*DB).probeRepeating.
+	repeatOnce  sync.Once
+	repeatSQL   string
+	repeatQuery string
 }
 
 // FindDBPath locates the Things3 SQLite database.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -5,12 +5,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	_ "modernc.org/sqlite"
 )
 
 type DB struct {
 	db *sql.DB
+
+	// repeatSQL caches the probed recurrence-column expression; see
+	// (*DB).repeatingExpr.
+	repeatOnce sync.Once
+	repeatSQL  string
 }
 
 // FindDBPath locates the Things3 SQLite database.

--- a/internal/db/dbtest/schema.sql
+++ b/internal/db/dbtest/schema.sql
@@ -18,7 +18,8 @@ CREATE TABLE TMTask (
     project                         TEXT,
     heading                         TEXT,
     untrashedLeafActionsCount       INTEGER,
-    openUntrashedLeafActionsCount   INTEGER
+    openUntrashedLeafActionsCount   INTEGER,
+    rt1_recurrenceRule              BLOB
 );
 
 CREATE TABLE TMArea (

--- a/internal/db/repeating.go
+++ b/internal/db/repeating.go
@@ -15,8 +15,18 @@ var recurrenceColumns = []string{"rt1_recurrenceRule", "recurrenceRule"}
 // and 0 otherwise, aliased against the `t` TMTask row. The probe runs once per
 // DB and the result is cached.
 func (d *DB) repeatingExpr() string {
+	d.probeRepeating()
+	return d.repeatSQL
+}
+
+// probeRepeating resolves the recurrence expression and the assembled task
+// query once per DB.
+func (d *DB) probeRepeating() {
 	d.repeatOnce.Do(func() {
 		d.repeatSQL = "0"
+		defer func() {
+			d.repeatQuery = strings.Replace(baseTaskQuery, repeatingPlaceholder, d.repeatSQL, 1)
+		}()
 		cols, err := d.tableColumns("TMTask")
 		if err != nil {
 			return
@@ -28,7 +38,6 @@ func (d *DB) repeatingExpr() string {
 			}
 		}
 	})
-	return d.repeatSQL
 }
 
 // tableColumns returns the column names of table. The name is interpolated
@@ -61,7 +70,8 @@ func (d *DB) tableColumns(table string) (map[string]bool, error) {
 	return cols, nil
 }
 
-// taskQuery fills the repeating placeholder in baseTaskQuery.
+// taskQuery returns baseTaskQuery with the repeating placeholder filled in.
 func (d *DB) taskQuery() string {
-	return strings.Replace(baseTaskQuery, repeatingPlaceholder, d.repeatingExpr(), 1)
+	d.probeRepeating()
+	return d.repeatQuery
 }

--- a/internal/db/repeating.go
+++ b/internal/db/repeating.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+)
+
+// recurrenceColumns are the TMTask columns that have carried a to-do's
+// recurrence rule across Things 3 schema versions, newest first. The column is
+// probed at runtime rather than hard-coded: a schema carrying none of them
+// degrades to "nothing repeats" instead of breaking every task query.
+var recurrenceColumns = []string{"rt1_recurrenceRule", "recurrenceRule"}
+
+// repeatingExpr returns the SQL expression that yields 1 for a repeating item
+// and 0 otherwise, aliased against the `t` TMTask row. The probe runs once per
+// DB and the result is cached.
+func (d *DB) repeatingExpr() string {
+	d.repeatOnce.Do(func() {
+		d.repeatSQL = "0"
+		cols, err := d.tableColumns("TMTask")
+		if err != nil {
+			return
+		}
+		for _, c := range recurrenceColumns {
+			if cols[c] {
+				d.repeatSQL = `CASE WHEN t."` + c + `" IS NOT NULL THEN 1 ELSE 0 END`
+				return
+			}
+		}
+	})
+	return d.repeatSQL
+}
+
+// tableColumns returns the column names of table. The name is interpolated
+// because PRAGMA does not accept bound parameters; every caller passes a
+// compile-time constant.
+func (d *DB) tableColumns(table string) (map[string]bool, error) {
+	rows, err := d.db.Query(fmt.Sprintf("PRAGMA table_info(%q)", table))
+	if err != nil {
+		return nil, fmt.Errorf("reading %s columns: %w", table, err)
+	}
+	defer rows.Close()
+
+	cols := map[string]bool{}
+	for rows.Next() {
+		var (
+			cid        int
+			name, typ  string
+			notNull    int
+			dflt       any
+			primaryKey int
+		)
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dflt, &primaryKey); err != nil {
+			return nil, fmt.Errorf("scanning %s columns: %w", table, err)
+		}
+		cols[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading %s columns: %w", table, err)
+	}
+	return cols, nil
+}
+
+// taskQuery fills the repeating placeholder in baseTaskQuery.
+func (d *DB) taskQuery() string {
+	return strings.Replace(baseTaskQuery, repeatingPlaceholder, d.repeatingExpr(), 1)
+}

--- a/internal/db/repeating_test.go
+++ b/internal/db/repeating_test.go
@@ -1,0 +1,120 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/ryanlewis/things-cli/internal/db/dbtest"
+)
+
+func seedRepeatingPair(t *testing.T) *DB {
+	t.Helper()
+	sqlDB := dbtest.NewSQL(t)
+	if _, err := sqlDB.Exec(
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, start, rt1_recurrenceRule)
+		 VALUES ('rep-1', 'Water plants', 0, 0, 0, 2, x'0102')`,
+	); err != nil {
+		t.Fatalf("seed repeating: %v", err)
+	}
+	if _, err := sqlDB.Exec(
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, start)
+		 VALUES ('one-1', 'Post letter', 0, 0, 0, 2)`,
+	); err != nil {
+		t.Fatalf("seed one-off: %v", err)
+	}
+	return &DB{db: sqlDB}
+}
+
+func TestGetTaskByUUIDReportsRepeating(t *testing.T) {
+	d := seedRepeatingPair(t)
+
+	rep, err := d.GetTaskByUUID("rep-1")
+	if err != nil {
+		t.Fatalf("GetTaskByUUID(rep-1): %v", err)
+	}
+	if !rep.Repeating {
+		t.Error("task with a recurrence rule: Repeating = false, want true")
+	}
+
+	one, err := d.GetTaskByUUID("one-1")
+	if err != nil {
+		t.Fatalf("GetTaskByUUID(one-1): %v", err)
+	}
+	if one.Repeating {
+		t.Error("task without a recurrence rule: Repeating = true, want false")
+	}
+}
+
+// Listing and search go through the same templated query, so the flag has to
+// survive every path a caller can reach a task by.
+func TestListAndSearchReportRepeating(t *testing.T) {
+	d := seedRepeatingPair(t)
+
+	tasks, err := d.ListTasks("someday", TaskFilter{})
+	if err != nil {
+		t.Fatalf("ListTasks(someday): %v", err)
+	}
+	got := map[string]bool{}
+	for _, task := range tasks {
+		got[task.UUID] = task.Repeating
+	}
+	if !got["rep-1"] || got["one-1"] {
+		t.Errorf("someday repeating flags = %v, want rep-1 true and one-1 false", got)
+	}
+
+	found, err := d.SearchTasks("plants")
+	if err != nil {
+		t.Fatalf("SearchTasks: %v", err)
+	}
+	if len(found) != 1 || !found[0].Repeating {
+		t.Errorf("SearchTasks(plants) = %+v, want one repeating task", found)
+	}
+}
+
+// Older Things schemas name the column differently, and a future one could
+// drop it. The probe must degrade to "nothing repeats" rather than making
+// every task query fail.
+func TestRepeatingColumnAbsentDegradesGracefully(t *testing.T) {
+	sqlDB := dbtest.NewSQL(t)
+	if _, err := sqlDB.Exec(`ALTER TABLE TMTask DROP COLUMN rt1_recurrenceRule`); err != nil {
+		t.Fatalf("drop column: %v", err)
+	}
+	if _, err := sqlDB.Exec(
+		`INSERT INTO TMTask (uuid, title, type, status, trashed) VALUES ('t1', 'Anything', 0, 0, 0)`,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	d := &DB{db: sqlDB}
+
+	if expr := d.repeatingExpr(); expr != "0" {
+		t.Errorf("repeatingExpr() = %q, want %q", expr, "0")
+	}
+	task, err := d.GetTaskByUUID("t1")
+	if err != nil {
+		t.Fatalf("GetTaskByUUID: %v", err)
+	}
+	if task == nil || task.Repeating {
+		t.Errorf("got %+v, want a task with Repeating false", task)
+	}
+}
+
+func TestRepeatingExprIsProbedOnce(t *testing.T) {
+	d := seedRepeatingPair(t)
+	first := d.repeatingExpr()
+	if first == "0" {
+		t.Fatalf("repeatingExpr() = %q, want a recurrence-column expression", first)
+	}
+	if second := d.repeatingExpr(); second != first {
+		t.Errorf("repeatingExpr() = %q on second call, want the cached %q", second, first)
+	}
+}
+
+func TestTableColumnsUnknownTable(t *testing.T) {
+	d := &DB{db: dbtest.NewSQL(t)}
+	cols, err := d.tableColumns("NoSuchTable")
+	if err != nil {
+		t.Fatalf("tableColumns: %v", err)
+	}
+	if len(cols) != 0 {
+		t.Errorf("tableColumns(NoSuchTable) = %v, want empty", cols)
+	}
+}

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -40,6 +40,10 @@ func DateFilterableView(view string) bool {
 	return dateFilterableViews[view]
 }
 
+// repeatingPlaceholder is substituted with the probed recurrence expression by
+// (*DB).taskQuery — the column name varies across Things schema versions.
+const repeatingPlaceholder = "{{repeating}}"
+
 // baseTaskQuery selects a task with its project, heading, area and tags.
 //
 // A task filed under a project heading carries t.heading and leaves t.project
@@ -69,7 +73,8 @@ SELECT
 	COALESCE(a.title, COALESCE(pa.title, '')),
 	COALESCE(GROUP_CONCAT(tag.title, char(31)), ''),
 	COALESCE(t."index", 0),
-	COALESCE(t.todayIndex, 0)
+	COALESCE(t.todayIndex, 0),
+	{{repeating}}
 FROM TMTask t
 LEFT JOIN TMTask h ON t.heading = h.uuid
 LEFT JOIN TMTask p ON p.uuid = COALESCE(t.project, h.project)
@@ -83,7 +88,7 @@ func scanTask(row interface{ Scan(...any) error }) (model.Task, error) {
 	var t model.Task
 	var startDate, deadline, stopDate, creationDate sql.NullFloat64
 	var tagsStr string
-	var trashed int
+	var trashed, repeating int
 
 	err := row.Scan(
 		&t.UUID, &t.Title, &t.Notes,
@@ -95,12 +100,14 @@ func scanTask(row interface{ Scan(...any) error }) (model.Task, error) {
 		&t.AreaUUID, &t.AreaTitle,
 		&tagsStr,
 		&t.Index, &t.TodayIndex,
+		&repeating,
 	)
 	if err != nil {
 		return t, err
 	}
 
 	t.Trashed = trashed != 0
+	t.Repeating = repeating != 0
 	if startDate.Valid {
 		d := model.ThingsDate(int64(startDate.Float64))
 		t.StartDate = &d
@@ -222,12 +229,12 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 		orderBy = "ORDER BY t.\"index\" ASC"
 	}
 
-	query := baseTaskQuery + " WHERE " + where + " GROUP BY t.uuid " + orderBy
+	query := d.taskQuery() + " WHERE " + where + " GROUP BY t.uuid " + orderBy
 	return d.collectTasks(query, args...)
 }
 
 func (d *DB) GetTaskByUUID(uuid string) (*model.Task, error) {
-	query := baseTaskQuery + " WHERE t.uuid = ? GROUP BY t.uuid"
+	query := d.taskQuery() + " WHERE t.uuid = ? GROUP BY t.uuid"
 	row := d.db.QueryRow(query, uuid)
 	t, err := scanTask(row)
 	if err == sql.ErrNoRows {
@@ -249,7 +256,7 @@ func (d *DB) GetTask(uuidOrTitle string) (*model.Task, error) {
 	}
 
 	// Try exact title match
-	query := baseTaskQuery + " WHERE t.title = ? AND t.trashed = 0 AND t.status = 0 GROUP BY t.uuid LIMIT 1"
+	query := d.taskQuery() + " WHERE t.title = ? AND t.trashed = 0 AND t.status = 0 GROUP BY t.uuid LIMIT 1"
 	row := d.db.QueryRow(query, uuidOrTitle)
 	task, err := scanTask(row)
 	if err == nil {
@@ -275,7 +282,7 @@ func (d *DB) GetTask(uuidOrTitle string) (*model.Task, error) {
 }
 
 func (d *DB) FindTasksByTitle(substr string) ([]model.Task, error) {
-	query := baseTaskQuery + " WHERE t.title LIKE ? AND t.trashed = 0 AND t.status = 0 GROUP BY t.uuid ORDER BY t.\"index\" ASC"
+	query := d.taskQuery() + " WHERE t.title LIKE ? AND t.trashed = 0 AND t.status = 0 GROUP BY t.uuid ORDER BY t.\"index\" ASC"
 	return d.collectTasks(query, "%"+substr+"%")
 }
 
@@ -290,7 +297,7 @@ func (e *AmbiguousTaskError) Error() string {
 
 func (d *DB) SearchTasks(query string) ([]model.Task, error) {
 	pattern := "%" + query + "%"
-	q := baseTaskQuery + " WHERE (t.title LIKE ? OR t.notes LIKE ?) AND t.trashed = 0 GROUP BY t.uuid ORDER BY t.\"index\" ASC"
+	q := d.taskQuery() + " WHERE (t.title LIKE ? OR t.notes LIKE ?) AND t.trashed = 0 GROUP BY t.uuid ORDER BY t.\"index\" ASC"
 	return d.collectTasks(q, pattern, pattern)
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -162,6 +162,11 @@ type Task struct {
 	Tags         []string    `json:"tags,omitempty"`
 	Index        int         `json:"index"`
 	TodayIndex   int         `json:"todayIndex"`
+
+	// Repeating marks an item Things treats as a repeating to-do or project.
+	// Things refuses status, when, deadline and duplicate updates on these,
+	// silently, so callers need to know before they try.
+	Repeating bool `json:"repeating,omitempty"`
 }
 
 type ChecklistItem struct {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -214,6 +214,9 @@ func printTaskDetail(w io.Writer, t *model.Task, items []model.ChecklistItem) er
 	if t.Deadline != nil {
 		fmt.Fprintf(w, "%s%s\n", label("Deadline:"), styledDate(t.Deadline, false))
 	}
+	if t.Repeating {
+		fmt.Fprintf(w, "%s%s\n", label("Repeats:"), "yes (Things blocks status, when and deadline edits)")
+	}
 	if t.CreationDate != nil {
 		fmt.Fprintf(w, "%s%s\n", label("Created:"), t.CreationDate.Format("2006-01-02 15:04"))
 	}

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -8,6 +8,7 @@ today, upcoming, projects, or areas on macOS.
 - Reads (`list`, `show`, `projects`, `areas`, `tags`, `search`) are safe — use freely.
 - Writes (`add`, `project add`, `edit`, `complete`, `cancel`, `log`, `open`) modify the user's real data. Confirm before destructive ones (`complete`, `cancel`, bulk `edit`).
 - `edit`, `project edit`, and `import` payloads with `operation: update` require *Things → Settings → General → Enable Things URLs*. The error to recognise: `update: auth token is required — enable Things URLs in Things → Settings → General …`.
+- `--complete` and `--cancel` are mutually exclusive on `edit` and `project edit`.
 - `complete` and `cancel` (and `edit --complete` / `--cancel`) read the item back afterwards and exit non-zero if the status did not change. Treat a non-zero exit as "the task is still open" — do not report it as done.
 
 ## Output

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -8,10 +8,13 @@ today, upcoming, projects, or areas on macOS.
 - Reads (`list`, `show`, `projects`, `areas`, `tags`, `search`) are safe — use freely.
 - Writes (`add`, `project add`, `edit`, `complete`, `cancel`, `log`, `open`) modify the user's real data. Confirm before destructive ones (`complete`, `cancel`, bulk `edit`).
 - `edit`, `project edit`, and `import` payloads with `operation: update` require *Things → Settings → General → Enable Things URLs*. The error to recognise: `update: auth token is required — enable Things URLs in Things → Settings → General …`.
+- `complete` and `cancel` (and `edit --complete` / `--cancel`) read the item back afterwards and exit non-zero if the status did not change. Treat a non-zero exit as "the task is still open" — do not report it as done.
 
 ## Output
 
 Most commands accept `--json` / `-j`. Prefer it when parsing output.
+
+Tasks and projects carry `"repeating": true` in JSON when Things treats them as repeating; the field is omitted otherwise. `things show` prints a `Repeats:` line for them.
 
 In JSON, `status` is a string enum — `"open"`, `"cancelled"`, or `"completed"` (not the raw Things integer) — on tasks, projects, and checklist items. Filter with e.g. `jq 'select(.status=="open")'`.
 
@@ -49,6 +52,7 @@ things edit <task> [--title --notes --prepend-notes --append-notes --when --dead
 things complete <task>          # task or project; project completion asks to confirm
 things cancel <task>            # task or project; project cancellation asks to confirm
 things log                      # move Today → Logbook
+things --no-verify complete <task>   # skip the read-back (rarely needed)
 things open [<ref>] [-p P | -a A | -t T | -q Q] [--filter T1,T2] [--background]
     # ref: task/project UUID, numeric list index, title, or built-in list name
     #      (today, inbox, upcoming, anytime, someday, logbook, trash, deadlines)
@@ -59,6 +63,17 @@ things import [--file F] [--reveal] < payload.json
     # batch create/update via the Things JSON URL scheme
     # payload is the array documented at culturedcode.com/things/support/articles/2803573/
 ```
+
+### Repeating to-dos and projects
+
+Things refuses to update `when`, `deadline`, completed/canceled status, and duplication on repeating items, and drops the request silently rather than reporting an error. The CLI checks first and fails with a non-zero exit:
+
+```
+"Water plants" is a repeating to-do — Things does not allow canceled to be changed
+on repeating to-dos and drops the request silently (…). Change it in the Things app instead
+```
+
+There is no CLI workaround — the user has to make the change in the Things app. Every other attribute (`--title`, `--notes`, `--tags`, `--list`, …) edits normally.
 
 ### Task reference forms
 


### PR DESCRIPTION
## What was wrong

`things cancel <uuid>` and `things complete <uuid>` exited 0 and printed nothing while leaving the task open. Same for `things edit <uuid> --cancel`.

The cause is a documented Things restriction rather than anything specific to those tasks. On repeating to-dos and repeating projects, Things [will not update](https://culturedcode.com/things/support/articles/2803573/) `when`, `deadline`, completed/canceled status or `completion-date`, and will not duplicate them. It rejects the request without reporting an error — the URL scheme has no callback (#19) and AppleScript's `set status to canceled` returns normally — so the CLI could not tell a dropped write from an applied one and reported success either way.

That accounts for every observation in #129: `--title` landed because `title` is not restricted, fresh repro tasks cancelled because none of them were repeating, and the non-zero `todayIndex` was incidental.

**Confidence:** high that this is the mechanism — the restriction is documented and matches every symptom. Medium that the recurrence-rule check will fire on the two specific tasks in the issue, because I could not read the live database to confirm they carry a recurrence rule. The read-back below covers that gap: if the detection is wrong, the command still fails loudly instead of claiming success.

## What changed

Two independent layers.

**1. Refuse the write up front.** The task query now reads the recurrence rule out of `TMTask` and exposes it as `repeating` on tasks and projects. `complete`, `cancel`, `edit` and `project edit` check it before issuing anything and fail with a non-zero exit naming the blocked attributes and pointing at the docs:

```
Error: "Water plants" is a repeating to-do — Things does not allow canceled to be changed on repeating to-dos and drops the request silently (https://culturedcode.com/things/support/articles/2803573/). Change it in the Things app instead
```

The column name has changed across Things schema versions (`rt1_recurrenceRule`, older `recurrenceRule`), so it is probed once via `PRAGMA table_info` and cached. A schema with neither degrades to "nothing repeats" rather than breaking every query.

`things show` now prints a `Repeats:` line and JSON carries `"repeating": true`, which is what made this hard to diagnose from the outside — nothing in the output said these to-dos were repeating.

**2. Read the status back after every status write.** `complete`, `cancel` and `edit --complete/--cancel` poll the database until the status matches, up to 10 seconds, and exit non-zero if it never does:

```
Error: status change did not apply: "Renew insurance" (W1gBDJPFpwUQrdP5Am5K7J) is still open after 10s. Things accepted the command and then dropped it silently — check that Things3 is running, or make the change in the app
```

This is the part that matters regardless of root cause — it turns any silently-dropped status write into a visible failure. Transient read errors are retried within the window, since Things is writing to the same database while we poll. `--duplicate` edits are exempt (Things applies those to the copy, so the original is expected to stay put). `--no-verify` skips the check.

There is no CLI workaround for the underlying restriction: Things simply does not accept these changes on a repeating item, through either interface. The change has to be made in the app.

Also: `edit --complete --cancel` used to be accepted and silently treated as `--complete`. The pair is now rejected at parse time.

## How it was tested

`make fmt`, `make lint` (0 issues) and `make test` (`-race`) all pass. New code is 77–100% covered.

- `internal/db`: the `repeating` flag is populated through every path that returns a task (get by uuid, list, search); a schema with the column dropped degrades to false instead of erroring; the probe runs once.
- `cmd/things`: every restricted flag combination is refused on a repeating to-do and a repeating project, with no command reaching Things; unrestricted edits (`--title`) still work on a repeating to-do; a write that reports success but changes nothing now fails with a clear error on all four entry points; a write that does land passes; `--no-verify` and `--duplicate` skip verification; a persistently unreadable database surfaces the read error.

No live Things data was touched — the writes are mocked through the existing `SetExecCommandForTest` seam and the database is `dbtest`'s in-memory schema.

## Not covered

`things import` with `operation: update` can set `when`/`deadline`/`completed`/`canceled` and goes through neither the repeating check nor the read-back, so the silent drop is still reachable that way. Batch payloads need their own design for reporting partial failures; worth a follow-up issue.

Separately, repeating templates appear in `things someday` even though the Things app files them under "Repeating". Unchanged here, but that is why these two to-dos looked like ordinary Someday tasks.

Closes #129
