### PR TITLE
docs(release): add v0.6.0 release notes header

### DIFF
--- a/.github/releases/v0.6.0.md
+++ b/.github/releases/v0.6.0.md
@@ -1,0 +1,28 @@
+## `things-cli` v0.6.0 — filters that tell the truth, writes that fail loudly
+
+Four fixes from recent use, three of them about the CLI quietly reporting the wrong thing. Two new flags.
+
+### Filters no longer under-report
+
+- **`--project`, `--area` and `--tag` now search all open tasks by default** instead of the Today view. Naming a project previously returned only its Today slice while the header just printed the project name; one project showed 8 tasks where there were 59. An explicit view still wins and is now labelled in the header when combined with a filter. (#140, #142)
+- **Tasks nested under a project heading are included** in project and area filters, and `show` reports their project and area. They were invisible before because Things stores the project on the heading row, not the task. (#139, #142)
+- Tasks left open under a trashed project no longer leak into filtered output.
+- Behaviour change: `things today "Chores"` now means today within Chores. It used to silently switch to the whole-project view.
+
+### Complete and cancel now verify the write landed
+
+- **Repeating to-dos and projects are refused up front.** Things silently drops status, when and deadline changes on repeating items through both the URL scheme and AppleScript, so `cancel` used to exit 0 and change nothing. The CLI now checks for a recurrence rule and refuses with a message naming the blocked attributes. `show` prints a `Repeats:` line and JSON carries `"repeating": true`. (#129, #143)
+- **Every complete and cancel reads the status back** from the database and exits non-zero if it did not change. A new global `--no-verify` skips the check. `edit --complete --cancel` together is now rejected. (#143)
+
+### Unknown tags are no longer dropped silently
+
+- Things ignores tags that do not already exist. `add`, `edit`, `project add`, `project edit` and `import` now warn on stderr for each unknown tag, and **`--strict-tags`** refuses to write at all. Matching is case-insensitive, as Things treats tag names. Creating tags from the CLI is still open as #144. (#102, #141)
+
+### Also
+
+- Dependency bumps: modernc sqlite v1.57, kong v1.16.1, lipgloss v2.0.6. (#118)
+- Release pipeline egress allowlist narrowed to the Apple notary bucket. (#138)
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).


### PR DESCRIPTION
Release header for v0.6.0, read by goreleaser from .github/releases/v0.6.0.md at tag time. Covers #142 (filters), #143 (repeating items and write verification), #141 (unknown tags, --strict-tags) and #118 (dependency bumps). No code changes.