### PR TITLE
fix(db): exclude project headings from task lookups

### DIFF
--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -518,6 +518,31 @@ func TestRunListJSONIsUnlabelled(t *testing.T) {
 	}
 }
 
+// A project heading is a TMTask row, but it is not a to-do: search must not
+// list it (and so must not cache it as a numeric index), and show must not
+// resolve it by uuid or by title (issue #146).
+func TestHeadingNotReachableFromLookups(t *testing.T) {
+	database := seedFullDB(t)
+
+	out, err := runOut(t, database, "--json", "search", "Weekly")
+	if err != nil {
+		t.Fatalf("run search Weekly: %v", err)
+	}
+	var found []model.Task
+	if err := json.Unmarshal([]byte(out), &found); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if len(found) != 0 {
+		t.Errorf("search returned the heading: %+v", found)
+	}
+
+	for _, ref := range []string{"head-1", "Weekly"} {
+		if err := runWith(t, database, "show", ref); err == nil {
+			t.Errorf("show %q: expected an error, got none", ref)
+		}
+	}
+}
+
 // A heading-nested task reports the project it sits in, so `things show` and
 // listings don't present it as a standalone task (issue #139).
 func TestRunListHeadingTaskShowsProject(t *testing.T) {

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -157,6 +157,13 @@ var viewFilters = map[string]string{
 	"project": "t.status = 0 AND t.trashed = 0 AND t.type = 0 AND COALESCE(p.trashed, 0) = 0",
 }
 
+// notHeading excludes project headings (TMTask type 2) from the lookup
+// queries. The list views restrict to t.type = 0 outright, but a lookup has to
+// keep returning projects as well as to-dos — show, edit, complete, cancel and
+// open all resolve projects through GetTask/GetTaskByUUID — so it excludes the
+// heading type rather than pinning the task type (issue #146).
+var notHeading = fmt.Sprintf("COALESCE(t.type, 0) != %d", model.TypeHeading)
+
 var viewOrderBy = map[string]string{
 	"logbook":   "ORDER BY t.stopDate DESC",
 	"deadlines": "ORDER BY t.deadline ASC",
@@ -234,7 +241,7 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 }
 
 func (d *DB) GetTaskByUUID(uuid string) (*model.Task, error) {
-	query := d.taskQuery() + " WHERE t.uuid = ? GROUP BY t.uuid"
+	query := d.taskQuery() + " WHERE t.uuid = ? AND " + notHeading + " GROUP BY t.uuid"
 	row := d.db.QueryRow(query, uuid)
 	t, err := scanTask(row)
 	if err == sql.ErrNoRows {
@@ -256,7 +263,7 @@ func (d *DB) GetTask(uuidOrTitle string) (*model.Task, error) {
 	}
 
 	// Try exact title match
-	query := d.taskQuery() + " WHERE t.title = ? AND t.trashed = 0 AND t.status = 0 GROUP BY t.uuid LIMIT 1"
+	query := d.taskQuery() + " WHERE t.title = ? AND t.trashed = 0 AND t.status = 0 AND " + notHeading + " GROUP BY t.uuid LIMIT 1"
 	row := d.db.QueryRow(query, uuidOrTitle)
 	task, err := scanTask(row)
 	if err == nil {
@@ -282,7 +289,7 @@ func (d *DB) GetTask(uuidOrTitle string) (*model.Task, error) {
 }
 
 func (d *DB) FindTasksByTitle(substr string) ([]model.Task, error) {
-	query := d.taskQuery() + " WHERE t.title LIKE ? AND t.trashed = 0 AND t.status = 0 GROUP BY t.uuid ORDER BY t.\"index\" ASC"
+	query := d.taskQuery() + " WHERE t.title LIKE ? AND t.trashed = 0 AND t.status = 0 AND " + notHeading + " GROUP BY t.uuid ORDER BY t.\"index\" ASC"
 	return d.collectTasks(query, "%"+substr+"%")
 }
 
@@ -297,7 +304,7 @@ func (e *AmbiguousTaskError) Error() string {
 
 func (d *DB) SearchTasks(query string) ([]model.Task, error) {
 	pattern := "%" + query + "%"
-	q := d.taskQuery() + " WHERE (t.title LIKE ? OR t.notes LIKE ?) AND t.trashed = 0 GROUP BY t.uuid ORDER BY t.\"index\" ASC"
+	q := d.taskQuery() + " WHERE (t.title LIKE ? OR t.notes LIKE ?) AND t.trashed = 0 AND " + notHeading + " GROUP BY t.uuid ORDER BY t.\"index\" ASC"
 	return d.collectTasks(q, pattern, pattern)
 }
 

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -720,3 +720,146 @@ func TestListTasksProjectViewGroupsByProject(t *testing.T) {
 		}
 	}
 }
+
+// --- heading exclusion from lookups (issue #146) ---
+
+// seedLookupHeadings adds two headings on top of the seedTasks fixture: one
+// with a title of its own, and one whose title collides exactly with an open
+// to-do so a lookup that failed to filter would either return the wrong row or
+// report the pair as ambiguous.
+func seedLookupHeadings(t *testing.T, d *DB) {
+	t.Helper()
+
+	mustExec(t, d, `INSERT INTO TMTask (uuid, title, notes, type, status, trashed, project, "index") VALUES
+		('head-phase', 'Phase one',  'heading notes', 2, 0, 0, 'proj-1', 20),
+		('head-dupe',  'Inbox task', '',              2, 0, 0, 'proj-1', 21)`)
+}
+
+func TestGetTaskByUUIDExcludesHeading(t *testing.T) {
+	d := newTestDB(t)
+	seedTasks(t, d)
+	seedLookupHeadings(t, d)
+
+	got, err := d.GetTaskByUUID("head-phase")
+	if err != nil {
+		t.Fatalf("GetTaskByUUID: %v", err)
+	}
+	if got != nil {
+		t.Errorf("heading returned as a task: %+v", got)
+	}
+}
+
+// Projects still resolve — show, edit, complete, cancel and open all rely on
+// GetTaskByUUID returning a project row.
+func TestGetTaskByUUIDKeepsProject(t *testing.T) {
+	d := newTestDB(t)
+	seedTasks(t, d)
+	seedLookupHeadings(t, d)
+
+	got, err := d.GetTaskByUUID("proj-1")
+	if err != nil {
+		t.Fatalf("GetTaskByUUID: %v", err)
+	}
+	if got == nil || got.Type != model.TypeProject {
+		t.Fatalf("project lookup: got %+v", got)
+	}
+}
+
+// A heading sharing a to-do's exact title must neither win the exact-title
+// match nor make it ambiguous.
+func TestGetTaskExactTitleSkipsHeading(t *testing.T) {
+	d := newTestDB(t)
+	seedTasks(t, d)
+	seedLookupHeadings(t, d)
+
+	got, err := d.GetTask("Inbox task")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.UUID != "t-inbox" {
+		t.Errorf("got %q, want t-inbox", got.UUID)
+	}
+}
+
+func TestGetTaskLikeMatchSkipsHeading(t *testing.T) {
+	d := newTestDB(t)
+	seedTasks(t, d)
+	seedLookupHeadings(t, d)
+
+	// "Phase" matches only the heading, so the lookup should not find a task.
+	if _, err := d.GetTask("Phase"); err == nil {
+		t.Fatal("expected not-found error for a heading-only title")
+	}
+
+	// A single to-do plus a same-named heading resolves to the to-do rather
+	// than raising AmbiguousTaskError.
+	got, err := d.GetTask("nbox tas")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.UUID != "t-inbox" {
+		t.Errorf("got %q, want t-inbox", got.UUID)
+	}
+}
+
+func TestFindTasksByTitleExcludesHeadings(t *testing.T) {
+	d := newTestDB(t)
+	seedTasks(t, d)
+	seedLookupHeadings(t, d)
+
+	got, err := d.FindTasksByTitle("Phase")
+	if err != nil {
+		t.Fatalf("FindTasksByTitle: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want no matches", uuidsOf(got))
+	}
+
+	dupes, err := d.FindTasksByTitle("Inbox task")
+	if err != nil {
+		t.Fatalf("FindTasksByTitle: %v", err)
+	}
+	if !sameSet(uuidsOf(dupes), []string{"t-inbox"}) {
+		t.Errorf("got %v, want [t-inbox]", uuidsOf(dupes))
+	}
+}
+
+func TestSearchTasksExcludesHeadings(t *testing.T) {
+	d := newTestDB(t)
+	seedTasks(t, d)
+	seedLookupHeadings(t, d)
+
+	byTitle, err := d.SearchTasks("Phase")
+	if err != nil {
+		t.Fatalf("SearchTasks: %v", err)
+	}
+	if len(byTitle) != 0 {
+		t.Errorf("title search: got %v, want no matches", uuidsOf(byTitle))
+	}
+
+	byNotes, err := d.SearchTasks("heading notes")
+	if err != nil {
+		t.Fatalf("SearchTasks: %v", err)
+	}
+	if len(byNotes) != 0 {
+		t.Errorf("notes search: got %v, want no matches", uuidsOf(byNotes))
+	}
+
+	// The to-do sharing the heading's title still comes back, alone.
+	shared, err := d.SearchTasks("Inbox task")
+	if err != nil {
+		t.Fatalf("SearchTasks: %v", err)
+	}
+	if !sameSet(uuidsOf(shared), []string{"t-inbox"}) {
+		t.Errorf("got %v, want [t-inbox]", uuidsOf(shared))
+	}
+
+	// Projects remain searchable.
+	proj, err := d.SearchTasks("Ship MVP")
+	if err != nil {
+		t.Fatalf("SearchTasks: %v", err)
+	}
+	if !sameSet(uuidsOf(proj), []string{"proj-1"}) {
+		t.Errorf("project search: got %v, want [proj-1]", uuidsOf(proj))
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -11,6 +11,9 @@ import (
 const (
 	TypeTask    = 0
 	TypeProject = 1
+	// TypeHeading is a project heading — a TMTask row that groups to-dos
+	// inside a project. It is never a to-do itself, so lookups exclude it.
+	TypeHeading = 2
 
 	StatusOpen      Status = 0
 	StatusCancelled Status = 2


### PR DESCRIPTION
## What changed

Project headings are `TMTask` rows with `type = 2`, and the lookup queries in `internal/db` had no type filter, so a heading could come back as if it were a to-do. `GetTaskByUUID`, `GetTask`'s exact-title match, `FindTasksByTitle` and `SearchTasks` now all exclude type 2 in SQL, via a shared `notHeading` predicate built from a new `model.TypeHeading` constant.

## Why

The list and filter paths were fixed in #142 by pinning `t.type = 0` in every `viewFilters` entry, but the lookups were left as-is. That leaves `search`, `show`, `edit`, `complete`, `cancel`, `open` and title resolution able to surface a heading. `search` is the worst of it: `SearchCmd.Run` feeds its results into the numeric-index cache, so a heading can be listed as `#3` and then resolved straight back through `GetTaskByUUID` into a write command.

I filtered in SQL rather than rejecting headings in the callers. The callers are the wrong place for two reasons: a caller-side check in `resolveTask` still lets the heading into the index cache that `search` populates, and it cannot stop a heading sharing a to-do's title from turning an exact-title lookup into an `AmbiguousTaskError`. Doing it in the query fixes both, and covers `verifyStatus` in `cmd/things/verify.go` for free.

The predicate is `COALESCE(t.type, 0) != 2` rather than `t.type = 0`, because lookups have to keep returning projects — `project edit`, `show`, `complete`, `cancel` and `open` all resolve a project through `GetTask`/`GetTaskByUUID`. Excluding the heading type keeps that working while the list views stay pinned to to-dos.

## How tested

`make test` and `make lint` both clean.

New regression tests, one per lookup, seeding a heading alongside the existing fixture — including a heading whose title collides exactly with an open to-do:

- `TestGetTaskByUUIDExcludesHeading`
- `TestGetTaskByUUIDKeepsProject` — guards that projects still resolve
- `TestGetTaskExactTitleSkipsHeading` — the same-titled heading neither wins the match nor makes it ambiguous
- `TestGetTaskLikeMatchSkipsHeading`
- `TestFindTasksByTitleExcludesHeadings`
- `TestSearchTasksExcludesHeadings` — title and notes, and projects stay searchable
- `TestHeadingNotReachableFromLookups` in `cmd/things` — end-to-end: `search` does not list the heading (so it never reaches the index cache) and `show` resolves it neither by uuid nor by title

I checked the tests are not vacuous by neutralising the predicate and confirming all of them fail.

No change to any subcommand's surface, so `internal/skill/SKILL.md` is untouched.

Closes #146