### PR TITLE
fix(import): apply the repeating check and status read-back to update items

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,9 @@ stay untouched. An empty value clears the field (e.g. `--deadline ""`).
 > request silently instead of reporting an error
 > ([docs](https://culturedcode.com/things/support/articles/2803573/)). The CLI
 > checks first and exits non-zero with an explanation. Every other flag works
-> normally; the restricted changes have to be made in the Things app.
+> normally; the restricted changes have to be made in the Things app. `import`
+> makes the same check per `operation: update` item — see [Repeating items in an
+> import payload](#repeating-items-in-an-import-payload).
 
 Examples:
 
@@ -390,7 +392,9 @@ and exits non-zero if the status did not change. Things has no callback for
 writes, so without this check a request it silently dropped is
 indistinguishable from one it applied. Repeating items are refused up front
 (see the note under [Editing](#editing-tasks-and-projects)); the read-back
-catches anything else — for example Things not running.
+catches anything else — for example Things not running. `import` does both, per
+item — see [Reading back an import's status
+changes](#reading-back-an-imports-status-changes).
 
 ```text
 $ things cancel W1gBDJPFpwUQrdP5Am5K7J
@@ -399,7 +403,9 @@ $ echo $?
 1
 ```
 
-Pass `--no-verify` to skip the check when you do not want to wait for it.
+Pass `--no-verify` to skip the check when you do not want to wait for it. It
+skips read-backs only; the up-front refusal of a restricted change on a
+repeating item is not affected.
 
 ### Revealing items in Things3
 
@@ -453,6 +459,35 @@ things import --file payload.json --reveal
 ```
 
 Note: macOS `open` has a URL length limit; split very large payloads.
+
+#### Repeating items in an import payload
+
+An `operation: update` item goes through the same repeating check as `edit`. If any item in the payload sets `when`, `deadline`, `completed` or `canceled` on a repeating to-do or project, the whole import is refused and nothing is sent:
+
+```text
+$ things import --file reschedule.json
+Error: 2 of 3 update items change attributes Things does not allow on repeating items, and drops the request silently (https://culturedcode.com/things/support/articles/2803573/). Nothing was sent to Things — fix these and run the import again, or make the changes in the Things app:
+  [1] (id abc…): "Water plants" is a repeating to-do — when, deadline
+  [2].attributes.items[0] (id def…): "Weekly review" is a repeating project — canceled
+```
+
+The refusal is all-or-nothing because the URL scheme takes one payload and gives no per-item result: there is no way to send the rest and report what was skipped. Each offending item is named by its position in the payload (nested items included), its id, its title and the blocked attributes, so a payload can be fixed in one pass. `--no-verify` does not lift the refusal — it is a documented restriction, not a read-back.
+
+Update items whose `id` is not in the database get a stderr warning; Things reports those itself, and the import still goes ahead.
+
+#### Reading back an import's status changes
+
+After the payload is sent, every update item that set `completed` or `canceled` is re-read from the database, for the same reason `complete` and `cancel` are (below). Every item is checked before anything is reported, and the whole batch shares one timeout budget rather than one per item:
+
+```text
+$ things import --file finish.json
+import: [1]: status change did not apply: "File taxes" (one-2) is still open after 10s. Things accepted the command and then dropped it silently — check that Things3 is running, or make the change in the app
+Error: 1 of 2 requested status changes did not apply (listed above). The rest of the import was still applied; re-run the import with only the failed items, or make the changes in the Things app
+$ echo $?
+1
+```
+
+Unlike the refusal above, this happens after the write: the items that did land stay landed. `--no-verify` skips it.
 
 ### Date values
 

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Note: macOS `open` has a URL length limit; split very large payloads.
 
 #### Repeating items in an import payload
 
-An `operation: update` item goes through the same repeating check as `edit`. If any item in the payload sets `when`, `deadline`, `completed` or `canceled` on a repeating to-do or project, the whole import is refused and nothing is sent:
+An `operation: update` item goes through the same repeating check as `edit`. If any item in the payload carries `when`, `deadline`, `completed` or `canceled` for a repeating to-do or project, the whole import is refused and nothing is sent. The value does not matter: the URL scheme documents both status fields as two-way ("Complete a to-do or set a to-do to incomplete") and says of each that it "cannot be updated on repeating to-dos", so `"completed": false` is refused exactly like `"completed": true`.
 
 ```text
 $ things import --file reschedule.json
@@ -477,7 +477,7 @@ Update items whose `id` is not in the database get a stderr warning; Things repo
 
 #### Reading back an import's status changes
 
-After the payload is sent, every update item that set `completed` or `canceled` is re-read from the database, for the same reason `complete` and `cancel` are (below). Every item is checked before anything is reported, and the whole batch shares one timeout budget rather than one per item:
+After the payload is sent, every update item that set `completed` or `canceled` is re-read from the database, for the same reason `complete` and `cancel` are (below). That includes setting either to `false`, which asks Things to mark the item incomplete — a reopen it drops is as invisible as a completion it drops. `canceled` takes priority over `completed` when a payload sets both, so the read-back expects what Things actually applies. Every item is checked before anything is reported, and the whole batch shares one timeout budget rather than one per item:
 
 ```text
 $ things import --file finish.json

--- a/README.md
+++ b/README.md
@@ -481,13 +481,15 @@ After the payload is sent, every update item that set `completed` or `canceled` 
 
 ```text
 $ things import --file finish.json
-import: [1]: status change did not apply: "File taxes" (one-2) is still open after 10s. Things accepted the command and then dropped it silently — check that Things3 is running, or make the change in the app
-Error: 1 of 2 requested status changes did not apply (listed above). The rest of the import was still applied; re-run the import with only the failed items, or make the changes in the Things app
+Error: 1 of 2 requested status changes did not apply. The rest of the import was still applied; re-run the import with only the failed items, or make the changes in the Things app:
+  [1]: status change did not apply: "File taxes" (one-2) is still open after 10s. Things accepted the command and then dropped it silently — check that Things3 is running, or make the change in the app
 $ echo $?
 1
 ```
 
 Unlike the refusal above, this happens after the write: the items that did land stay landed. `--no-verify` skips it.
+
+Both the refusal and the read-back failure carry their per-item detail in the error itself rather than on a separate stream, so under `--json` the whole thing arrives in the `message` field of the [error object](#errors-under---json).
 
 ### Date values
 

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ An `operation: update` item goes through the same repeating check as `edit`. If 
 $ things import --file reschedule.json
 Error: 2 of 3 update items change attributes Things does not allow on repeating items, and drops the request silently (https://culturedcode.com/things/support/articles/2803573/). Nothing was sent to Things — fix these and run the import again, or make the changes in the Things app:
   [1] (id abc…): "Water plants" is a repeating to-do — when, deadline
-  [2].attributes.items[0] (id def…): "Weekly review" is a repeating project — canceled
+  [2].attributes.items[0] (id def…): "Take the bins out" is a repeating to-do — canceled
 ```
 
 The refusal is all-or-nothing because the URL scheme takes one payload and gives no per-item result: there is no way to send the rest and report what was skipped. Each offending item is named by its position in the payload (nested items included), its id, its title and the blocked attributes, so a payload can be fixed in one pass. `--no-verify` does not lift the refusal — it is a documented restriction, not a read-back.

--- a/cmd/things/importcheck.go
+++ b/cmd/things/importcheck.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ryanlewis/things-cli/internal/db"
+	"github.com/ryanlewis/things-cli/internal/model"
+)
+
+// checklistItemType is the one payload item type that does not live in TMTask.
+// Checklist items have their own table and cannot repeat, so the repeating
+// check and the read-back both skip them rather than look up an id that
+// GetTaskByUUID could never resolve.
+const checklistItemType = "checklist-item"
+
+// importUpdate is one `operation: update` item found in an import payload,
+// reduced to the parts the repeating check and the status read-back need.
+type importUpdate struct {
+	// path locates the item in the payload for error messages, e.g. `[2]` for
+	// a top-level item or `[2].attributes.items[0]` for one nested in a
+	// project.
+	path     string
+	itemType string
+	id       string
+	attrs    map[string]any
+}
+
+// resolvable reports whether the item names a row the CLI can look up. Items
+// without an id are Things' problem to report, and checklist items are not in
+// TMTask.
+func (u importUpdate) resolvable() bool {
+	return u.id != "" && u.itemType != checklistItemType
+}
+
+// importPlan is what the pre-write pass learned about a payload: the update
+// items in it, and the database rows they point at. Sharing the lookups means
+// the read-back afterwards knows each item's title without querying again.
+type importPlan struct {
+	updates []importUpdate
+	tasks   map[string]*model.Task // by id; a nil value means "not in the database"
+}
+
+// importUpdates collects every `operation: update` item in a Things JSON
+// payload. Items nest — a project carries `items`, a to-do carries
+// `checklist-items` — so this walks the whole decoded tree the way
+// walkImportTags does. The payload has already been validated as JSON by the
+// caller; anything unparseable yields no updates and the import proceeds as
+// before, leaving Things to reject it.
+func importUpdates(data []byte) []importUpdate {
+	var payload any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil
+	}
+	var updates []importUpdate
+	walkImportUpdates(payload, "", &updates)
+	return updates
+}
+
+func walkImportUpdates(node any, path string, updates *[]importUpdate) {
+	switch v := node.(type) {
+	case map[string]any:
+		if op, _ := v["operation"].(string); op == "update" {
+			id, _ := v["id"].(string)
+			itemType, _ := v["type"].(string)
+			attrs, _ := v["attributes"].(map[string]any)
+			*updates = append(*updates, importUpdate{
+				path:     path,
+				itemType: strings.TrimSpace(itemType),
+				id:       strings.TrimSpace(id),
+				attrs:    attrs,
+			})
+		}
+		// Walk keys in a fixed order: Go randomises map iteration, and the
+		// order items are discovered in decides the order they are reported.
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			walkImportUpdates(v[key], path+"."+key, updates)
+		}
+	case []any:
+		for i, child := range v {
+			walkImportUpdates(child, fmt.Sprintf("%s[%d]", path, i), updates)
+		}
+	}
+}
+
+// restrictedImportAttrs names the attributes in an update item's `attributes`
+// that Things refuses on a repeating item, in the order the docs list them. It
+// is the payload-shaped counterpart of restrictedEdits, which does the same
+// job for the `edit` flags.
+func restrictedImportAttrs(attrs map[string]any) []string {
+	var blocked []string
+	for _, name := range []string{"when", "deadline"} {
+		if _, ok := attrs[name]; ok {
+			blocked = append(blocked, name)
+		}
+	}
+	for _, name := range []string{"completed", "canceled"} {
+		if requestsStatusChange(attrs, name) {
+			blocked = append(blocked, name)
+		}
+	}
+	return blocked
+}
+
+// requestsStatusChange reports whether a status attribute asks Things to move
+// the item. An explicit `false` says "leave it as it is", which leaves Things
+// nothing to drop, so it is not treated as a restricted edit. A non-boolean
+// value is treated as a request: Things decides what to make of it, and
+// guessing it means nothing would put the silent drop back.
+func requestsStatusChange(attrs map[string]any, name string) bool {
+	v, ok := attrs[name]
+	if !ok || v == nil {
+		return false
+	}
+	b, isBool := v.(bool)
+	return !isBool || b
+}
+
+// wantedStatus reports the status an update item asks Things to move the item
+// to. Only a literal `true` counts: anything else either leaves the status
+// alone or is a payload error for Things to report. `completed` wins over
+// `canceled` when a payload sets both, which is the same precedence `edit`
+// applies to --complete over --cancel.
+func wantedStatus(attrs map[string]any) (model.Status, bool) {
+	if b, ok := attrs["completed"].(bool); ok && b {
+		return model.StatusCompleted, true
+	}
+	if b, ok := attrs["canceled"].(bool); ok && b {
+		return model.StatusCancelled, true
+	}
+	return model.StatusOpen, false
+}
+
+// prepareImport is the pre-write pass over an import payload. It refuses the
+// whole import when any `operation: update` item would change an attribute
+// Things drops silently on a repeating to-do or project — the same check
+// `edit`, `complete` and `cancel` make, applied per item.
+//
+// The refusal is all-or-nothing on purpose: the URL scheme takes one payload
+// and gives no per-item result, so there is no way to send the rest and report
+// what was skipped. Refusing before anything is sent leaves the user with a
+// payload they can fix and re-run.
+func prepareImport(d *Deps, database *db.DB, data []byte) (*importPlan, error) {
+	plan := &importPlan{updates: importUpdates(data), tasks: map[string]*model.Task{}}
+
+	var refusals, missing []string
+	for _, u := range plan.updates {
+		if !u.resolvable() {
+			continue
+		}
+		task, ok := plan.tasks[u.id]
+		if !ok {
+			var err error
+			task, err = database.GetTaskByUUID(u.id)
+			if err != nil {
+				return nil, fmt.Errorf("checking %s (id %s) against the Things database: %w", u.path, u.id, err)
+			}
+			plan.tasks[u.id] = task
+		}
+		if task == nil {
+			missing = append(missing, fmt.Sprintf("%s (id %s)", u.path, u.id))
+			continue
+		}
+		blocked := restrictedImportAttrs(u.attrs)
+		if len(blocked) == 0 || !task.Repeating {
+			continue
+		}
+		kind := "to-do"
+		if task.Type == model.TypeProject {
+			kind = "project"
+		}
+		refusals = append(refusals, fmt.Sprintf("  %s (id %s): %q is a repeating %s — %s",
+			u.path, u.id, task.Title, kind, strings.Join(blocked, ", ")))
+	}
+
+	for _, m := range missing {
+		fmt.Fprintf(d.errOut(), "warning: %s is not in the Things database — Things will report this itself\n", m)
+	}
+	if len(refusals) == 0 {
+		return plan, nil
+	}
+	return nil, fmt.Errorf("%d of %d update items change attributes Things does not allow on repeating items, and drops the request silently (%s). Nothing was sent to Things — fix these and run the import again, or make the changes in the Things app:\n%s",
+		len(refusals), len(plan.updates), repeatingDocsURL, strings.Join(refusals, "\n"))
+}
+
+// verifyImportStatuses re-reads every item the payload asked to complete or
+// cancel and reports the ones whose status never changed. Things gives the
+// import no per-item result, so this is the only way a silently dropped status
+// change in a batch becomes visible.
+//
+// Every item is checked before anything is reported: a payload's later items
+// are just as interesting as its first, so the read-back does not stop at the
+// first failure. The whole batch shares one timeout budget.
+func verifyImportStatuses(d *Deps, database *db.DB, plan *importPlan) error {
+	if d.NoVerify {
+		return nil
+	}
+
+	var wants []statusWant
+	var paths []string
+	for _, u := range plan.updates {
+		if !u.resolvable() {
+			continue
+		}
+		// An id the pre-write pass could not find was already warned about;
+		// Things reports it too, and reading it back would only repeat that.
+		task := plan.tasks[u.id]
+		if task == nil {
+			continue
+		}
+		want, ok := wantedStatus(u.attrs)
+		if !ok {
+			continue
+		}
+		wants = append(wants, statusWant{uuid: u.id, title: task.Title, want: want})
+		paths = append(paths, u.path)
+	}
+	if len(wants) == 0 {
+		return nil
+	}
+
+	failed := 0
+	for i, err := range verifyStatuses(database, wants, verifyTimeout) {
+		if err == nil {
+			continue
+		}
+		failed++
+		fmt.Fprintf(d.errOut(), "import: %s: %v\n", paths[i], err)
+	}
+	if failed == 0 {
+		return nil
+	}
+	return fmt.Errorf("%d of %d requested status changes did not apply (listed above). The rest of the import was still applied; re-run the import with only the failed items, or make the changes in the Things app",
+		failed, len(wants))
+}

--- a/cmd/things/importcheck.go
+++ b/cmd/things/importcheck.go
@@ -94,54 +94,54 @@ func walkImportUpdates(node any, path string, updates *[]importUpdate) {
 // that Things refuses on a repeating item, in the order the docs list them. It
 // is the payload-shaped counterpart of restrictedEdits, which does the same
 // job for the `edit` flags.
+//
+// Presence is enough, whatever the value. The URL scheme docs say of both
+// status fields that "this field cannot be updated on repeating to-dos" (and
+// the same for repeating projects), so `"completed": false` is refused exactly
+// like `"completed": true` — setting a repeating item to incomplete is as much
+// an update of that field as completing it.
 func restrictedImportAttrs(attrs map[string]any) []string {
 	var blocked []string
-	for _, name := range []string{"when", "deadline"} {
+	for _, name := range []string{"when", "deadline", "completed", "canceled"} {
 		if _, ok := attrs[name]; ok {
-			blocked = append(blocked, name)
-		}
-	}
-	for _, name := range []string{"completed", "canceled"} {
-		if requestsStatusChange(attrs, name) {
 			blocked = append(blocked, name)
 		}
 	}
 	return blocked
 }
 
-// requestsStatusChange reports whether a status attribute asks Things to move
-// the item. An explicit `false` says "leave it as it is", which leaves Things
-// nothing to drop, so it is not treated as a restricted edit. A non-boolean
-// value is treated as a request: Things decides what to make of it, and
-// guessing it means nothing would put the silent drop back.
-func requestsStatusChange(attrs map[string]any, name string) bool {
-	v, ok := attrs[name]
-	if !ok || v == nil {
-		return false
-	}
-	b, isBool := v.(bool)
-	return !isBool || b
-}
-
 // wantedStatus reports the status an update item asks Things to move the item
-// to. Only a literal `true` counts, and `completed` wins over `canceled` when
-// a payload sets both — the same precedence `edit` applies to --complete over
-// --cancel.
+// to. Both status fields are two-way, per the `update` command's parameter
+// table at repeatingDocsURL: `completed` is "Complete a to-do or set a to-do
+// to incomplete", `canceled` likewise, and each documents that setting the
+// other one to false on an item in that state also marks it incomplete. So a
+// literal `false` is a real request for `open`, not a no-op, and a dropped
+// reopen is as invisible as a dropped completion.
 //
-// An explicit `false` is deliberately not treated as a request. Whether
-// `"completed": false` reopens a completed item is not something this
-// repository or the Things documentation establishes, and the CLI itself never
-// sends it (setBool drops a false). If Things ignores it, reading it back
-// would fail an import that fully succeeded — a worse outcome than the missed
-// detection, since the read-back's whole job is to be trustworthy. If Things
-// does honour it, a dropped reopen stays invisible; see issue #145 for the
-// note, and confirm the behaviour against Things before changing this.
+// `canceled` "Takes priority over `completed`", so it decides the outcome
+// whenever it is present — with one exception. The two entries disagree about
+// `canceled: false` alongside `completed: true`: `canceled` claims priority
+// outright, while `completed` says it is ignored only "if `canceled` is also
+// set to `true`". Rather than guess, that one combination is left unverified;
+// guessing wrong would fail an import that Things applied correctly. It is
+// still refused up front on a repeating target, where the outcome does not
+// matter because neither field may be updated at all.
 func wantedStatus(attrs map[string]any) (model.Status, bool) {
-	if b, ok := attrs["completed"].(bool); ok && b {
-		return model.StatusCompleted, true
-	}
-	if b, ok := attrs["canceled"].(bool); ok && b {
-		return model.StatusCancelled, true
+	completed, hasCompleted := attrs["completed"].(bool)
+	canceled, hasCanceled := attrs["canceled"].(bool)
+	switch {
+	case hasCanceled && hasCompleted && !canceled && completed:
+		return model.StatusOpen, false
+	case hasCanceled:
+		if canceled {
+			return model.StatusCancelled, true
+		}
+		return model.StatusOpen, true
+	case hasCompleted:
+		if completed {
+			return model.StatusCompleted, true
+		}
+		return model.StatusOpen, true
 	}
 	return model.StatusOpen, false
 }

--- a/cmd/things/importcheck.go
+++ b/cmd/things/importcheck.go
@@ -124,10 +124,18 @@ func requestsStatusChange(attrs map[string]any, name string) bool {
 }
 
 // wantedStatus reports the status an update item asks Things to move the item
-// to. Only a literal `true` counts: anything else either leaves the status
-// alone or is a payload error for Things to report. `completed` wins over
-// `canceled` when a payload sets both, which is the same precedence `edit`
-// applies to --complete over --cancel.
+// to. Only a literal `true` counts, and `completed` wins over `canceled` when
+// a payload sets both — the same precedence `edit` applies to --complete over
+// --cancel.
+//
+// An explicit `false` is deliberately not treated as a request. Whether
+// `"completed": false` reopens a completed item is not something this
+// repository or the Things documentation establishes, and the CLI itself never
+// sends it (setBool drops a false). If Things ignores it, reading it back
+// would fail an import that fully succeeded — a worse outcome than the missed
+// detection, since the read-back's whole job is to be trustworthy. If Things
+// does honour it, a dropped reopen stays invisible; see issue #145 for the
+// note, and confirm the behaviour against Things before changing this.
 func wantedStatus(attrs map[string]any) (model.Status, bool) {
 	if b, ok := attrs["completed"].(bool); ok && b {
 		return model.StatusCompleted, true
@@ -180,14 +188,18 @@ func prepareImport(d *Deps, database *db.DB, data []byte) (*importPlan, error) {
 			u.path, u.id, task.Title, kind, strings.Join(blocked, ", ")))
 	}
 
+	// Refuse first: the warnings below promise that Things will report the
+	// unknown ids itself, which is only true when the payload is actually
+	// sent. A refused import never reaches Things.
+	if len(refusals) > 0 {
+		return nil, fmt.Errorf("%d of %d update items change attributes Things does not allow on repeating items, and drops the request silently (%s). Nothing was sent to Things — fix these and run the import again, or make the changes in the Things app:\n%s",
+			len(refusals), len(plan.updates), repeatingDocsURL, strings.Join(refusals, "\n"))
+	}
+
 	for _, m := range missing {
 		fmt.Fprintf(d.errOut(), "warning: %s is not in the Things database — Things will report this itself\n", m)
 	}
-	if len(refusals) == 0 {
-		return plan, nil
-	}
-	return nil, fmt.Errorf("%d of %d update items change attributes Things does not allow on repeating items, and drops the request silently (%s). Nothing was sent to Things — fix these and run the import again, or make the changes in the Things app:\n%s",
-		len(refusals), len(plan.updates), repeatingDocsURL, strings.Join(refusals, "\n"))
+	return plan, nil
 }
 
 // verifyImportStatuses re-reads every item the payload asked to complete or

--- a/cmd/things/importcheck.go
+++ b/cmd/things/importcheck.go
@@ -238,17 +238,21 @@ func verifyImportStatuses(d *Deps, database *db.DB, plan *importPlan) error {
 		return nil
 	}
 
-	failed := 0
+	// The failures go in the error rather than straight to stderr: under
+	// --json the error is rendered as one object on stdout (issue #152) and
+	// anything written to stderr never reaches the reader, so a summary
+	// pointing at a list printed elsewhere would name detail the consumer
+	// cannot see.
+	var failures []string
 	for i, err := range verifyStatuses(database, wants, verifyTimeout) {
 		if err == nil {
 			continue
 		}
-		failed++
-		fmt.Fprintf(d.errOut(), "import: %s: %v\n", paths[i], err)
+		failures = append(failures, fmt.Sprintf("  %s: %v", paths[i], err))
 	}
-	if failed == 0 {
+	if len(failures) == 0 {
 		return nil
 	}
-	return fmt.Errorf("%d of %d requested status changes did not apply (listed above). The rest of the import was still applied; re-run the import with only the failed items, or make the changes in the Things app",
-		failed, len(wants))
+	return fmt.Errorf("%d of %d requested status changes did not apply. The rest of the import was still applied; re-run the import with only the failed items, or make the changes in the Things app:\n%s",
+		len(failures), len(wants), strings.Join(failures, "\n"))
 }

--- a/cmd/things/importcheck_test.go
+++ b/cmd/things/importcheck_test.go
@@ -343,14 +343,19 @@ func TestImportReportsEveryDroppedStatusChange(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected a non-zero exit, got nil")
 	}
+	// The detail belongs in the error, not on stderr: under --json the error
+	// is the only thing the consumer reads.
 	if !strings.Contains(err.Error(), "1 of 2 requested status changes did not apply") {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if !strings.Contains(stderr, `import: [1]: status change did not apply: "File taxes" (one-2) is still open`) {
-		t.Errorf("stderr missing the failing item:\n%s", stderr)
+	if !strings.Contains(err.Error(), `[1]: status change did not apply: "File taxes" (one-2) is still open`) {
+		t.Errorf("error missing the failing item:\n%v", err)
 	}
-	if strings.Contains(stderr, "one-1") {
-		t.Errorf("the item that landed was reported as a failure:\n%s", stderr)
+	if strings.Contains(err.Error(), "one-1") {
+		t.Errorf("the item that landed was reported as a failure:\n%v", err)
+	}
+	if stderr != "" {
+		t.Errorf("per-item detail should be in the error, not stderr:\n%s", stderr)
 	}
 }
 
@@ -419,12 +424,12 @@ func TestImportReadsBackAReopen(t *testing.T) {
 
 	t.Run("dropped", func(t *testing.T) {
 		stubExecApplyingAll(t, sqlDB, nil)
-		stderr, err := runImport(t, database, payload)
+		_, err := runImport(t, database, payload)
 		if err == nil {
 			t.Fatal("expected a non-zero exit for a dropped reopen, got nil")
 		}
-		if !strings.Contains(stderr, `"File taxes" (done-1) is still completed`) {
-			t.Errorf("stderr missing the dropped reopen:\n%s", stderr)
+		if !strings.Contains(err.Error(), `"File taxes" (done-1) is still completed`) {
+			t.Errorf("error missing the dropped reopen:\n%v", err)
 		}
 	})
 
@@ -473,4 +478,43 @@ func TestImportReadsBackCanceledOverCompleted(t *testing.T) {
 	if stderr != "" {
 		t.Errorf("unexpected stderr: %s", stderr)
 	}
+}
+
+// Both import failures have to survive the --json error path (issue #152):
+// under --json the rendered object on stdout is all a consumer reads, so the
+// per-item detail must be inside it rather than on stderr.
+func TestImportFailuresRenderAsJSON(t *testing.T) {
+	t.Run("refusal", func(t *testing.T) {
+		database, _ := seedWritable(t)
+		stubExecDropping(t)
+
+		payload := `[{"type":"to-do","operation":"update","id":"rep-1","attributes":{"when":"today"}}]`
+		err := runWith(t, database, "--json", "import", "--file", importPayload(t, payload))
+		if err == nil {
+			t.Fatal("expected a refusal")
+		}
+		p, raw := decodePayload(t, err)
+		if !strings.Contains(p.Message, `[0] (id rep-1): "Water plants" is a repeating to-do — when`) {
+			t.Errorf("payload lost the per-item detail: %s", raw)
+		}
+	})
+
+	t.Run("readBack", func(t *testing.T) {
+		fastVerify(t)
+		database, sqlDB := seedWritable(t)
+		stubExecApplyingAll(t, sqlDB, nil)
+
+		payload := `[{"type":"to-do","operation":"update","id":"one-1","attributes":{"completed":true}}]`
+		err := runWith(t, database, "--json", "import", "--file", importPayload(t, payload))
+		if err == nil {
+			t.Fatal("expected a read-back failure")
+		}
+		p, raw := decodePayload(t, err)
+		if strings.Contains(p.Message, "listed above") {
+			t.Errorf("message points at detail a JSON reader never sees: %s", raw)
+		}
+		if !strings.Contains(p.Message, `"Post letter" (one-1) is still open`) {
+			t.Errorf("payload lost the per-item detail: %s", raw)
+		}
+	})
 }

--- a/cmd/things/importcheck_test.go
+++ b/cmd/things/importcheck_test.go
@@ -1,0 +1,365 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ryanlewis/things-cli/internal/db"
+	"github.com/ryanlewis/things-cli/internal/model"
+	"github.com/ryanlewis/things-cli/internal/things"
+)
+
+// importPayload writes payload to a temp file and returns the path, so a test
+// can drive `import --file` without touching stdin.
+func importPayload(t *testing.T, payload string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "payload.json")
+	if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	return path
+}
+
+// runImport runs `import --file` against database and returns what the command
+// wrote to stderr alongside the error.
+func runImport(t *testing.T, database *db.DB, payload string, extra ...string) (string, error) {
+	t.Helper()
+	args := append([]string{"import", "--file", importPayload(t, payload)}, extra...)
+	return runCapturingStderr(t, database, args...)
+}
+
+func TestImportUpdatesWalksNestedItems(t *testing.T) {
+	payload := `[
+	  {"type":"to-do","attributes":{"title":"created"}},
+	  {"type":"to-do","operation":"update","id":"a","attributes":{"when":"today"}},
+	  {"type":"project","operation":"update","id":"b","attributes":{"items":[
+	     {"type":"to-do","operation":"update","id":"c","attributes":{"completed":true}}
+	  ]}}
+	]`
+	got := importUpdates([]byte(payload))
+	want := []struct{ path, id string }{
+		{"[1]", "a"},
+		{"[2]", "b"},
+		{"[2].attributes.items[0]", "c"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("found %d updates, want %d: %+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].path != w.path || got[i].id != w.id {
+			t.Errorf("update %d = {%s %s}, want {%s %s}", i, got[i].path, got[i].id, w.path, w.id)
+		}
+	}
+}
+
+// The walk descends through maps, whose iteration order Go randomises. Repeat
+// it to catch an ordering that only shows up sometimes.
+func TestImportUpdatesOrderIsStable(t *testing.T) {
+	payload := `[{"type":"project","operation":"update","id":"p","attributes":{
+	    "title":"P","when":"today","items":[
+	      {"type":"to-do","operation":"update","id":"x","attributes":{"completed":true}},
+	      {"type":"to-do","operation":"update","id":"y","attributes":{"canceled":true}}
+	    ]}}]`
+	var first []string
+	for i := 0; i < 25; i++ {
+		var paths []string
+		for _, u := range importUpdates([]byte(payload)) {
+			paths = append(paths, u.path)
+		}
+		if i == 0 {
+			first = paths
+			continue
+		}
+		if strings.Join(paths, ",") != strings.Join(first, ",") {
+			t.Fatalf("run %d gave %v, first run gave %v", i, paths, first)
+		}
+	}
+}
+
+func TestImportUpdatesIgnoresUnparseablePayload(t *testing.T) {
+	if got := importUpdates([]byte(`[{"type":}]`)); got != nil {
+		t.Errorf("want no updates from invalid JSON, got %+v", got)
+	}
+}
+
+func TestRestrictedImportAttrs(t *testing.T) {
+	cases := []struct {
+		name  string
+		attrs string
+		want  []string
+	}{
+		{"none", `{"title":"x","tags":["a"]}`, nil},
+		{"all", `{"when":"today","deadline":"2026-01-01","completed":true,"canceled":true}`,
+			[]string{"when", "deadline", "completed", "canceled"}},
+		{"clearedDeadline", `{"deadline":""}`, []string{"deadline"}},
+		{"nullWhen", `{"when":null}`, []string{"when"}},
+		{"statusFalse", `{"completed":false,"canceled":false}`, nil},
+		{"statusNull", `{"completed":null}`, nil},
+		{"statusNonBool", `{"completed":"true"}`, []string{"completed"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var attrs map[string]any
+			if err := json.Unmarshal([]byte(c.attrs), &attrs); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got := restrictedImportAttrs(attrs)
+			if strings.Join(got, ",") != strings.Join(c.want, ",") {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestWantedStatus(t *testing.T) {
+	cases := []struct {
+		attrs string
+		want  model.Status
+		ok    bool
+	}{
+		{`{"completed":true}`, model.StatusCompleted, true},
+		{`{"canceled":true}`, model.StatusCancelled, true},
+		{`{"completed":true,"canceled":true}`, model.StatusCompleted, true},
+		{`{"completed":false}`, model.StatusOpen, false},
+		{`{"title":"x"}`, model.StatusOpen, false},
+	}
+	for _, c := range cases {
+		var attrs map[string]any
+		if err := json.Unmarshal([]byte(c.attrs), &attrs); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		got, ok := wantedStatus(attrs)
+		if got != c.want || ok != c.ok {
+			t.Errorf("wantedStatus(%s) = (%v, %v), want (%v, %v)", c.attrs, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestImportRefusesRepeatingUpdates(t *testing.T) {
+	cases := []struct {
+		name string
+		item string
+		want string
+	}{
+		{"when", `{"type":"to-do","operation":"update","id":"rep-1","attributes":{"when":"today"}}`, "when"},
+		{"deadline", `{"type":"to-do","operation":"update","id":"rep-1","attributes":{"deadline":"2026-05-01"}}`, "deadline"},
+		{"completed", `{"type":"to-do","operation":"update","id":"rep-1","attributes":{"completed":true}}`, "completed"},
+		{"canceled", `{"type":"to-do","operation":"update","id":"rep-1","attributes":{"canceled":true}}`, "canceled"},
+		{"project", `{"type":"project","operation":"update","id":"repproj-1","attributes":{"canceled":true}}`, "canceled"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			database, _ := seedWritable(t)
+			calls := stubExecDropping(t)
+
+			err := runWith(t, database, "import", "--file", importPayload(t, "["+c.item+"]"))
+			if err == nil {
+				t.Fatal("expected a refusal, got nil")
+			}
+			for _, want := range []string{"[0]", c.want, "repeating", repeatingDocsURL, "Nothing was sent"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q missing %q", err, want)
+				}
+			}
+			if *calls != 0 {
+				t.Errorf("payload was sent to Things anyway (%d calls)", *calls)
+			}
+		})
+	}
+}
+
+func TestImportRefusalListsEveryOffendingItem(t *testing.T) {
+	database, _ := seedWritable(t)
+	calls := stubExecDropping(t)
+
+	payload := `[
+	  {"type":"to-do","operation":"update","id":"one-1","attributes":{"when":"today"}},
+	  {"type":"to-do","operation":"update","id":"rep-1","attributes":{"when":"today","deadline":"2026-05-01"}},
+	  {"type":"project","operation":"update","id":"repproj-1","attributes":{"canceled":true}}
+	]`
+	err := runWith(t, database, "import", "--file", importPayload(t, payload))
+	if err == nil {
+		t.Fatal("expected a refusal, got nil")
+	}
+	for _, want := range []string{
+		"2 of 3 update items",
+		`[1] (id rep-1): "Water plants" is a repeating to-do — when, deadline`,
+		`[2] (id repproj-1): "Weekly review" is a repeating project — canceled`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q:\n%s", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "one-1") {
+		t.Errorf("non-repeating item was reported as an offender:\n%s", err)
+	}
+	if *calls != 0 {
+		t.Errorf("payload was sent to Things anyway (%d calls)", *calls)
+	}
+}
+
+func TestImportRefusesRepeatingItemNestedInProject(t *testing.T) {
+	database, _ := seedWritable(t)
+	calls := stubExecDropping(t)
+
+	payload := `[{"type":"project","operation":"update","id":"repproj-1","attributes":{
+	    "title":"Renamed",
+	    "items":[{"type":"to-do","operation":"update","id":"rep-1","attributes":{"completed":true}}]}}]`
+	err := runWith(t, database, "import", "--file", importPayload(t, payload))
+	if err == nil {
+		t.Fatal("expected a refusal, got nil")
+	}
+	if !strings.Contains(err.Error(), "[0].attributes.items[0] (id rep-1)") {
+		t.Errorf("nested item not reported by path:\n%s", err)
+	}
+	if *calls != 0 {
+		t.Errorf("payload was sent to Things anyway (%d calls)", *calls)
+	}
+}
+
+func TestImportAllowsUnrestrictedEditsOnRepeatingItems(t *testing.T) {
+	database, _ := seedWritable(t)
+	calls := stubExecDropping(t)
+
+	payload := `[{"type":"to-do","operation":"update","id":"rep-1","attributes":{"title":"New title","completed":false}}]`
+	if err := runWith(t, database, "import", "--file", importPayload(t, payload)); err != nil {
+		t.Fatalf("import refused an allowed edit: %v", err)
+	}
+	if *calls != 1 {
+		t.Errorf("expected the payload to be sent, got %d calls", *calls)
+	}
+}
+
+func TestImportWarnsAboutUnknownIDs(t *testing.T) {
+	database, _ := seedWritable(t)
+	stubExecDropping(t)
+
+	payload := `[{"type":"to-do","operation":"update","id":"nope-1","attributes":{"title":"x"}}]`
+	stderr, err := runImport(t, database, payload)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !strings.Contains(stderr, "[0] (id nope-1) is not in the Things database") {
+		t.Errorf("stderr missing unknown-id warning:\n%s", stderr)
+	}
+}
+
+// A checklist item lives outside TMTask, so looking its id up would always
+// come back empty and warn about an item that is perfectly valid.
+func TestImportDoesNotLookUpChecklistItems(t *testing.T) {
+	database, _ := seedWritable(t)
+	stubExecDropping(t)
+
+	payload := `[{"type":"checklist-item","operation":"update","id":"chk-1","attributes":{"completed":true}}]`
+	stderr, err := runImport(t, database, payload)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if strings.Contains(stderr, "chk-1") {
+		t.Errorf("checklist item was looked up:\n%s", stderr)
+	}
+}
+
+// stubExecApplyingAll mocks the import write and, as Things would, moves each
+// listed uuid to its status. Ids not listed are left untouched, which is what a
+// silent drop looks like.
+func stubExecApplyingAll(t *testing.T, sqlDB *sql.DB, statuses map[string]int) {
+	t.Helper()
+	prev := things.SetExecCommandForTest(func(string, ...string) *exec.Cmd {
+		for uuid, status := range statuses {
+			if _, err := sqlDB.Exec(`UPDATE TMTask SET status = ? WHERE uuid = ?`, status, uuid); err != nil {
+				t.Errorf("simulating Things write: %v", err)
+			}
+		}
+		return exec.Command("true")
+	})
+	t.Cleanup(func() { things.SetExecCommandForTest(prev) })
+}
+
+func TestImportReadsBackStatusChanges(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	if _, err := sqlDB.Exec(`INSERT INTO TMTask (uuid, title, type, status, trashed, start) VALUES ('one-2', 'File taxes', 0, 0, 0, 2)`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	stubExecApplyingAll(t, sqlDB, map[string]int{
+		"one-1": int(model.StatusCompleted),
+		"one-2": int(model.StatusCancelled),
+	})
+
+	payload := `[
+	  {"type":"to-do","operation":"update","id":"one-1","attributes":{"completed":true}},
+	  {"type":"to-do","operation":"update","id":"one-2","attributes":{"canceled":true}}
+	]`
+	stderr, err := runImport(t, database, payload)
+	if err != nil {
+		t.Fatalf("import: %v (stderr: %s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr: %s", stderr)
+	}
+}
+
+func TestImportReportsEveryDroppedStatusChange(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	if _, err := sqlDB.Exec(`INSERT INTO TMTask (uuid, title, type, status, trashed, start) VALUES ('one-2', 'File taxes', 0, 0, 0, 2)`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Things applies the first item and drops the second — the batch shape of
+	// issue #129.
+	stubExecApplyingAll(t, sqlDB, map[string]int{"one-1": int(model.StatusCompleted)})
+
+	payload := `[
+	  {"type":"to-do","operation":"update","id":"one-1","attributes":{"completed":true}},
+	  {"type":"to-do","operation":"update","id":"one-2","attributes":{"canceled":true}}
+	]`
+	stderr, err := runImport(t, database, payload)
+	if err == nil {
+		t.Fatal("expected a non-zero exit, got nil")
+	}
+	if !strings.Contains(err.Error(), "1 of 2 requested status changes did not apply") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stderr, `import: [1]: status change did not apply: "File taxes" (one-2) is still open`) {
+		t.Errorf("stderr missing the failing item:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "one-1") {
+		t.Errorf("the item that landed was reported as a failure:\n%s", stderr)
+	}
+}
+
+func TestImportNoVerifySkipsReadBack(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	stubExecApplyingAll(t, sqlDB, nil)
+
+	payload := `[{"type":"to-do","operation":"update","id":"one-1","attributes":{"completed":true}}]`
+	stderr, err := runImport(t, database, payload, "--no-verify")
+	if err != nil {
+		t.Fatalf("import with --no-verify: %v", err)
+	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr: %s", stderr)
+	}
+}
+
+// --no-verify turns off the read-back, not the up-front refusal: the refusal
+// is not a guess about what Things did, it is what the docs say it will do.
+func TestImportNoVerifyStillRefusesRepeating(t *testing.T) {
+	database, _ := seedWritable(t)
+	calls := stubExecDropping(t)
+
+	payload := `[{"type":"to-do","operation":"update","id":"rep-1","attributes":{"completed":true}}]`
+	if err := runWith(t, database, "import", "--file", importPayload(t, payload), "--no-verify"); err == nil {
+		t.Fatal("expected a refusal, got nil")
+	}
+	if *calls != 0 {
+		t.Errorf("payload was sent to Things anyway (%d calls)", *calls)
+	}
+}

--- a/cmd/things/importcheck_test.go
+++ b/cmd/things/importcheck_test.go
@@ -98,8 +98,10 @@ func TestRestrictedImportAttrs(t *testing.T) {
 			[]string{"when", "deadline", "completed", "canceled"}},
 		{"clearedDeadline", `{"deadline":""}`, []string{"deadline"}},
 		{"nullWhen", `{"when":null}`, []string{"when"}},
-		{"statusFalse", `{"completed":false,"canceled":false}`, nil},
-		{"statusNull", `{"completed":null}`, nil},
+		// The docs say the status fields "cannot be updated on repeating
+		// to-dos" — setting one to false is still updating it.
+		{"statusFalse", `{"completed":false,"canceled":false}`, []string{"completed", "canceled"}},
+		{"statusNull", `{"completed":null}`, []string{"completed"}},
 		{"statusNonBool", `{"completed":"true"}`, []string{"completed"}},
 	}
 	for _, c := range cases {
@@ -118,29 +120,39 @@ func TestRestrictedImportAttrs(t *testing.T) {
 
 func TestWantedStatus(t *testing.T) {
 	cases := []struct {
+		name  string
 		attrs string
 		want  model.Status
 		ok    bool
 	}{
-		{`{"completed":true}`, model.StatusCompleted, true},
-		{`{"canceled":true}`, model.StatusCancelled, true},
-		{`{"completed":true,"canceled":true}`, model.StatusCompleted, true},
-		{`{"title":"x"}`, model.StatusOpen, false},
-		// An explicit false is not read back: see the note on wantedStatus.
-		{`{"completed":false}`, model.StatusOpen, false},
-		{`{"canceled":false}`, model.StatusOpen, false},
-		// A true still wins over a false alongside it.
-		{`{"completed":false,"canceled":true}`, model.StatusCancelled, true},
+		{"completed", `{"completed":true}`, model.StatusCompleted, true},
+		{"canceled", `{"canceled":true}`, model.StatusCancelled, true},
+		{"neither", `{"title":"x"}`, model.StatusOpen, false},
+		// Both status fields are two-way: false asks for incomplete.
+		{"completedFalse", `{"completed":false}`, model.StatusOpen, true},
+		{"canceledFalse", `{"canceled":false}`, model.StatusOpen, true},
+		// "canceled … Takes priority over completed", and completed is
+		// "Ignored if canceled is also set to true".
+		{"bothTrue", `{"completed":true,"canceled":true}`, model.StatusCancelled, true},
+		{"bothFalse", `{"completed":false,"canceled":false}`, model.StatusOpen, true},
+		{"canceledTrueCompletedFalse", `{"completed":false,"canceled":true}`, model.StatusCancelled, true},
+		// The two doc entries disagree about this one; left unverified rather
+		// than guessed.
+		{"canceledFalseCompletedTrue", `{"completed":true,"canceled":false}`, model.StatusOpen, false},
+		// A non-bool is a payload error for Things to report, not a request.
+		{"nonBool", `{"completed":"true"}`, model.StatusOpen, false},
 	}
 	for _, c := range cases {
-		var attrs map[string]any
-		if err := json.Unmarshal([]byte(c.attrs), &attrs); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-		got, ok := wantedStatus(attrs)
-		if got != c.want || ok != c.ok {
-			t.Errorf("wantedStatus(%s) = (%v, %v), want (%v, %v)", c.attrs, got, ok, c.want, c.ok)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			var attrs map[string]any
+			if err := json.Unmarshal([]byte(c.attrs), &attrs); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got, ok := wantedStatus(attrs)
+			if got != c.want || ok != c.ok {
+				t.Errorf("wantedStatus(%s) = (%v, %v), want (%v, %v)", c.attrs, got, ok, c.want, c.ok)
+			}
+		})
 	}
 }
 
@@ -154,6 +166,10 @@ func TestImportRefusesRepeatingUpdates(t *testing.T) {
 		{"deadline", `{"type":"to-do","operation":"update","id":"rep-1","attributes":{"deadline":"2026-05-01"}}`, "deadline"},
 		{"completed", `{"type":"to-do","operation":"update","id":"rep-1","attributes":{"completed":true}}`, "completed"},
 		{"canceled", `{"type":"to-do","operation":"update","id":"rep-1","attributes":{"canceled":true}}`, "canceled"},
+		// Setting a repeating item to incomplete is still updating a field the
+		// docs say cannot be updated on repeating items.
+		{"completedFalse", `{"type":"to-do","operation":"update","id":"rep-1","attributes":{"completed":false}}`, "completed"},
+		{"canceledFalse", `{"type":"to-do","operation":"update","id":"rep-1","attributes":{"canceled":false}}`, "canceled"},
 		{"project", `{"type":"project","operation":"update","id":"repproj-1","attributes":{"canceled":true}}`, "canceled"},
 	}
 	for _, c := range cases {
@@ -230,7 +246,7 @@ func TestImportAllowsUnrestrictedEditsOnRepeatingItems(t *testing.T) {
 	database, _ := seedWritable(t)
 	calls := stubExecDropping(t)
 
-	payload := `[{"type":"to-do","operation":"update","id":"rep-1","attributes":{"title":"New title","completed":false}}]`
+	payload := `[{"type":"to-do","operation":"update","id":"rep-1","attributes":{"title":"New title","notes":"n","tags":["urgent"]}}]`
 	if err := runWith(t, database, "import", "--file", importPayload(t, payload)); err != nil {
 		t.Fatalf("import refused an allowed edit: %v", err)
 	}
@@ -387,5 +403,74 @@ func TestImportRefusalDoesNotWarnAboutUnknownIDs(t *testing.T) {
 	}
 	if *calls != 0 {
 		t.Errorf("payload was sent to Things anyway (%d calls)", *calls)
+	}
+}
+
+// `"completed": false` asks Things to set an item to incomplete — the `update`
+// command documents both status fields as two-way. A reopen Things drops is as
+// invisible as a completion it drops, so it is read back the same way.
+func TestImportReadsBackAReopen(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	if _, err := sqlDB.Exec(`INSERT INTO TMTask (uuid, title, type, status, trashed, start) VALUES ('done-1', 'File taxes', 0, 3, 0, 2)`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	payload := `[{"type":"to-do","operation":"update","id":"done-1","attributes":{"completed":false}}]`
+
+	t.Run("dropped", func(t *testing.T) {
+		stubExecApplyingAll(t, sqlDB, nil)
+		stderr, err := runImport(t, database, payload)
+		if err == nil {
+			t.Fatal("expected a non-zero exit for a dropped reopen, got nil")
+		}
+		if !strings.Contains(stderr, `"File taxes" (done-1) is still completed`) {
+			t.Errorf("stderr missing the dropped reopen:\n%s", stderr)
+		}
+	})
+
+	t.Run("applied", func(t *testing.T) {
+		stubExecApplyingAll(t, sqlDB, map[string]int{"done-1": int(model.StatusOpen)})
+		stderr, err := runImport(t, database, payload)
+		if err != nil {
+			t.Fatalf("import: %v (stderr: %s)", err, stderr)
+		}
+		if stderr != "" {
+			t.Errorf("unexpected stderr: %s", stderr)
+		}
+	})
+}
+
+// `"completed": false` on an item that is already open asks for a status it is
+// already in, so the read-back is satisfied at once rather than reporting a
+// failure against a payload Things had nothing to do with.
+func TestImportReopenOfAnOpenItemIsNotAFailure(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	stubExecApplyingAll(t, sqlDB, nil)
+
+	payload := `[{"type":"to-do","operation":"update","id":"one-1","attributes":{"completed":false}}]`
+	stderr, err := runImport(t, database, payload)
+	if err != nil {
+		t.Fatalf("import: %v (stderr: %s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr: %s", stderr)
+	}
+}
+
+// canceled takes priority over completed, so a payload setting both is read
+// back against cancelled — not completed, which Things ignores.
+func TestImportReadsBackCanceledOverCompleted(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	stubExecApplyingAll(t, sqlDB, map[string]int{"one-1": int(model.StatusCancelled)})
+
+	payload := `[{"type":"to-do","operation":"update","id":"one-1","attributes":{"completed":true,"canceled":true}}]`
+	stderr, err := runImport(t, database, payload)
+	if err != nil {
+		t.Fatalf("import treated a cancelled item as a failed completion: %v (stderr: %s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr: %s", stderr)
 	}
 }

--- a/cmd/things/importcheck_test.go
+++ b/cmd/things/importcheck_test.go
@@ -125,8 +125,12 @@ func TestWantedStatus(t *testing.T) {
 		{`{"completed":true}`, model.StatusCompleted, true},
 		{`{"canceled":true}`, model.StatusCancelled, true},
 		{`{"completed":true,"canceled":true}`, model.StatusCompleted, true},
-		{`{"completed":false}`, model.StatusOpen, false},
 		{`{"title":"x"}`, model.StatusOpen, false},
+		// An explicit false is not read back: see the note on wantedStatus.
+		{`{"completed":false}`, model.StatusOpen, false},
+		{`{"canceled":false}`, model.StatusOpen, false},
+		// A true still wins over a false alongside it.
+		{`{"completed":false,"canceled":true}`, model.StatusCancelled, true},
 	}
 	for _, c := range cases {
 		var attrs map[string]any
@@ -358,6 +362,28 @@ func TestImportNoVerifyStillRefusesRepeating(t *testing.T) {
 	payload := `[{"type":"to-do","operation":"update","id":"rep-1","attributes":{"completed":true}}]`
 	if err := runWith(t, database, "import", "--file", importPayload(t, payload), "--no-verify"); err == nil {
 		t.Fatal("expected a refusal, got nil")
+	}
+	if *calls != 0 {
+		t.Errorf("payload was sent to Things anyway (%d calls)", *calls)
+	}
+}
+
+// A refused import never reaches Things, so the unknown-id warning — which
+// tells the user Things will report the id itself — must not be printed.
+func TestImportRefusalDoesNotWarnAboutUnknownIDs(t *testing.T) {
+	database, _ := seedWritable(t)
+	calls := stubExecDropping(t)
+
+	payload := `[
+	  {"type":"to-do","operation":"update","id":"nope-1","attributes":{"title":"x"}},
+	  {"type":"to-do","operation":"update","id":"rep-1","attributes":{"completed":true}}
+	]`
+	stderr, err := runImport(t, database, payload)
+	if err == nil {
+		t.Fatal("expected a refusal, got nil")
+	}
+	if strings.Contains(stderr, "nope-1") {
+		t.Errorf("refused import still warned that Things would report the id:\n%s", stderr)
 	}
 	if *calls != 0 {
 		t.Errorf("payload was sent to Things anyway (%d calls)", *calls)

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -35,7 +35,7 @@ type CLI struct {
 	DB      string           `help:"Override database path." type:"existingfile"`
 	Version kong.VersionFlag `help:"Print version and exit." short:"v"`
 
-	NoVerify bool `help:"Skip the read-back that confirms a complete/cancel or tag creation actually landed." name:"no-verify" default:"false"`
+	NoVerify bool `help:"Skip the read-back that confirms a complete/cancel, tag creation, or an import's status changes actually landed." name:"no-verify" default:"false"`
 
 	List     ListCmd     `cmd:"" help:"List tasks (today,inbox,upcoming,anytime,someday,repeating,logbook,trash,deadlines). Use as: things today, things inbox, etc." default:"withargs"`
 	Projects ProjectsCmd `cmd:"" help:"List projects."`
@@ -738,6 +738,12 @@ func (c *ImportCmd) Run(d *Deps) error {
 	if err := verifyTags(d, c.TagFlags, importTags(data)); err != nil {
 		return err
 	}
+	// Refuse before anything is sent if any `operation: update` item would
+	// change an attribute Things drops silently on a repeating item.
+	plan, err := prepareImport(d, database, data)
+	if err != nil {
+		return err
+	}
 	token, err := database.GetAuthToken()
 	if err != nil {
 		// Don't fail the import — the payload may be create-only and not need
@@ -745,7 +751,10 @@ func (c *ImportCmd) Run(d *Deps) error {
 		// `operation: update` failure aren't left guessing.
 		fmt.Fprintf(d.errOut(), "warning: could not read Things auth token: %v\n", err)
 	}
-	return things.ImportJSON(string(data), token, c.Reveal)
+	if err := things.ImportJSON(string(data), token, c.Reveal); err != nil {
+		return err
+	}
+	return verifyImportStatuses(d, database, plan)
 }
 
 type OpenCmd struct {

--- a/cmd/things/verify.go
+++ b/cmd/things/verify.go
@@ -61,33 +61,78 @@ func restrictedEdits(when, deadline *string, complete, cancel, duplicate bool) [
 	return blocked
 }
 
-// verifyStatus re-reads the item until its status matches want, and reports an
-// error if it never does. Without this a write Things ignored is
-// indistinguishable from one it applied.
+// statusWant pairs an item with the status a write asked Things to move it to.
+type statusWant struct {
+	uuid  string
+	title string
+	want  model.Status
+}
+
+// verifyStatuses re-reads each item until its status matches the one requested,
+// and reports per item whether the change landed. The returned slice is
+// parallel to wants; a nil entry means that item is confirmed. Without this a
+// write Things ignored is indistinguishable from one it applied.
+//
+// One budget covers the whole batch and items are polled in rounds, so an
+// import asking for ten completions waits the same as a single one rather than
+// ten times as long. Things applies a payload's items together, so a round is
+// also the shape that matches how the changes actually show up.
 //
 // A failed read is retried rather than returned: Things is writing to the same
 // database while we poll, and a transient SQLITE_BUSY there must not turn a
 // write that landed into a reported failure. A read that keeps failing is
 // surfaced once the deadline passes.
-func verifyStatus(database *db.DB, task *model.Task, want model.Status) error {
-	deadline := time.Now().Add(verifyTimeout)
-	for {
-		current, err := database.GetTaskByUUID(task.UUID)
-		switch {
-		case err != nil:
-			if !time.Now().Before(deadline) {
-				return fmt.Errorf("verifying status change: %w", err)
-			}
-		case current == nil:
-			return fmt.Errorf("verifying status change: %s no longer exists in the Things database", task.UUID)
-		case current.Status == want:
-			return nil
-		case !time.Now().Before(deadline):
-			return fmt.Errorf("status change did not apply: %q (%s) is still %s after %s. Things accepted the command and then dropped it silently — check that Things3 is running, or make the change in the app",
-				task.Title, task.UUID, current.Status, verifyTimeout)
-		}
-		verifySleep(verifyInterval)
+func verifyStatuses(database *db.DB, wants []statusWant, budget time.Duration) []error {
+	results := make([]error, len(wants))
+	pending := make([]int, len(wants))
+	for i := range wants {
+		pending[i] = i
 	}
+
+	deadline := time.Now().Add(budget)
+	for len(pending) > 0 {
+		// Read the clock once per round so every item in it is judged against
+		// the same deadline.
+		expired := !time.Now().Before(deadline)
+		var next []int
+		for _, i := range pending {
+			w := wants[i]
+			current, err := database.GetTaskByUUID(w.uuid)
+			switch {
+			case err != nil:
+				if expired {
+					results[i] = fmt.Errorf("verifying status change: %w", err)
+					continue
+				}
+			case current == nil:
+				results[i] = fmt.Errorf("verifying status change: %s no longer exists in the Things database", w.uuid)
+				continue
+			case current.Status == w.want:
+				continue
+			case expired:
+				results[i] = fmt.Errorf("status change did not apply: %q (%s) is still %s after %s. Things accepted the command and then dropped it silently — check that Things3 is running, or make the change in the app",
+					w.title, w.uuid, current.Status, budget)
+				continue
+			}
+			next = append(next, i)
+		}
+		pending = next
+		if expired {
+			// Every item was judged in this round; anything still listed would
+			// only spin.
+			break
+		}
+		if len(pending) > 0 {
+			verifySleep(verifyInterval)
+		}
+	}
+	return results
+}
+
+// verifyStatus re-reads a single item until its status matches want, and
+// reports an error if it never does.
+func verifyStatus(database *db.DB, task *model.Task, want model.Status) error {
+	return verifyStatuses(database, []statusWant{{uuid: task.UUID, title: task.Title, want: want}}, verifyTimeout)[0]
 }
 
 // applyStatusWrite runs a status-changing write and confirms it landed, unless

--- a/cmd/things/verify_test.go
+++ b/cmd/things/verify_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ryanlewis/things-cli/internal/db"
 	"github.com/ryanlewis/things-cli/internal/db/dbtest"
+	"github.com/ryanlewis/things-cli/internal/model"
 	"github.com/ryanlewis/things-cli/internal/skill"
 	"github.com/ryanlewis/things-cli/internal/things"
 )
@@ -251,5 +252,70 @@ func TestEditRejectsCompleteAndCancelTogether(t *testing.T) {
 				t.Fatalf("parse %v = %v, want a mutual-exclusion error", args, err)
 			}
 		})
+	}
+}
+
+// The batch read-back shares one budget across every item, so a payload of ten
+// dropped status changes must not wait ten timeouts. Counting sleeps is the
+// stable way to assert that: with a per-item deadline each item would burn its
+// own full run of polls.
+func TestVerifyStatusesShareOneDeadline(t *testing.T) {
+	timeout, interval, sleep := verifyTimeout, verifyInterval, verifySleep
+	t.Cleanup(func() { verifyTimeout, verifyInterval, verifySleep = timeout, interval, sleep })
+
+	database, _ := seedWritable(t)
+	// A budget of a few intervals, and a sleep that advances no real clock, so
+	// the deadline is reached by elapsed wall time in a handful of rounds.
+	verifyTimeout = 30 * time.Millisecond
+	verifyInterval = 5 * time.Millisecond
+	sleeps := 0
+	verifySleep = func(d time.Duration) {
+		sleeps++
+		time.Sleep(d)
+	}
+
+	wants := make([]statusWant, 8)
+	for i := range wants {
+		wants[i] = statusWant{uuid: "one-1", title: "Post letter", want: model.StatusCompleted}
+	}
+	errs := verifyStatuses(database, wants, verifyTimeout)
+
+	for i, err := range errs {
+		if err == nil {
+			t.Fatalf("item %d reported as landed, but nothing changed its status", i)
+		}
+		if !strings.Contains(err.Error(), "status change did not apply") {
+			t.Errorf("item %d: unexpected error %v", i, err)
+		}
+	}
+	// One sleep per round, and rounds stop at the shared deadline: at most
+	// budget/interval of them however many items there are. A per-item
+	// deadline would restart the count for each item and sleep roughly
+	// len(wants) times as often. Load can only push the real count below the
+	// bound, never above it, so this does not depend on how fast the machine
+	// is.
+	if maxRounds := int(verifyTimeout/verifyInterval) + 2; sleeps > maxRounds {
+		t.Errorf("slept %d times for %d items, want at most %d rounds — the deadline is not shared", sleeps, len(wants), maxRounds)
+	}
+}
+
+// A single write's read-back keeps the message it always had, batch refactor
+// or not.
+func TestVerifyStatusReportsTheItemThatDidNotChange(t *testing.T) {
+	fastVerify(t)
+	database, _ := seedWritable(t)
+
+	task, err := database.GetTaskByUUID("one-1")
+	if err != nil || task == nil {
+		t.Fatalf("seed lookup: %v", err)
+	}
+	err = verifyStatus(database, task, model.StatusCompleted)
+	if err == nil {
+		t.Fatal("expected a failure, got nil")
+	}
+	for _, want := range []string{"status change did not apply", `"Post letter" (one-1)`, "is still open"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
 	}
 }

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -149,9 +149,10 @@ things import < payload.json  # batch create/update via the Things JSON URL sche
 [documented by Cultured Code](https://culturedcode.com/things/support/articles/2803573/).
 
 Items with `"operation": "update"` go through the same repeating check as
-`edit`: if any of them sets `when`, `deadline`, `completed` or `canceled` on a
-repeating to-do or project, the whole import is refused before anything is
-sent, and the error names every offending item. Update items that set
+`edit`: if any of them carries `when`, `deadline`, `completed` or `canceled`
+for a repeating to-do or project, the whole import is refused before anything
+is sent, and the error names every offending item. The status fields are
+two-way, so `false` is refused as readily as `true`. Update items that set
 `completed` or `canceled` are read back from the database afterwards, and any
 that Things dropped are reported one per line with a non-zero exit.
 

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -148,6 +148,13 @@ things import < payload.json  # batch create/update via the Things JSON URL sche
 `import` payload is the array
 [documented by Cultured Code](https://culturedcode.com/things/support/articles/2803573/).
 
+Items with `"operation": "update"` go through the same repeating check as
+`edit`: if any of them sets `when`, `deadline`, `completed` or `canceled` on a
+repeating to-do or project, the whole import is refused before anything is
+sent, and the error names every offending item. Update items that set
+`completed` or `canceled` are read back from the database afterwards, and any
+that Things dropped are reported one per line with a non-zero exit.
+
 ## Opening in the app
 
 ```sh

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -68,7 +68,7 @@ things edit <task> [--title --notes --prepend-notes --append-notes --when --dead
 things complete <task>          # task or project; project completion asks to confirm
 things cancel <task>            # task or project; project cancellation asks to confirm
 things log                      # move Today → Logbook
-things --no-verify complete <task>   # skip the read-back (rarely needed)
+things --no-verify complete <task>   # skip the read-back (rarely needed; also applies to import)
 things open [<ref>] [-p P | -a A | -t T | -q Q] [--filter T1,T2] [--background]
     # ref: task/project UUID, numeric list index, title, or built-in list name
     #      (today, inbox, upcoming, anytime, someday, repeating, logbook, trash,
@@ -79,6 +79,8 @@ things open [<ref>] [-p P | -a A | -t T | -q Q] [--filter T1,T2] [--background]
 things import [--file F] [--reveal] [--strict-tags | --create-tags] < payload.json
     # batch create/update via the Things JSON URL scheme
     # payload is the array documented at culturedcode.com/things/support/articles/2803573/
+    # update items on repeating to-dos/projects are refused up front (see below)
+    # update items setting completed/canceled are read back afterwards
 ```
 
 ### Repeating to-dos and projects
@@ -93,6 +95,19 @@ on repeating to-dos and drops the request silently (…). Change it in the Thing
 ```
 
 There is no CLI workaround — the user has to make the change in the Things app. Every other attribute (`--title`, `--notes`, `--tags`, `--list`, …) edits normally.
+
+`import` applies the same check per item. If any `operation: update` item sets `when`, `deadline`, `completed` or `canceled` on a repeating to-do or project, the whole import is refused before anything is sent — the URL scheme takes one payload and reports nothing per item, so there is no way to send the rest and say what was skipped. The error names each offending item by its position in the payload (nested items included, e.g. `[2].attributes.items[0]`), its id, its title and the blocked attributes. Fix or drop those items and run the import again.
+
+### Confirming a status change landed
+
+Things has no callback for writes, so after a `complete`, a `cancel`, or an `import` item that sets `completed`/`canceled`, the CLI re-reads the item from the database and exits non-zero if the status never changed. An import checks every such item before reporting, one stderr line each, and the whole batch shares one timeout budget:
+
+```
+import: [1]: status change did not apply: "File taxes" (one-2) is still open after 10s. …
+Error: 1 of 2 requested status changes did not apply (listed above). …
+```
+
+The rest of the import is already applied at that point — re-run with only the failed items. `--no-verify` skips the read-back; it does not skip the repeating refusal above, which is a documented rule rather than a guess about what Things did.
 
 ### Tags must already exist
 

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -100,11 +100,11 @@ There is no CLI workaround — the user has to make the change in the Things app
 
 ### Confirming a status change landed
 
-Things has no callback for writes, so after a `complete`, a `cancel`, or an `import` item that sets `completed`/`canceled`, the CLI re-reads the item from the database and exits non-zero if the status never changed. Setting either field to `false` asks for incomplete and is read back too; `canceled` takes priority over `completed` when both are set. An import checks every such item before reporting, one stderr line each, and the whole batch shares one timeout budget:
+Things has no callback for writes, so after a `complete`, a `cancel`, or an `import` item that sets `completed`/`canceled`, the CLI re-reads the item from the database and exits non-zero if the status never changed. Setting either field to `false` asks for incomplete and is read back too; `canceled` takes priority over `completed` when both are set. An import checks every such item before reporting, and the whole batch shares one timeout budget. The per-item detail is part of the error, so it survives `--json`:
 
 ```
-import: [1]: status change did not apply: "File taxes" (one-2) is still open after 10s. …
-Error: 1 of 2 requested status changes did not apply (listed above). …
+Error: 1 of 2 requested status changes did not apply. …:
+  [1]: status change did not apply: "File taxes" (one-2) is still open after 10s. …
 ```
 
 The rest of the import is already applied at that point — re-run with only the failed items. `--no-verify` skips the read-back; it does not skip the repeating refusal above, which is a documented rule rather than a guess about what Things did.

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -96,11 +96,11 @@ on repeating to-dos and drops the request silently (…). Change it in the Thing
 
 There is no CLI workaround — the user has to make the change in the Things app. Every other attribute (`--title`, `--notes`, `--tags`, `--list`, …) edits normally.
 
-`import` applies the same check per item. If any `operation: update` item sets `when`, `deadline`, `completed` or `canceled` on a repeating to-do or project, the whole import is refused before anything is sent — the URL scheme takes one payload and reports nothing per item, so there is no way to send the rest and say what was skipped. The error names each offending item by its position in the payload (nested items included, e.g. `[2].attributes.items[0]`), its id, its title and the blocked attributes. Fix or drop those items and run the import again.
+`import` applies the same check per item. If any `operation: update` item carries `when`, `deadline`, `completed` or `canceled` for a repeating to-do or project, the whole import is refused before anything is sent. The value is irrelevant — the status fields are two-way and neither can be updated on a repeating item, so `"completed": false` is refused like `"completed": true` — the URL scheme takes one payload and reports nothing per item, so there is no way to send the rest and say what was skipped. The error names each offending item by its position in the payload (nested items included, e.g. `[2].attributes.items[0]`), its id, its title and the blocked attributes. Fix or drop those items and run the import again.
 
 ### Confirming a status change landed
 
-Things has no callback for writes, so after a `complete`, a `cancel`, or an `import` item that sets `completed`/`canceled`, the CLI re-reads the item from the database and exits non-zero if the status never changed. An import checks every such item before reporting, one stderr line each, and the whole batch shares one timeout budget:
+Things has no callback for writes, so after a `complete`, a `cancel`, or an `import` item that sets `completed`/`canceled`, the CLI re-reads the item from the database and exits non-zero if the status never changed. Setting either field to `false` asks for incomplete and is read back too; `canceled` takes priority over `completed` when both are set. An import checks every such item before reporting, one stderr line each, and the whole batch shares one timeout budget:
 
 ```
 import: [1]: status change did not apply: "File taxes" (one-2) is still open after 10s. …


### PR DESCRIPTION
## What changed

`things import` forwarded its payload verbatim, so an `operation: update` item could ask Things to set `when`, `deadline`, `completed` or `canceled` on a repeating to-do or project. Things drops those silently (#129), and `import` went through neither the up-front refusal nor the post-write read-back that `edit`, `complete` and `cancel` gained in #143. This closes both halves for `import`.

**Pre-write refusal.** Every `operation: update` item in the payload — including ones nested in a project's `items` — is resolved against the database before anything is sent. If any names a repeating item and changes a restricted attribute, the whole import is refused:

```text
Error: 2 of 3 update items change attributes Things does not allow on repeating items, and drops the request silently (https://culturedcode.com/things/support/articles/2803573/). Nothing was sent to Things — fix these and run the import again, or make the changes in the Things app:
  [1] (id abc…): "Water plants" is a repeating to-do — when, deadline
  [2].attributes.items[0] (id def…): "Take the bins out" is a repeating to-do — canceled
```

All-or-nothing is the design, not a shortcut: the URL scheme takes one payload and reports nothing per item, so there is no way to send the rest and say what was skipped. Each offending item is named by payload path, id, title and blocked attributes so a payload can be fixed in one pass.

**Post-write read-back.** Every update item that set `completed` or `canceled` is re-read afterwards. All of them are checked before anything is reported — a payload's later items matter as much as its first — one stderr line per item that did not land, then a non-zero exit:

```text
Error: 1 of 2 requested status changes did not apply. The rest of the import was still applied; re-run the import with only the failed items, or make the changes in the Things app:
  [1]: status change did not apply: "File taxes" (one-2) is still open after 10s. …
```

`--no-verify` skips the read-back. It does not lift the refusal, which is a documented restriction rather than a guess about what Things did.

**Batch budget.** `verifyStatus` now delegates to a new `verifyStatuses`, which polls in rounds against one shared deadline. A ten-item import waits one timeout budget rather than ten. Single-write callers are unchanged, error messages included.

Update items whose `id` is not in the database get a stderr warning and the import proceeds — Things reports those itself.

## Why

`import` is the one write path that reached the silent-drop behaviour of #129 with no guard at all, so the fix in #143 was incomplete. It is also the path where a silent drop is hardest to spot by hand, since a batch gives no per-item feedback.

## How tested

`make test` (`-race`) and `make lint` (0 issues), plus `go vet`. New tests in `cmd/things/importcheck_test.go` and `cmd/things/verify_test.go` cover the payload walk (nesting, stable ordering under Go's randomised map iteration, unparseable input), the restricted-attribute and wanted-status classifiers, refusal for each blocked attribute and for nested items, the unknown-id warning, checklist items being skipped, the read-back reporting every dropped item rather than stopping at the first, and `--no-verify` skipping the read-back but not the refusal.

Both new test groups were checked against a deliberately broken implementation rather than assumed meaningful: with the wiring removed every behavioural test fails, and `TestVerifyStatusesShareOneDeadline` fails with "slept 48 times for 8 items, want at most 8 rounds" when `verifyStatuses` is replaced by a sequential per-item version. That test asserts sleep counts rather than wall-clock time, so machine load can only push the count below the bound.

No test touches real Things data — all of it runs against the in-memory `dbtest` schema with `SetExecCommandForTest`.

## Status fields are two-way

The `update` command's parameter table at the [URL scheme docs](https://culturedcode.com/things/support/articles/2803573/) settles two things that a first pass got wrong, and both are fixed here:

- `completed` is "Complete a to-do or set a to-do to incomplete", `canceled` likewise, and each notes that setting the other to `false` on an item in that state also marks it incomplete. So `"completed": false` is a real request, not a no-op. A reopen Things drops is exactly as invisible as a completion it drops, so it is read back — and since both entries also say the field "cannot be updated on repeating to-dos", presence alone is refused on a repeating target whatever the value.
- `canceled` "Takes priority over `completed`", and `completed` is "Ignored if `canceled` is also set to `true`". The read-back had this precedence backwards, so a payload setting both would have been checked against *completed* while Things applied *cancelled* — reporting a failure against an import that worked.

The two entries disagree about `canceled: false` alongside `completed: true`: `canceled` claims priority outright, while `completed` says it is ignored only when `canceled` is `true`. That one combination is left unverified rather than guessed, since guessing wrong fails a working import. It is still refused up front on a repeating target, where the outcome is moot because neither field may be updated at all.

## Under `--json`

Both failures carry their per-item detail inside the error rather than on a separate stream, so #157's error path renders them intact: `{"error": "error", "message": "2 of 3 update items ...:\n  [1] (id abc…): ..."}`. The read-back previously printed its lines to stderr and summarised with "(listed above)", which under `--json` named a list the consumer never sees — stderr is not part of that contract.

They render as the generic `"error"` token. A structured payload — an `items` array of `{path, id, title, blocked}` — would suit a batch failure better, but that means extending the wire format #157 just landed and documented, so it is left as a follow-up rather than decided here.

## Notes

- `duplicate` is not in the restricted set. Unlike the `--duplicate` flag it is not a documented attribute of the JSON scheme's update operation, so including it risked refusing valid payloads.
- `prepareImport` issues one `GetTaskByUUID` per unique update id, and the poll re-reads each pending item per round. Payload size is already bounded by the macOS URL length limit, so this is small in practice; a batched `GetTasksByUUIDs` in `internal/db` would be the fix if it ever matters.

Docs updated in `README.md`, `docs/_tabs/commands.md` and `internal/skill/SKILL.md`.

Closes #145


