### PR TITLE
feat(tags): create tags from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ project.
 | `--list NAME` | ✓ | — | List (project or area) name |
 | `--area NAME` | — | ✓ | Area to file the project under |
 | `--strict-tags` | ✓ | ✓ | Fail instead of writing when a tag does not exist (see [Tags must already exist](#tags-must-already-exist)) |
+| `--create-tags` | ✓ | ✓ | Create tags that do not exist before writing (see [Tags must already exist](#tags-must-already-exist)) |
 
 Examples:
 
@@ -256,6 +257,7 @@ stay untouched. An empty value clears the field (e.g. `--deadline ""`).
 | `--duplicate` | ✓ | ✓ | Duplicate before applying edits |
 | `--reveal` | ✓ | ✓ | Reveal in Things after editing |
 | `--strict-tags` | ✓ | ✓ | Fail instead of writing when a tag does not exist (see [Tags must already exist](#tags-must-already-exist)) |
+| `--create-tags` | ✓ | ✓ | Create tags that do not exist before writing (see [Tags must already exist](#tags-must-already-exist)) |
 
 > **Repeating items:** Things refuses `--when`, `--deadline`, `--complete`,
 > `--cancel`, and `--duplicate` on repeating to-dos and projects, and drops the
@@ -277,32 +279,57 @@ things project edit "Launch" --append-notes "Beta cut on Friday"
 
 Things applies only tags that already exist. A tag it doesn't recognise is
 dropped silently — the task is still created or updated, minus the tag, and
-the command exits 0. The CLI cannot create tags: the URL scheme has no way
-to, and there is no `things tag add` command.
+the command exits 0. The URL scheme cannot create tags, so the CLI creates
+them over AppleScript instead.
 
-To stop that being invisible, every write that carries tags (`add`,
+To stop the drop being invisible, every write that carries tags (`add`,
 `project add`, `edit`, `project edit`, `import`) first checks them against
 the Things database and warns on stderr about any it cannot find:
 
 ```
 $ things add "Review the flags" --tags "Work,cifas-auto-reject"
 warning: these tags do not exist in Things and will be ignored: cifas-auto-reject
-warning: Things only applies tags that already exist — create them in Things first, or use --strict-tags to fail instead of dropping them
+warning: Things only applies tags that already exist — create them with --create-tags or `things tag add`, or use --strict-tags to fail instead of dropping them
 ```
 
-The write still goes ahead. Pass `--strict-tags` to refuse it instead:
+The write still goes ahead. Pass `--create-tags` to create the missing tags
+first, so the write applies all of them:
+
+```
+$ things add "Review the flags" --tags "Work,cifas-auto-reject" --create-tags
+created in Things: cifas-auto-reject
+```
+
+Or pass `--strict-tags` to refuse the write instead:
 
 ```
 $ things add "Review the flags" --tags "Work,cifas-auto-reject" --strict-tags
-Error: these tags do not exist in Things: cifas-auto-reject — create them in Things first, or drop --strict-tags to write anyway
+Error: these tags do not exist in Things: cifas-auto-reject — create them in Things first, run `things tag add cifas-auto-reject`, or drop --strict-tags to write anyway
 ```
 
-Nothing is written in that case, and the exit status is non-zero. Tag names
-are matched case-insensitively, the way Things treats them. If the database
-can't be read, `add` and `project add` skip the check with a warning — unless
-`--strict-tags` is set, which then fails rather than write unchecked. `edit`,
-`project edit` and `import` need the database for other reasons and fail
-either way.
+Nothing is written in that case, and the exit status is non-zero. The two
+flags contradict each other and are rejected together. Tag names are matched
+case-insensitively, the way Things treats them. If the database can't be read,
+`add` and `project add` skip the check with a warning — unless `--strict-tags`
+or `--create-tags` is set, either of which then fails rather than write
+unchecked. `edit`, `project edit` and `import` need the database for other
+reasons and fail either way.
+
+### Creating tags
+
+`things tag add` creates tags without writing a task:
+
+```
+$ things tag add focus "deep work" Work
+created: focus, deep work
+already exists: Work
+```
+
+Names that already exist are skipped rather than duplicated, matched
+case-insensitively. Creation goes through AppleScript, so Things3 must be
+running. The command reads the tag list back afterwards to confirm the tags
+landed; `--no-verify` skips that. `--json` reports the two lists as
+`{"created": [...], "skipped": [...]}`.
 
 ### Completing, cancelling, logging
 
@@ -381,6 +408,7 @@ for create-only payloads).
 | `-f, --file PATH` | Read JSON payload from this file instead of stdin |
 | `--reveal` | Reveal the first created/updated item in Things after import |
 | `--strict-tags` | Fail instead of importing when a tag in the payload does not exist (see [Tags must already exist](#tags-must-already-exist)) |
+| `--create-tags` | Create tags in the payload that do not exist before importing (see [Tags must already exist](#tags-must-already-exist)) |
 
 ```sh
 things import < payload.json

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -35,7 +35,7 @@ type CLI struct {
 	DB      string           `help:"Override database path." type:"existingfile"`
 	Version kong.VersionFlag `help:"Print version and exit." short:"v"`
 
-	NoVerify bool `help:"Skip the read-back that confirms a complete/cancel actually landed." name:"no-verify" default:"false"`
+	NoVerify bool `help:"Skip the read-back that confirms a complete/cancel or tag creation actually landed." name:"no-verify" default:"false"`
 
 	List     ListCmd     `cmd:"" help:"List tasks (today,inbox,upcoming,anytime,someday,logbook,trash,deadlines). Use as: things today, things inbox, etc." default:"withargs"`
 	Projects ProjectsCmd `cmd:"" help:"List projects."`

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -41,6 +41,7 @@ type CLI struct {
 	Projects ProjectsCmd `cmd:"" help:"List projects."`
 	Areas    AreasCmd    `cmd:"" help:"List areas."`
 	Tags     TagsCmd     `cmd:"" help:"List tags."`
+	Tag      TagCmd      `cmd:"" help:"Manage tags."`
 	Show     ShowCmd     `cmd:"" help:"Show task detail."`
 	Add      AddCmd      `cmd:"" help:"Create a new task."`
 	Project  ProjectCmd  `cmd:"" help:"Manage projects."`
@@ -305,11 +306,11 @@ type AddCmd struct {
 	Heading   string `help:"Heading within project."`
 	List      string `help:"List (project or area) name."`
 
-	StrictTags
+	TagFlags
 }
 
 func (c *AddCmd) Run(d *Deps) error {
-	if err := verifyTagStrings(d, c.StrictTags.StrictTags, &c.Tags); err != nil {
+	if err := verifyTagStrings(d, c.TagFlags, &c.Tags); err != nil {
 		return err
 	}
 	list := c.List
@@ -342,11 +343,11 @@ type ProjectAddCmd struct {
 	Area     string `help:"Area name or UUID."`
 	Todos    string `help:"Newline-separated initial to-dos."`
 
-	StrictTags
+	TagFlags
 }
 
 func (c *ProjectAddCmd) Run(d *Deps) error {
-	if err := verifyTagStrings(d, c.StrictTags.StrictTags, &c.Tags); err != nil {
+	if err := verifyTagStrings(d, c.TagFlags, &c.Tags); err != nil {
 		return err
 	}
 	return things.AddProject(things.AddProjectParams{
@@ -383,7 +384,7 @@ type ProjectEditCmd struct {
 	Duplicate bool `help:"Duplicate the project before applying edits."`
 	Reveal    bool `help:"Reveal the project in Things after editing."`
 
-	StrictTags
+	TagFlags
 }
 
 func (c *ProjectEditCmd) Run(d *Deps) error {
@@ -403,7 +404,7 @@ func (c *ProjectEditCmd) Run(d *Deps) error {
 	}
 	// After checkRepeating: no point warning about tags on an edit Things
 	// is going to refuse anyway.
-	if err := verifyTagStrings(d, c.StrictTags.StrictTags, c.Tags, c.AddTags); err != nil {
+	if err := verifyTagStrings(d, c.TagFlags, c.Tags, c.AddTags); err != nil {
 		return err
 	}
 
@@ -460,7 +461,7 @@ type EditCmd struct {
 	Duplicate bool `help:"Duplicate the task before applying edits."`
 	Reveal    bool `help:"Reveal the task in Things after editing."`
 
-	StrictTags
+	TagFlags
 }
 
 func (c *EditCmd) Run(d *Deps) error {
@@ -477,7 +478,7 @@ func (c *EditCmd) Run(d *Deps) error {
 	}
 	// After checkRepeating: no point warning about tags on an edit Things
 	// is going to refuse anyway.
-	if err := verifyTagStrings(d, c.StrictTags.StrictTags, c.Tags, c.AddTags); err != nil {
+	if err := verifyTagStrings(d, c.TagFlags, c.Tags, c.AddTags); err != nil {
 		return err
 	}
 
@@ -701,7 +702,7 @@ type ImportCmd struct {
 	File   string `help:"Read JSON payload from this file instead of stdin." short:"f" type:"existingfile"`
 	Reveal bool   `help:"Reveal the first created/updated item in Things after import."`
 
-	StrictTags
+	TagFlags
 }
 
 func (c *ImportCmd) Run(d *Deps) error {
@@ -727,7 +728,7 @@ func (c *ImportCmd) Run(d *Deps) error {
 	if err := validateImportJSON(data); err != nil {
 		return err
 	}
-	if err := verifyTags(d, c.StrictTags.StrictTags, importTags(data)); err != nil {
+	if err := verifyTags(d, c.TagFlags, importTags(data)); err != nil {
 		return err
 	}
 	token, err := database.GetAuthToken()

--- a/cmd/things/tag_add_test.go
+++ b/cmd/things/tag_add_test.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/ryanlewis/things-cli/internal/db"
+	"github.com/ryanlewis/things-cli/internal/db/dbtest"
+	"github.com/ryanlewis/things-cli/internal/skill"
+	"github.com/ryanlewis/things-cli/internal/things"
+)
+
+// seedTagDB returns an in-memory DB holding the tag "Work", a to-do to hang
+// writes off, and the auth token, plus the raw handle so a test can simulate
+// Things creating a tag.
+func seedTagDB(t *testing.T) (*db.DB, *sql.DB) {
+	t.Helper()
+	sqlDB := dbtest.NewSQL(t)
+	stmts := []string{
+		`INSERT INTO TMSettings (uuid, uriSchemeAuthenticationToken) VALUES ('s1', 'tok')`,
+		`INSERT INTO TMTag (uuid, title, "index") VALUES ('tag-1', 'Work', 0)`,
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, start)
+		 VALUES ('one-1', 'Post letter', 0, 0, 0, 2)`,
+	}
+	for _, s := range stmts {
+		if _, err := sqlDB.Exec(s); err != nil {
+			t.Fatalf("seed %q: %v", s, err)
+		}
+	}
+	return db.NewFromSQL(sqlDB), sqlDB
+}
+
+// stubExecCreatingTags records every exec call. When sqlDB is non-nil it also
+// inserts the tag named by a tag-creating AppleScript, as Things would, so the
+// read-back finds it.
+func stubExecCreatingTags(t *testing.T, sqlDB *sql.DB) *[][]string {
+	t.Helper()
+	var calls [][]string
+	prev := things.SetExecCommandForTest(func(name string, args ...string) *exec.Cmd {
+		calls = append(calls, append([]string{name}, args...))
+		if sqlDB == nil || len(args) != 2 || args[0] != "-e" {
+			return exec.Command("true")
+		}
+		title := tagNameFromScript(args[1])
+		if title == "" {
+			return exec.Command("true")
+		}
+		if _, err := sqlDB.Exec(
+			`INSERT INTO TMTag (uuid, title, "index") VALUES (?, ?, ?)`,
+			fmt.Sprintf("new-tag-%d", len(calls)), title, len(calls),
+		); err != nil {
+			t.Errorf("simulating Things tag write: %v", err)
+		}
+		return exec.Command("true")
+	})
+	t.Cleanup(func() { things.SetExecCommandForTest(prev) })
+	return &calls
+}
+
+// tagNameFromScript pulls the tag name back out of a creation script, undoing
+// the escaping appleScriptString applied. Returns "" for any other script.
+func tagNameFromScript(script string) string {
+	const prefix = `make new tag with properties {name:"`
+	i := strings.Index(script, prefix)
+	if i < 0 {
+		return ""
+	}
+	rest := script[i+len(prefix):]
+	j := strings.Index(rest, `"}`)
+	if j < 0 {
+		return ""
+	}
+	return strings.NewReplacer(`\\`, `\`, `\"`, `"`).Replace(rest[:j])
+}
+
+// osascriptTagNames lists the tags the recorded calls asked Things to create.
+func osascriptTagNames(calls [][]string) []string {
+	var names []string
+	for _, c := range calls {
+		if len(c) == 3 && c[0] == "osascript" {
+			if name := tagNameFromScript(c[2]); name != "" {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
+// writeTempFile writes content to a throwaway file and returns its path.
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "payload")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// parseCLI parses args the way main does, returning the parse error instead of
+// failing the test — for asserting on flag validation.
+func parseCLI(t *testing.T, args ...string) error {
+	t.Helper()
+	var cli CLI
+	parser, err := kong.New(&cli, kong.Name("things"),
+		kong.Vars{
+			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
+			"skill_agents":  skill.AgentNames(),
+		},
+	)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	_, err = parser.Parse(args)
+	return err
+}
+
+func TestTagAddCreatesOnlyMissingTags(t *testing.T) {
+	database, sqlDB := seedTagDB(t)
+	calls := stubExecCreatingTags(t, sqlDB)
+
+	out, err := runOut(t, database, "tag", "add", "focus", "Work")
+	if err != nil {
+		t.Fatalf("tag add: %v", err)
+	}
+	if got := osascriptTagNames(*calls); len(got) != 1 || got[0] != "focus" {
+		t.Errorf("created %v, want [focus]", got)
+	}
+	if !strings.Contains(out, "created: focus") {
+		t.Errorf("output does not report the creation: %q", out)
+	}
+	if !strings.Contains(out, "already exists: Work") {
+		t.Errorf("output does not report the skip: %q", out)
+	}
+}
+
+// Things treats names differing only in case as the same tag, so "work"
+// alongside an existing "Work" must not create a near-duplicate.
+func TestTagAddSkipsCaseInsensitiveMatch(t *testing.T) {
+	database, sqlDB := seedTagDB(t)
+	calls := stubExecCreatingTags(t, sqlDB)
+
+	out, err := runOut(t, database, "tag", "add", "work")
+	if err != nil {
+		t.Fatalf("tag add: %v", err)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("expected no writes, got %v", *calls)
+	}
+	if !strings.Contains(out, "already exists: work") {
+		t.Errorf("output does not report the skip: %q", out)
+	}
+}
+
+func TestTagAddDedupesArguments(t *testing.T) {
+	database, sqlDB := seedTagDB(t)
+	calls := stubExecCreatingTags(t, sqlDB)
+
+	if _, err := runOut(t, database, "tag", "add", "focus", "FOCUS", " focus "); err != nil {
+		t.Fatalf("tag add: %v", err)
+	}
+	if got := osascriptTagNames(*calls); len(got) != 1 || got[0] != "focus" {
+		t.Errorf("created %v, want [focus] once", got)
+	}
+}
+
+func TestTagAddRejectsBlankNames(t *testing.T) {
+	database, sqlDB := seedTagDB(t)
+	calls := stubExecCreatingTags(t, sqlDB)
+
+	_, err := runOut(t, database, "tag", "add", "  ")
+	if err == nil || !strings.Contains(err.Error(), "no tag names") {
+		t.Fatalf("expected a no-names error, got %v", err)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("expected no writes, got %v", *calls)
+	}
+}
+
+func TestTagAddJSON(t *testing.T) {
+	database, sqlDB := seedTagDB(t)
+	stubExecCreatingTags(t, sqlDB)
+
+	out, err := runOut(t, database, "--json", "tag", "add", "focus", "Work")
+	if err != nil {
+		t.Fatalf("tag add: %v", err)
+	}
+	var got tagAddResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if len(got.Created) != 1 || got.Created[0] != "focus" {
+		t.Errorf("created = %v, want [focus]", got.Created)
+	}
+	if len(got.Skipped) != 1 || got.Skipped[0] != "Work" {
+		t.Errorf("skipped = %v, want [Work]", got.Skipped)
+	}
+}
+
+// A creation Things accepted and then dropped must not report success.
+func TestTagAddVerifiesCreationLanded(t *testing.T) {
+	fastVerify(t)
+	database, _ := seedTagDB(t)
+	stubExecCreatingTags(t, nil) // records the call, writes nothing
+
+	_, err := runOut(t, database, "tag", "add", "focus")
+	if err == nil || !strings.Contains(err.Error(), "tag creation did not apply") {
+		t.Fatalf("expected a verification failure, got %v", err)
+	}
+}
+
+func TestTagAddNoVerifySkipsReadBack(t *testing.T) {
+	fastVerify(t)
+	database, _ := seedTagDB(t)
+	stubExecCreatingTags(t, nil)
+
+	if _, err := runOut(t, database, "--no-verify", "tag", "add", "focus"); err != nil {
+		t.Fatalf("tag add --no-verify: %v", err)
+	}
+}
+
+func TestTagAddReportsCreationFailure(t *testing.T) {
+	database, _ := seedTagDB(t)
+	prev := things.SetExecCommandForTest(func(string, ...string) *exec.Cmd {
+		return exec.Command("false")
+	})
+	t.Cleanup(func() { things.SetExecCommandForTest(prev) })
+
+	_, err := runOut(t, database, "tag", "add", "focus")
+	if err == nil || !strings.Contains(err.Error(), `creating tag "focus"`) {
+		t.Fatalf("expected a creation failure naming the tag, got %v", err)
+	}
+}
+
+// --create-tags creates each missing tag over AppleScript before the URL
+// scheme write, so Things has the tag by the time it applies it.
+func TestCreateTagsRunsBeforeTheWrite(t *testing.T) {
+	database, sqlDB := seedTagDB(t)
+	calls := stubExecCreatingTags(t, sqlDB)
+
+	stderr, err := runCapturingStderr(t, database, "add", "Buy milk", "--tags", "focus,Work", "--create-tags")
+	if err != nil {
+		t.Fatalf("add --create-tags: %v", err)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("expected a create then a write, got %v", *calls)
+	}
+	if got := osascriptTagNames(*calls); len(got) != 1 || got[0] != "focus" {
+		t.Errorf("created %v, want [focus] only", got)
+	}
+	write := (*calls)[1]
+	if write[0] != "open" || !strings.Contains(strings.Join(write, " "), "things:///add") {
+		t.Errorf("second call is not the URL-scheme write: %v", write)
+	}
+	if !strings.Contains(stderr, "created in Things: focus") {
+		t.Errorf("stderr does not report the creation: %q", stderr)
+	}
+	if strings.Contains(stderr, "will be ignored") {
+		t.Errorf("stderr still warns about a tag it created: %q", stderr)
+	}
+}
+
+// Every command that accepts tags accepts --create-tags.
+func TestCreateTagsOnEveryTagWrite(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"add", []string{"add", "Buy milk", "--tags", "focus", "--create-tags"}},
+		{"projectAdd", []string{"project", "add", "Launch", "--tags", "focus", "--create-tags"}},
+		{"edit", []string{"edit", "one-1", "--add-tags", "focus", "--create-tags"}},
+		{"projectEdit", []string{"project", "edit", "proj-1", "--add-tags", "focus", "--create-tags"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			database, sqlDB := seedTagDB(t)
+			if _, err := sqlDB.Exec(
+				`INSERT INTO TMTask (uuid, title, type, status, trashed) VALUES ('proj-1', 'Chores', 1, 0, 0)`,
+			); err != nil {
+				t.Fatalf("seed project: %v", err)
+			}
+			calls := stubExecCreatingTags(t, sqlDB)
+
+			if _, err := runOut(t, database, tc.args...); err != nil {
+				t.Fatalf("%v: %v", tc.args, err)
+			}
+			if got := osascriptTagNames(*calls); len(got) != 1 || got[0] != "focus" {
+				t.Errorf("created %v, want [focus]", got)
+			}
+		})
+	}
+}
+
+func TestImportCreateTags(t *testing.T) {
+	database, sqlDB := seedTagDB(t)
+	calls := stubExecCreatingTags(t, sqlDB)
+
+	path := writeTempFile(t, `[{"type":"to-do","attributes":{"title":"x","tags":["focus","Work"]}}]`)
+	if _, err := runOut(t, database, "import", "--file", path, "--create-tags"); err != nil {
+		t.Fatalf("import --create-tags: %v", err)
+	}
+	if got := osascriptTagNames(*calls); len(got) != 1 || got[0] != "focus" {
+		t.Errorf("created %v, want [focus]", got)
+	}
+}
+
+// A tag that could not be created aborts the write rather than letting Things
+// silently drop it.
+func TestCreateTagsFailureBlocksTheWrite(t *testing.T) {
+	database, _ := seedTagDB(t)
+	var calls int
+	prev := things.SetExecCommandForTest(func(string, ...string) *exec.Cmd {
+		calls++
+		return exec.Command("false")
+	})
+	t.Cleanup(func() { things.SetExecCommandForTest(prev) })
+
+	_, err := runOut(t, database, "add", "Buy milk", "--tags", "focus", "--create-tags")
+	if err == nil || !strings.Contains(err.Error(), `creating tag "focus"`) {
+		t.Fatalf("expected a creation failure, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected the write to be skipped, got %d exec calls", calls)
+	}
+}
+
+// --create-tags and --strict-tags ask for opposite things, so they are
+// rejected together on every command that carries them.
+func TestCreateTagsConflictsWithStrictTags(t *testing.T) {
+	cases := [][]string{
+		{"add", "Buy milk", "--tags", "focus", "--create-tags", "--strict-tags"},
+		{"project", "add", "Launch", "--tags", "focus", "--create-tags", "--strict-tags"},
+		{"edit", "one-1", "--add-tags", "focus", "--create-tags", "--strict-tags"},
+		{"project", "edit", "proj-1", "--add-tags", "focus", "--create-tags", "--strict-tags"},
+		{"import", "--create-tags", "--strict-tags"},
+	}
+	for _, args := range cases {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			err := parseCLI(t, args...)
+			if err == nil {
+				t.Fatal("expected the two flags to be rejected together")
+			}
+			if !strings.Contains(err.Error(), "create-tags") || !strings.Contains(err.Error(), "strict-tags") {
+				t.Errorf("error does not name both flags: %v", err)
+			}
+		})
+	}
+}
+
+// --create-tags cannot fall back to a warning: without the database it cannot
+// tell which tags are missing, so it refuses rather than writing a task whose
+// tags Things would drop.
+func TestCreateTagsRefusesWithoutTheDatabase(t *testing.T) {
+	deps, _ := newTagDeps(t)
+	deps.DB = nil
+	deps.DBPath = writeTempFile(t, "not a database")
+
+	err := verifyTags(deps, TagFlags{CreateTags: true}, []string{"anything"})
+	if err == nil || !strings.Contains(err.Error(), "--create-tags") {
+		t.Fatalf("expected a --create-tags failure, got %v", err)
+	}
+}

--- a/cmd/things/tags.go
+++ b/cmd/things/tags.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -62,11 +63,26 @@ func verifyTags(d *Deps, flags TagFlags, names []string) error {
 
 	list := strings.Join(unknown, ", ")
 	if flags.StrictTags {
-		return fmt.Errorf("these tags do not exist in Things: %s — create them in Things first, run `things tag add %s`, or drop --strict-tags to write anyway", list, list)
+		return fmt.Errorf("these tags do not exist in Things: %s — create them in Things first, run `%s`, or drop --strict-tags to write anyway", list, tagAddHint(unknown))
 	}
 	fmt.Fprintf(d.errOut(), "warning: these tags do not exist in Things and will be ignored: %s\n", list)
 	fmt.Fprintf(d.errOut(), "warning: Things only applies tags that already exist — create them with --create-tags or `things tag add`, or use --strict-tags to fail instead of dropping them\n")
 	return nil
+}
+
+// tagAddHint renders a copy-pastable `things tag add` command for names.
+// `tag add` takes names as separate positional arguments and does not split on
+// commas, so joining with ", " would suggest a command that creates a tag
+// literally named "foo," — hence a space-separated, quoted list.
+func tagAddHint(names []string) string {
+	parts := make([]string, 0, len(names))
+	for _, n := range names {
+		if strings.ContainsAny(n, " \t\"'\\`$") {
+			n = strconv.Quote(n)
+		}
+		parts = append(parts, n)
+	}
+	return "things tag add " + strings.Join(parts, " ")
 }
 
 // createTags makes each missing tag in Things over AppleScript. It runs before
@@ -177,14 +193,17 @@ type tagAddResult struct {
 }
 
 func (c *TagAddCmd) Run(d *Deps) error {
-	database, err := d.Database()
-	if err != nil {
-		return err
-	}
-
+	// Validate the arguments before opening the database, so a blank name
+	// reports itself rather than surfacing as "cannot find the Things
+	// database" on a machine where the database is missing.
 	names := dedupeTagNames(c.Names)
 	if len(names) == 0 {
 		return fmt.Errorf("tag add: no tag names given")
+	}
+
+	database, err := d.Database()
+	if err != nil {
+		return err
 	}
 
 	// UnknownTags matches case-insensitively, so "work" is reported as
@@ -218,6 +237,9 @@ func (c *TagAddCmd) Run(d *Deps) error {
 
 	if len(created) > 0 && !d.NoVerify {
 		if err := verifyTagsCreated(database, created); err != nil {
+			// The creations were sent, so say which ones — otherwise a
+			// verification failure looks like nothing happened.
+			fmt.Fprintf(d.errOut(), "sent to Things before the failure: %s\n", strings.Join(created, ", "))
 			return err
 		}
 	}

--- a/cmd/things/tags.go
+++ b/cmd/things/tags.go
@@ -4,30 +4,40 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/ryanlewis/things-cli/internal/db"
+	"github.com/ryanlewis/things-cli/internal/output"
 	"github.com/ryanlewis/things-cli/internal/things"
 )
 
-// StrictTags is embedded in every write command that accepts tags. The Things
+// TagFlags is embedded in every write command that accepts tags. The Things
 // URL scheme applies only tags that already exist and ignores the rest without
 // reporting it, so by default we warn and let the write through; --strict-tags
-// turns that warning into a refusal.
-type StrictTags struct {
-	StrictTags bool `help:"Fail instead of writing when a tag does not exist in Things." name:"strict-tags"`
+// turns that warning into a refusal, and --create-tags creates the missing tags
+// over AppleScript so the write can apply them. The two contradict each other,
+// so kong rejects them together.
+type TagFlags struct {
+	StrictTags bool `help:"Fail instead of writing when a tag does not exist in Things." name:"strict-tags" xor:"tag-policy"`
+	CreateTags bool `help:"Create tags that do not exist in Things before writing." name:"create-tags" xor:"tag-policy"`
 }
 
 // verifyTags checks requested tag names against the tags in the Things
-// database and reports the ones that don't exist. Without strict it warns on
-// stderr and returns nil so the write still happens; with strict it returns an
-// error and the caller writes nothing.
-func verifyTags(d *Deps, strict bool, names []string) error {
+// database and deals with the ones that don't exist. By default it warns on
+// stderr and returns nil so the write still happens; --strict-tags turns that
+// into an error and the caller writes nothing; --create-tags creates them and
+// lets the write proceed with every tag applied.
+func verifyTags(d *Deps, flags TagFlags, names []string) error {
 	if len(names) == 0 {
 		return nil
 	}
 
 	unavailable := func(err error) error {
-		if strict {
+		switch {
+		case flags.StrictTags:
 			return fmt.Errorf("--strict-tags: cannot check tags against the Things database: %w", err)
+		case flags.CreateTags:
+			return fmt.Errorf("--create-tags: cannot check tags against the Things database: %w", err)
 		}
 		fmt.Fprintf(d.errOut(), "warning: could not check tags against the Things database: %v\n", err)
 		fmt.Fprintf(d.errOut(), "warning: tags that do not already exist in Things will be dropped without notice\n")
@@ -46,25 +56,49 @@ func verifyTags(d *Deps, strict bool, names []string) error {
 		return nil
 	}
 
+	if flags.CreateTags {
+		return createTags(d, unknown)
+	}
+
 	list := strings.Join(unknown, ", ")
-	if strict {
-		return fmt.Errorf("these tags do not exist in Things: %s — create them in Things first, or drop --strict-tags to write anyway", list)
+	if flags.StrictTags {
+		return fmt.Errorf("these tags do not exist in Things: %s — create them in Things first, run `things tag add %s`, or drop --strict-tags to write anyway", list, list)
 	}
 	fmt.Fprintf(d.errOut(), "warning: these tags do not exist in Things and will be ignored: %s\n", list)
-	fmt.Fprintf(d.errOut(), "warning: Things only applies tags that already exist — create them in Things first, or use --strict-tags to fail instead of dropping them\n")
+	fmt.Fprintf(d.errOut(), "warning: Things only applies tags that already exist — create them with --create-tags or `things tag add`, or use --strict-tags to fail instead of dropping them\n")
+	return nil
+}
+
+// createTags makes each missing tag in Things over AppleScript. It runs before
+// the URL-scheme write that wants to apply them: osascript returns only once
+// Things has the tag, so the write that follows finds it by name. No read-back
+// is needed — that would only prove the SQLite database had caught up, which
+// the URL scheme does not depend on.
+func createTags(d *Deps, names []string) error {
+	var created []string
+	for _, name := range names {
+		if err := things.CreateTag(name); err != nil {
+			if len(created) > 0 {
+				fmt.Fprintf(d.errOut(), "created in Things before the failure: %s\n", strings.Join(created, ", "))
+			}
+			return fmt.Errorf("creating tag %q: %w", name, err)
+		}
+		created = append(created, name)
+	}
+	fmt.Fprintf(d.errOut(), "created in Things: %s\n", strings.Join(created, ", "))
 	return nil
 }
 
 // verifyTagStrings checks comma-separated tag values (as passed to --tags /
 // --add-tags). nil pointers and empty strings contribute nothing.
-func verifyTagStrings(d *Deps, strict bool, values ...*string) error {
+func verifyTagStrings(d *Deps, flags TagFlags, values ...*string) error {
 	var names []string
 	for _, v := range values {
 		if v != nil {
 			names = append(names, things.SplitTags(*v)...)
 		}
 	}
-	return verifyTags(d, strict, names)
+	return verifyTags(d, flags, names)
 }
 
 // importTags collects every tag named anywhere in a Things JSON payload. Tags
@@ -124,4 +158,125 @@ func jsonTagValues(node any) []string {
 		return things.SplitTags(v)
 	}
 	return nil
+}
+
+// TagCmd groups the tag write commands. Listing tags stays on the top-level
+// `things tags`.
+type TagCmd struct {
+	Add TagAddCmd `cmd:"" help:"Create tags in Things."`
+}
+
+type TagAddCmd struct {
+	Names []string `arg:"" required:"" help:"Tag names to create. Names that already exist are skipped."`
+}
+
+// tagAddResult is the --json shape of `things tag add`.
+type tagAddResult struct {
+	Created []string `json:"created"`
+	Skipped []string `json:"skipped"`
+}
+
+func (c *TagAddCmd) Run(d *Deps) error {
+	database, err := d.Database()
+	if err != nil {
+		return err
+	}
+
+	names := dedupeTagNames(c.Names)
+	if len(names) == 0 {
+		return fmt.Errorf("tag add: no tag names given")
+	}
+
+	// UnknownTags matches case-insensitively, so "work" is reported as
+	// existing when Things already has "Work" and we don't create a near
+	// duplicate the user would have to merge by hand.
+	missing, err := database.UnknownTags(names)
+	if err != nil {
+		return err
+	}
+	toCreate := make(map[string]struct{}, len(missing))
+	for _, n := range missing {
+		toCreate[foldTagName(n)] = struct{}{}
+	}
+	skipped := []string{}
+	for _, n := range names {
+		if _, ok := toCreate[foldTagName(n)]; !ok {
+			skipped = append(skipped, n)
+		}
+	}
+
+	created := []string{}
+	for _, name := range missing {
+		if err := things.CreateTag(name); err != nil {
+			if len(created) > 0 {
+				fmt.Fprintf(d.errOut(), "created before the failure: %s\n", strings.Join(created, ", "))
+			}
+			return fmt.Errorf("creating tag %q: %w", name, err)
+		}
+		created = append(created, name)
+	}
+
+	if len(created) > 0 && !d.NoVerify {
+		if err := verifyTagsCreated(database, created); err != nil {
+			return err
+		}
+	}
+
+	if d.JSON {
+		return output.Print(d.Stdout, tagAddResult{Created: created, Skipped: skipped}, true)
+	}
+	if len(created) > 0 {
+		fmt.Fprintf(d.Stdout, "created: %s\n", strings.Join(created, ", "))
+	}
+	if len(skipped) > 0 {
+		fmt.Fprintf(d.Stdout, "already exists: %s\n", strings.Join(skipped, ", "))
+	}
+	return nil
+}
+
+// verifyTagsCreated re-reads the tag list until every name shows up, so a
+// creation Things dropped is not reported as success. Things writes the tag to
+// its SQLite database a moment after AppleScript returns, hence the poll.
+// --no-verify skips it.
+func verifyTagsCreated(database *db.DB, names []string) error {
+	deadline := time.Now().Add(verifyTimeout)
+	for {
+		missing, err := database.UnknownTags(names)
+		switch {
+		case err != nil:
+			if !time.Now().Before(deadline) {
+				return fmt.Errorf("verifying tag creation: %w", err)
+			}
+		case len(missing) == 0:
+			return nil
+		case !time.Now().Before(deadline):
+			return fmt.Errorf("tag creation did not apply: %s still missing from the Things database after %s. Things accepted the command and then dropped it silently — check that Things3 is running",
+				strings.Join(missing, ", "), verifyTimeout)
+		}
+		verifySleep(verifyInterval)
+	}
+}
+
+// dedupeTagNames trims the requested names, drops empties, and collapses ones
+// that differ only in case — Things treats those as the same tag.
+func dedupeTagNames(names []string) []string {
+	var out []string
+	seen := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		key := foldTagName(n)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}
+
+func foldTagName(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
 }

--- a/cmd/things/tags_test.go
+++ b/cmd/things/tags_test.go
@@ -288,3 +288,37 @@ func TestRunImportWarnsOnUnknownTag(t *testing.T) {
 		t.Error("expected the import to still be dispatched")
 	}
 }
+
+// The strict-tags error suggests a `things tag add` command. `tag add` takes
+// names as separate positional arguments and does not split on commas, so a
+// comma-joined suggestion would create a tag literally named "focus,".
+func TestTagAddHint(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"one", []string{"focus"}, "things tag add focus"},
+		{"many", []string{"focus", "cifas-auto-reject"}, "things tag add focus cifas-auto-reject"},
+		{"spaces", []string{"deep work", "focus"}, `things tag add "deep work" focus`},
+		{"quote", []string{`ev"il`}, `things tag add "ev\"il"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := tagAddHint(c.in); got != c.want {
+				t.Errorf("tagAddHint(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestStrictTagsErrorSuggestsAUsableCommand(t *testing.T) {
+	deps, _ := newTagDeps(t)
+	err := verifyTags(deps, TagFlags{StrictTags: true}, []string{"cifas-auto-reject", "deep work"})
+	if err == nil {
+		t.Fatal("expected an error under --strict-tags")
+	}
+	if !strings.Contains(err.Error(), "`things tag add cifas-auto-reject \"deep work\"`") {
+		t.Errorf("error does not suggest a usable command: %v", err)
+	}
+}

--- a/cmd/things/tags_test.go
+++ b/cmd/things/tags_test.go
@@ -18,7 +18,7 @@ func newTagDeps(t *testing.T) (*Deps, *bytes.Buffer) {
 func TestVerifyTagsAllKnown(t *testing.T) {
 	deps, stderr := newTagDeps(t)
 	// seedFullDB creates the tag "urgent".
-	if err := verifyTags(deps, false, []string{"urgent"}); err != nil {
+	if err := verifyTags(deps, TagFlags{}, []string{"urgent"}); err != nil {
 		t.Fatalf("verifyTags: %v", err)
 	}
 	if stderr.Len() != 0 {
@@ -28,7 +28,7 @@ func TestVerifyTagsAllKnown(t *testing.T) {
 
 func TestVerifyTagsWarnsOnUnknown(t *testing.T) {
 	deps, stderr := newTagDeps(t)
-	if err := verifyTags(deps, false, []string{"urgent", "cifas-auto-reject"}); err != nil {
+	if err := verifyTags(deps, TagFlags{}, []string{"urgent", "cifas-auto-reject"}); err != nil {
 		t.Fatalf("verifyTags: %v", err)
 	}
 	out := stderr.String()
@@ -45,7 +45,7 @@ func TestVerifyTagsWarnsOnUnknown(t *testing.T) {
 
 func TestVerifyTagsStrictFails(t *testing.T) {
 	deps, stderr := newTagDeps(t)
-	err := verifyTags(deps, true, []string{"cifas-auto-reject"})
+	err := verifyTags(deps, TagFlags{StrictTags: true}, []string{"cifas-auto-reject"})
 	if err == nil {
 		t.Fatal("expected an error under --strict-tags")
 	}
@@ -63,7 +63,7 @@ func TestVerifyTagsNoNamesSkipsDatabase(t *testing.T) {
 	// without a readable Things database.
 	var stderr bytes.Buffer
 	deps := &Deps{DBPath: filepath.Join(t.TempDir(), "missing.sqlite"), Stdout: io.Discard, Stderr: &stderr}
-	if err := verifyTags(deps, true, nil); err != nil {
+	if err := verifyTags(deps, TagFlags{StrictTags: true}, nil); err != nil {
 		t.Fatalf("verifyTags with no tags: %v", err)
 	}
 	if stderr.Len() != 0 {
@@ -83,7 +83,7 @@ func TestVerifyTagsDatabaseUnavailable(t *testing.T) {
 
 	// Default: the check is skipped with a warning and the write proceeds.
 	deps, stderr := newDeps()
-	if err := verifyTags(deps, false, []string{"anything"}); err != nil {
+	if err := verifyTags(deps, TagFlags{}, []string{"anything"}); err != nil {
 		t.Fatalf("verifyTags: %v", err)
 	}
 	if !strings.Contains(stderr.String(), "could not check tags") {
@@ -92,7 +92,7 @@ func TestVerifyTagsDatabaseUnavailable(t *testing.T) {
 
 	// Strict: an unverifiable tag is a failure, not a warning.
 	deps, _ = newDeps()
-	err := verifyTags(deps, true, []string{"anything"})
+	err := verifyTags(deps, TagFlags{StrictTags: true}, []string{"anything"})
 	if err == nil || !strings.Contains(err.Error(), "--strict-tags") {
 		t.Fatalf("expected a strict failure, got %v", err)
 	}
@@ -102,7 +102,7 @@ func TestVerifyTagStrings(t *testing.T) {
 	deps, stderr := newTagDeps(t)
 	tags := "urgent, nope"
 	addTags := "also-nope"
-	if err := verifyTagStrings(deps, false, &tags, nil, &addTags); err != nil {
+	if err := verifyTagStrings(deps, TagFlags{}, &tags, nil, &addTags); err != nil {
 		t.Fatalf("verifyTagStrings: %v", err)
 	}
 	out := stderr.String()

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -105,8 +105,22 @@ things add "Review the flags" --tags "Work,cifas-auto-reject"
 # warning: these tags do not exist in Things and will be ignored: cifas-auto-reject
 ```
 
-The write still happens. Add `--strict-tags` to fail and write nothing
-instead. The CLI cannot create tags — create them in Things first.
+The write still happens. Add `--create-tags` to create the missing tags
+first so the write applies them all, or `--strict-tags` to fail and write
+nothing instead. The two contradict each other and are rejected together.
+
+## Creating tags
+
+```sh
+things tag add focus "deep work"
+things tag add Work                 # skipped, it already exists
+things tag add focus --json         # {"created": [...], "skipped": [...]}
+```
+
+Names that already exist are skipped rather than duplicated, matched
+case-insensitively as Things matches them. Creation goes through
+AppleScript, so Things3 must be running; the tag list is read back
+afterwards to confirm it landed, which `--no-verify` skips.
 
 ## Completing and cancelling
 

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -6,7 +6,7 @@ today, upcoming, projects, or areas on macOS.
 ## Safety
 
 - Reads (`list`, `show`, `projects`, `areas`, `tags`, `search`) are safe — use freely.
-- Writes (`add`, `project add`, `edit`, `complete`, `cancel`, `log`, `open`) modify the user's real data. Confirm before destructive ones (`complete`, `cancel`, bulk `edit`).
+- Writes (`add`, `project add`, `edit`, `tag add`, `complete`, `cancel`, `log`, `open`) modify the user's real data. Confirm before destructive ones (`complete`, `cancel`, bulk `edit`).
 - `edit`, `project edit`, and `import` payloads with `operation: update` require *Things → Settings → General → Enable Things URLs*. The error to recognise: `update: auth token is required — enable Things URLs in Things → Settings → General …`.
 - `--complete` and `--cancel` are mutually exclusive on `edit` and `project edit`.
 - `complete` and `cancel` (and `edit --complete` / `--cancel`) read the item back afterwards and exit non-zero if the status did not change. Treat a non-zero exit as "the task is still open" — do not report it as done.
@@ -46,10 +46,12 @@ things areas
 things tags
 things search <query>
 
-things add <title> [--notes --when --deadline --tags --checklist --project --heading --list --strict-tags]
-things project add <title> [--notes --when --deadline --tags --area --todos --strict-tags]
-things project edit <project> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --area --area-id --complete --cancel --duplicate --reveal --strict-tags]
-things edit <task> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --checklist --prepend-checklist --append-checklist --list --list-id --heading --heading-id --complete --cancel --duplicate --reveal --strict-tags]
+things tag add <name>...        # create tags; existing names (case-insensitive) are skipped
+
+things add <title> [--notes --when --deadline --tags --checklist --project --heading --list --strict-tags --create-tags]
+things project add <title> [--notes --when --deadline --tags --area --todos --strict-tags --create-tags]
+things project edit <project> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --area --area-id --complete --cancel --duplicate --reveal --strict-tags --create-tags]
+things edit <task> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --checklist --prepend-checklist --append-checklist --list --list-id --heading --heading-id --complete --cancel --duplicate --reveal --strict-tags --create-tags]
 things complete <task>          # task or project; project completion asks to confirm
 things cancel <task>            # task or project; project cancellation asks to confirm
 things log                      # move Today → Logbook
@@ -60,7 +62,7 @@ things open [<ref>] [-p P | -a A | -t T | -q Q] [--filter T1,T2] [--background]
     # exactly one of <ref> / -p / -a / -t / -q is required
     # --filter narrows the opened list by tags; --background keeps focus elsewhere
 
-things import [--file F] [--reveal] [--strict-tags] < payload.json
+things import [--file F] [--reveal] [--strict-tags | --create-tags] < payload.json
     # batch create/update via the Things JSON URL scheme
     # payload is the array documented at culturedcode.com/things/support/articles/2803573/
 ```
@@ -84,7 +86,17 @@ Things applies only tags that already exist and ignores the rest without saying 
 warning: these tags do not exist in Things and will be ignored: cifas-auto-reject
 ```
 
-The write still goes ahead. Pass `--strict-tags` to fail before writing instead. There is no way to create a tag from the CLI — create it in Things first, then re-run.
+The write still goes ahead. Pass `--create-tags` to create the missing tags over AppleScript first, so the write applies all of them; pass `--strict-tags` to fail before writing instead. The two contradict each other and are rejected together.
+
+`things tag add <name>...` creates tags on their own, without a write to hang them off:
+
+```
+$ things tag add focus "deep work" Work
+created: focus, deep work
+already exists: Work
+```
+
+Both routes need Things3 running (creation goes through AppleScript) and skip names that already exist, matching case-insensitively as Things does.
 
 ### Task reference forms
 

--- a/internal/things/applescript.go
+++ b/internal/things/applescript.go
@@ -3,6 +3,7 @@ package things
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 var execCommand = exec.Command
@@ -47,4 +48,31 @@ func CancelProject(uuid string) error {
 set theProject to project id "%s"
 set status of theProject to canceled
 end tell`, uuid), "cancelling project")
+}
+
+// appleScriptString renders s as an AppleScript string literal, quotes
+// included. Every other script in this file interpolates a UUID the CLI read
+// out of the database, but a tag name comes straight from the command line, so
+// it has to be escaped: an unescaped quote or backslash would end the literal
+// early and turn the rest of the name into script.
+func appleScriptString(s string) string {
+	r := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		"\n", `\n`,
+		"\r", `\r`,
+		"\t", `\t`,
+	)
+	return `"` + r.Replace(s) + `"`
+}
+
+// CreateTag creates a tag in Things. The URL scheme cannot create tags — it
+// applies only ones that already exist — so this is the only route.
+//
+// It does not check first: callers compare against the database (see
+// db.UnknownTags) and pass only names that are missing.
+func CreateTag(name string) error {
+	return runAppleScript(fmt.Sprintf(`tell application "Things3"
+make new tag with properties {name:%s}
+end tell`, appleScriptString(name)), "creating tag")
 }

--- a/internal/things/applescript_test.go
+++ b/internal/things/applescript_test.go
@@ -128,3 +128,71 @@ func TestAppleScriptErrorIncludesOutput(t *testing.T) {
 		t.Errorf("error missing stderr output: %v", err)
 	}
 }
+
+func TestAppleScriptString(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"plain", "Work", `"Work"`},
+		{"quote", `say "hi"`, `"say \"hi\""`},
+		{"backslash", `a\b`, `"a\\b"`},
+		{"backslashQuote", `a\"b`, `"a\\\"b"`},
+		{"newline", "a\nb", `"a\nb"`},
+		{"carriageReturn", "a\rb", `"a\rb"`},
+		{"tab", "a\tb", `"a\tb"`},
+		{"unicode", "café ✅", `"café ✅"`},
+		{"empty", "", `""`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := appleScriptString(c.in); got != c.want {
+				t.Errorf("appleScriptString(%q) = %s, want %s", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestCreateTagScript(t *testing.T) {
+	script := applescriptStub(t, "")
+
+	if err := CreateTag("urgent"); err != nil {
+		t.Fatalf("CreateTag: %v", err)
+	}
+	want := `tell application "Things3"
+make new tag with properties {name:"urgent"}
+end tell`
+	if *script != want {
+		t.Errorf("script =\n%s\nwant:\n%s", *script, want)
+	}
+}
+
+// A tag name is user input, so it must not be able to close the AppleScript
+// string literal and have the remainder run as script.
+func TestCreateTagEscapesName(t *testing.T) {
+	script := applescriptStub(t, "")
+
+	if err := CreateTag(`ev"il\ tag`); err != nil {
+		t.Fatalf("CreateTag: %v", err)
+	}
+	want := `tell application "Things3"
+make new tag with properties {name:"ev\"il\\ tag"}
+end tell`
+	if *script != want {
+		t.Errorf("script =\n%s\nwant:\n%s", *script, want)
+	}
+}
+
+func TestCreateTagError(t *testing.T) {
+	applescriptStub(t, "no tag for you")
+
+	err := CreateTag("urgent")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "creating tag") {
+		t.Errorf("error lacks context: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no tag for you") {
+		t.Errorf("error drops osascript output: %v", err)
+	}
+}


### PR DESCRIPTION
## What changed

Two ways to create a Things tag from the CLI, where before there were none.

**`things tag add <name>...`** creates tags on their own:

```
$ things tag add focus "deep work" Work
created: focus, deep work
already exists: Work
```

Names that already exist are skipped rather than duplicated, matched case-insensitively as Things matches them, and duplicate arguments are collapsed the same way. `--json` reports `{"created": [...], "skipped": [...]}`. The tag list is read back afterwards to confirm the creation landed; `--no-verify` skips that, as it does for `complete`/`cancel`.

**`--create-tags`** on `add`, `project add`, `edit`, `project edit` and `import` creates the missing tags before the write, so the write applies all of them:

```
$ things add "Review the flags" --tags "Work,cifas-auto-reject" --create-tags
created in Things: cifas-auto-reject
```

It sits alongside the existing `--strict-tags`. The two ask for opposite things, so kong rejects them together (`--strict-tags and --create-tags can't be used together`). With `--create-tags` set, an unreadable database is a hard failure rather than the usual warn-and-continue — without it the CLI cannot tell which tags are missing.

## Why

The Things URL scheme applies only tags that already exist and drops the rest silently. #141 made that visible (warning plus `--strict-tags`), but left the user to switch to the app to fix it. AppleScript can create tags, so the CLI now does — before the URL-scheme write, so Things has the tag by the time it applies it.

Tag names come from the command line, so `internal/things` gained `appleScriptString`, which renders a name as an AppleScript string literal with backslash, quote, newline, carriage return and tab escaped. Every other script in that file interpolates a UUID read out of the database; this is the first one that interpolates user input.

Closes #144

## How tested

`make test` (`go test -race ./...`) and `make lint` are green. New tests:

- `internal/things`: the exact script text `CreateTag` produces, the escaping table (quotes, backslashes, control characters, UTF-8), and a name that tries to close the string literal early.
- `cmd/things`: creation of only the missing tags, case-insensitive and duplicate skipping, blank-name rejection, JSON output, read-back failure and `--no-verify`, creation failure naming the tag; `--create-tags` ordering (AppleScript create, then the `things:///add` write) on all five commands, a creation failure blocking the write, and the `--strict-tags`/`--create-tags` conflict against a real kong parser.

Every write goes through the mocked `execCommand` seam — no real `osascript` and no `things:///` URLs against the app. The tests assert the exact script text rather than just that something ran.

Docs updated: `README.md`, `docs/_tabs/commands.md`, and `internal/skill/SKILL.md` (the flag lists, the "tags must already exist" section, and `tag add` in the safety list of writes).

## Notes

- `things tag add "a,b"` is allowed through. Things itself permits a comma in a tag name, but `--tags`/`--add-tags` split on commas, so such a tag can't be applied from this CLI afterwards. Left as a pass-through rather than a guard.
- `ImportCmd` is touched only for the flag embed and the one `verifyTags` call; the `StrictTags` embed struct is renamed `TagFlags` now that it carries two flags.