### PR TITLE
fix(views): keep repeating templates out of someday, add repeating view

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,16 +111,15 @@ name in `show` and JSON output.
 A repeating to-do is stored as a template plus the to-dos it generates. Only
 the template appears in `things repeating`; the generated to-dos are ordinary
 tasks and show up in `today`, `upcoming` and the rest as usual. Templates are
-kept out of every other view.
+kept out of every other view except `trash` and `logbook`, which report what
+the database holds.
 
-The date filters (`--on`, `--from`,
-`--to`) apply to date-filterable views — `today`, `upcoming`, `anytime`,
-`deadlines`, and project listings (`someday` items have no start date, so
-they can't be date-filtered, and neither can `repeating` templates) — and
-`--on` can't be combined with
-`--from`/`--to`. `--include-completed` applies to the `today` view only, so
-with a filter it needs the view spelled out: `things today -p "Launch v2"
---include-completed`.
+The date filters (`--on`, `--from`, `--to`) apply to date-filterable views —
+`today`, `upcoming`, `anytime`, `deadlines`, and project listings (`someday`
+items have no start date, so they can't be date-filtered, and neither can
+`repeating` templates) — and `--on` can't be combined with `--from`/`--to`.
+`--include-completed` applies to the `today` view only, so with a filter it
+needs the view spelled out: `things today -p "Launch v2" --include-completed`.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ things open --project "Launch"         # reveal in the Things app
 What it does:
 
 - **List & inspect** every built-in view (`today`, `inbox`, `upcoming`,
-  `anytime`, `someday`, `logbook`, `trash`, `deadlines`) plus projects,
-  areas, tags, and full-text search
+  `anytime`, `someday`, `repeating`, `logbook`, `trash`, `deadlines`) plus
+  projects, areas, tags, and full-text search
 - **Create** tasks and projects with notes, schedules, deadlines, tags,
   checklists, and headings
 - **Edit** anything mutable via `things:///update` — only the flags you
@@ -76,6 +76,7 @@ project literally called `Inbox` would need `things -p Inbox`.
 | `upcoming` | Scheduled tasks and deadlines |
 | `anytime` | Anytime list |
 | `someday` | Someday list |
+| `repeating` | Repeating to-do templates |
 | `logbook` | Completed tasks |
 | `trash` | Trashed tasks |
 | `deadlines` | Tasks with a deadline |
@@ -107,10 +108,16 @@ Tasks filed under a project heading count as part of the project, so they
 show up under `-p` and under the project's `-a` area, and carry the project
 name in `show` and JSON output.
 
+A repeating to-do is stored as a template plus the to-dos it generates. Only
+the template appears in `things repeating`; the generated to-dos are ordinary
+tasks and show up in `today`, `upcoming` and the rest as usual. Templates are
+kept out of every other view.
+
 The date filters (`--on`, `--from`,
 `--to`) apply to date-filterable views — `today`, `upcoming`, `anytime`,
 `deadlines`, and project listings (`someday` items have no start date, so
-they can't be date-filtered) — and `--on` can't be combined with
+they can't be date-filtered, and neither can `repeating` templates) — and
+`--on` can't be combined with
 `--from`/`--to`. `--include-completed` applies to the `today` view only, so
 with a filter it needs the view spelled out: `things today -p "Launch v2"
 --include-completed`.

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -37,7 +37,7 @@ type CLI struct {
 
 	NoVerify bool `help:"Skip the read-back that confirms a complete/cancel actually landed." name:"no-verify" default:"false"`
 
-	List     ListCmd     `cmd:"" help:"List tasks (today,inbox,upcoming,anytime,someday,logbook,trash,deadlines). Use as: things today, things inbox, etc." default:"withargs"`
+	List     ListCmd     `cmd:"" help:"List tasks (today,inbox,upcoming,anytime,someday,repeating,logbook,trash,deadlines). Use as: things today, things inbox, etc." default:"withargs"`
 	Projects ProjectsCmd `cmd:"" help:"List projects."`
 	Areas    AreasCmd    `cmd:"" help:"List areas."`
 	Tags     TagsCmd     `cmd:"" help:"List tags."`
@@ -117,7 +117,7 @@ func (c *VersionCmd) Run(d *Deps) error {
 }
 
 type ListCmd struct {
-	Args    []string `arg:"" optional:"" help:"View or project name. Views: today,inbox,upcoming,anytime,someday,logbook,trash,deadlines."`
+	Args    []string `arg:"" optional:"" help:"View or project name. Views: today,inbox,upcoming,anytime,someday,repeating,logbook,trash,deadlines."`
 	Project string   `help:"Filter by project name or UUID." short:"p"`
 	Area    string   `help:"Filter by area name or UUID." short:"a"`
 	Tag     string   `help:"Filter by tag name." short:"t"`

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -182,6 +182,9 @@ func TestRunDispatchReadOnly(t *testing.T) {
 	cases := [][]string{
 		{"list", "inbox"},
 		{"list", "today"},
+		{"list", "someday"},
+		{"list", "repeating"},
+		{"list", "repeating", "--tag", "urgent"},
 		{"projects"},
 		{"areas"},
 		{"tags"},

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -21,7 +21,8 @@ Available views: `today`, `inbox`, `upcoming`, `anytime`, `someday`,
 
 `repeating` lists repeating to-do templates. The to-dos a template generates
 are ordinary tasks and appear in `today`, `upcoming` and the rest; the
-template itself appears only here.
+template itself appears only here, and in `trash` or `logbook` if it ends up
+there.
 
 Filter any list with `-p/--project`, `-a/--area`, or `-t/--tag`. On their
 own the filters cover every open task in the project, area, or tag; add a

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -17,7 +17,11 @@ things <view>          # shortcut: things inbox, things today, etc.
 ```
 
 Available views: `today`, `inbox`, `upcoming`, `anytime`, `someday`,
-`logbook`, `trash`, `deadlines`.
+`repeating`, `logbook`, `trash`, `deadlines`.
+
+`repeating` lists repeating to-do templates. The to-dos a template generates
+are ordinary tasks and appear in `today`, `upcoming` and the rest; the
+template itself appears only here.
 
 Filter any list with `-p/--project`, `-a/--area`, or `-t/--tag`. On their
 own the filters cover every open task in the project, area, or tag; add a

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -13,7 +13,7 @@ import (
 type DB struct {
 	db *sql.DB
 
-	// repeatSQL caches the probed recurrence-column expression and
+	// repeatSQL caches the probed recurrence-column reference and
 	// repeatQuery the task query built from it; see (*DB).probeRepeating.
 	repeatOnce  sync.Once
 	repeatSQL   string

--- a/internal/db/repeating.go
+++ b/internal/db/repeating.go
@@ -11,19 +11,27 @@ import (
 // degrades to "nothing repeats" instead of breaking every task query.
 var recurrenceColumns = []string{"rt1_recurrenceRule", "recurrenceRule"}
 
-// repeatingExpr returns the SQL expression that yields 1 for a repeating item
-// and 0 otherwise, aliased against the `t` TMTask row. The probe runs once per
-// DB and the result is cached.
-func (d *DB) repeatingExpr() string {
+// recurrenceCol returns the recurrence column reference, aliased against the
+// `t` TMTask row, for callers to test with IS NULL / IS NOT NULL. On a schema
+// carrying no such column it is the literal NULL, which makes "IS NOT NULL"
+// false for every row and "IS NULL" true for every row — nothing repeats. The
+// probe runs once per DB and the result is cached.
+//
+// A bare column reference rather than a CASE expression is deliberate: Things
+// ships a partial index (index_TMTask_id_where_recurrenceRuleNotNull, ON
+// TMTask(uuid) WHERE rt1_recurrenceRule IS NOT NULL) that SQLite only matches
+// syntactically, so `t."rt1_recurrenceRule" IS NOT NULL` uses it while
+// `CASE WHEN ... END = 1` falls back to scanning every task.
+func (d *DB) recurrenceCol() string {
 	d.probeRepeating()
 	return d.repeatSQL
 }
 
-// probeRepeating resolves the recurrence expression and the assembled task
-// query once per DB.
+// probeRepeating resolves the recurrence column reference and the assembled
+// task query once per DB.
 func (d *DB) probeRepeating() {
 	d.repeatOnce.Do(func() {
-		d.repeatSQL = "0"
+		d.repeatSQL = "NULL"
 		defer func() {
 			d.repeatQuery = strings.Replace(baseTaskQuery, repeatingPlaceholder, d.repeatSQL, 1)
 		}()
@@ -33,7 +41,7 @@ func (d *DB) probeRepeating() {
 		}
 		for _, c := range recurrenceColumns {
 			if cols[c] {
-				d.repeatSQL = `CASE WHEN t."` + c + `" IS NOT NULL THEN 1 ELSE 0 END`
+				d.repeatSQL = `t."` + c + `"`
 				return
 			}
 		}

--- a/internal/db/repeating_test.go
+++ b/internal/db/repeating_test.go
@@ -106,6 +106,27 @@ func TestRepeatingViewHonoursFilters(t *testing.T) {
 	}
 }
 
+// Trashing a project leaves its rows trashed = 0, so a template inside one
+// would outlive the project it lived in — the Repeating view needs the same
+// guard the today and project views apply.
+func TestRepeatingViewExcludesTrashedProject(t *testing.T) {
+	d := newTestDB(t)
+
+	mustExec(t, d, `INSERT INTO TMTask (uuid, title, type, status, trashed, "index") VALUES
+		('proj-gone', 'Trashed project', 1, 0, 1, 1)`)
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, project, "index", rt1_recurrenceRule) VALUES
+		('rep-orphan', 'Water plants', 0, 0, 0, 2, 0, 'proj-gone', 1, x'0102')`)
+
+	got, err := d.ListTasks("repeating", TaskFilter{})
+	if err != nil {
+		t.Fatalf("ListTasks(repeating): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ListTasks(repeating) = %v, want no templates from a trashed project", uuidsOf(got))
+	}
+}
+
 // Older Things schemas name the column differently, and a future one could
 // drop it. The probe must degrade to "nothing repeats" rather than making
 // every task query fail.
@@ -121,8 +142,8 @@ func TestRepeatingColumnAbsentDegradesGracefully(t *testing.T) {
 	}
 	d := &DB{db: sqlDB}
 
-	if expr := d.repeatingExpr(); expr != "0" {
-		t.Errorf("repeatingExpr() = %q, want %q", expr, "0")
+	if col := d.recurrenceCol(); col != "NULL" {
+		t.Errorf("recurrenceCol() = %q, want %q", col, "NULL")
 	}
 	task, err := d.GetTaskByUUID("t1")
 	if err != nil {
@@ -151,14 +172,14 @@ func TestRepeatingColumnAbsentDegradesGracefully(t *testing.T) {
 	}
 }
 
-func TestRepeatingExprIsProbedOnce(t *testing.T) {
+func TestRecurrenceColIsProbedOnce(t *testing.T) {
 	d := seedRepeatingPair(t)
-	first := d.repeatingExpr()
-	if first == "0" {
-		t.Fatalf("repeatingExpr() = %q, want a recurrence-column expression", first)
+	first := d.recurrenceCol()
+	if first == "NULL" {
+		t.Fatalf("recurrenceCol() = %q, want a recurrence-column reference", first)
 	}
-	if second := d.repeatingExpr(); second != first {
-		t.Errorf("repeatingExpr() = %q on second call, want the cached %q", second, first)
+	if second := d.recurrenceCol(); second != first {
+		t.Errorf("recurrenceCol() = %q on second call, want the cached %q", second, first)
 	}
 }
 

--- a/internal/db/repeating_test.go
+++ b/internal/db/repeating_test.go
@@ -49,16 +49,12 @@ func TestGetTaskByUUIDReportsRepeating(t *testing.T) {
 func TestListAndSearchReportRepeating(t *testing.T) {
 	d := seedRepeatingPair(t)
 
-	tasks, err := d.ListTasks("someday", TaskFilter{})
+	tasks, err := d.ListTasks("repeating", TaskFilter{})
 	if err != nil {
-		t.Fatalf("ListTasks(someday): %v", err)
+		t.Fatalf("ListTasks(repeating): %v", err)
 	}
-	got := map[string]bool{}
-	for _, task := range tasks {
-		got[task.UUID] = task.Repeating
-	}
-	if !got["rep-1"] || got["one-1"] {
-		t.Errorf("someday repeating flags = %v, want rep-1 true and one-1 false", got)
+	if len(tasks) != 1 || tasks[0].UUID != "rep-1" || !tasks[0].Repeating {
+		t.Errorf("ListTasks(repeating) = %+v, want just rep-1 flagged repeating", tasks)
 	}
 
 	found, err := d.SearchTasks("plants")
@@ -67,6 +63,46 @@ func TestListAndSearchReportRepeating(t *testing.T) {
 	}
 	if len(found) != 1 || !found[0].Repeating {
 		t.Errorf("SearchTasks(plants) = %+v, want one repeating task", found)
+	}
+}
+
+// rep-1 and one-1 differ only by the recurrence rule, so someday keeping the
+// one-off and dropping the template is the whole of issue #147. The catch-all
+// "project" view backs `things --project/--area/--tag`, so it has to drop the
+// template too or the leak just moves.
+func TestTemplatesExcludedFromOpenViews(t *testing.T) {
+	d := seedRepeatingPair(t)
+
+	for _, view := range []string{"someday", "project"} {
+		tasks, err := d.ListTasks(view, TaskFilter{})
+		if err != nil {
+			t.Fatalf("ListTasks(%q): %v", view, err)
+		}
+		if len(tasks) != 1 || tasks[0].UUID != "one-1" {
+			t.Errorf("ListTasks(%q) = %+v, want just one-1", view, uuidsOf(tasks))
+		}
+	}
+}
+
+// A template is a valid target for the same filters as any other view.
+func TestRepeatingViewHonoursFilters(t *testing.T) {
+	d := newTestDB(t)
+	seedTasks(t, d)
+
+	got, err := d.ListTasks("repeating", TaskFilter{Area: "Work"})
+	if err != nil {
+		t.Fatalf("ListTasks(repeating, area=Work): %v", err)
+	}
+	if !sameSet(uuidsOf(got), []string{"t-repeat"}) {
+		t.Errorf("repeating --area Work = %v, want [t-repeat]", uuidsOf(got))
+	}
+
+	got, err = d.ListTasks("repeating", TaskFilter{Project: "Nonexistent"})
+	if err != nil {
+		t.Fatalf("ListTasks(repeating, project=Nonexistent): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("repeating --project Nonexistent = %v, want none", uuidsOf(got))
 	}
 }
 
@@ -94,6 +130,24 @@ func TestRepeatingColumnAbsentDegradesGracefully(t *testing.T) {
 	}
 	if task == nil || task.Repeating {
 		t.Errorf("got %+v, want a task with Repeating false", task)
+	}
+
+	// With nothing identifiable as a template, the repeating view is empty
+	// and the exclusion the other views apply is a no-op rather than a
+	// filter that hides everything.
+	rep, err := d.ListTasks("repeating", TaskFilter{})
+	if err != nil {
+		t.Fatalf("ListTasks(repeating): %v", err)
+	}
+	if len(rep) != 0 {
+		t.Errorf("ListTasks(repeating) = %+v, want none", rep)
+	}
+	open, err := d.ListTasks("project", TaskFilter{})
+	if err != nil {
+		t.Fatalf("ListTasks(project): %v", err)
+	}
+	if len(open) != 1 || open[0].UUID != "t1" {
+		t.Errorf("ListTasks(project) = %v, want just t1", uuidsOf(open))
 	}
 }
 

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -151,6 +151,11 @@ var viewFilters = map[string]string{
 	"logbook":   "t.status = 3 AND t.trashed = 0 AND t.type = 0",
 	"trash":     "t.trashed = 1 AND t.type = 0",
 	"deadlines": "t.deadline IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
+	// Things' Repeating list: the templates that generate to-dos, not the
+	// to-dos they generate. A template carries the recurrence rule; each
+	// generated instance is an ordinary row with no rule of its own, so
+	// {{repeating}} = 1 selects templates alone (issue #147).
+	"repeating": repeatingPlaceholder + " = 1 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
 	// The catch-all open set: also the default view for a bare --project/
 	// --area/--tag filter, so it has to exclude tasks living in a trashed
 	// project the way the today view does.
@@ -175,6 +180,18 @@ var viewOrderBy = map[string]string{
 	"project": "ORDER BY COALESCE(a.\"index\", pa.\"index\", 0), COALESCE(p.\"index\", 0), t.start ASC, t.\"index\" ASC",
 }
 
+// viewsIncludingTemplates lists the views that keep repeating templates in
+// their results. Everywhere else templates are filtered out: Things files a
+// template under Repeating, not under the start bucket its row happens to
+// carry, so a Someday-start template showing up in `things someday` is a leak
+// (issue #147). trash and logbook stay literal — they report what the database
+// actually holds, templates included.
+var viewsIncludingTemplates = map[string]bool{
+	"repeating": true,
+	"trash":     true,
+	"logbook":   true,
+}
+
 func ValidView(name string) bool {
 	_, ok := viewFilters[name]
 	return ok
@@ -187,6 +204,9 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 	}
 	if view == "today" && opts.IncludeCompleted {
 		where = todayWhere(true)
+	}
+	if !viewsIncludingTemplates[view] {
+		where += " AND " + repeatingPlaceholder + " = 0"
 	}
 
 	var args []any
@@ -228,6 +248,12 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 	if orderBy == "" {
 		orderBy = "ORDER BY t.\"index\" ASC"
 	}
+
+	// The recurrence column varies across Things schema versions, so the
+	// filters carry a placeholder that only a live DB can resolve. On a
+	// schema with no such column the expression degrades to 0: the exclusion
+	// becomes a no-op and the repeating view returns nothing.
+	where = strings.ReplaceAll(where, repeatingPlaceholder, d.repeatingExpr())
 
 	query := d.taskQuery() + " WHERE " + where + " GROUP BY t.uuid " + orderBy
 	return d.collectTasks(query, args...)

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -40,8 +40,9 @@ func DateFilterableView(view string) bool {
 	return dateFilterableViews[view]
 }
 
-// repeatingPlaceholder is substituted with the probed recurrence expression by
-// (*DB).taskQuery — the column name varies across Things schema versions.
+// repeatingPlaceholder is substituted with the probed recurrence column
+// reference by (*DB).taskQuery — the column name varies across Things schema
+// versions, and a schema carrying none resolves it to NULL.
 const repeatingPlaceholder = "{{repeating}}"
 
 // baseTaskQuery selects a task with its project, heading, area and tags.
@@ -74,7 +75,7 @@ SELECT
 	COALESCE(GROUP_CONCAT(tag.title, char(31)), ''),
 	COALESCE(t."index", 0),
 	COALESCE(t.todayIndex, 0),
-	{{repeating}}
+	CASE WHEN {{repeating}} IS NOT NULL THEN 1 ELSE 0 END
 FROM TMTask t
 LEFT JOIN TMTask h ON t.heading = h.uuid
 LEFT JOIN TMTask p ON p.uuid = COALESCE(t.project, h.project)
@@ -154,8 +155,11 @@ var viewFilters = map[string]string{
 	// Things' Repeating list: the templates that generate to-dos, not the
 	// to-dos they generate. A template carries the recurrence rule; each
 	// generated instance is an ordinary row with no rule of its own, so
-	// {{repeating}} = 1 selects templates alone (issue #147).
-	"repeating": repeatingPlaceholder + " = 1 AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
+	// "{{repeating}} IS NOT NULL" selects templates alone (issue #147).
+	// Trashing a project leaves its rows trashed = 0, so the template of a
+	// repeating to-do in a trashed project needs the same guard the today
+	// and project views apply or it outlives the project it lived in.
+	"repeating": repeatingPlaceholder + " IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0 AND COALESCE(p.trashed, 0) = 0",
 	// The catch-all open set: also the default view for a bare --project/
 	// --area/--tag filter, so it has to exclude tasks living in a trashed
 	// project the way the today view does.
@@ -206,7 +210,7 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 		where = todayWhere(true)
 	}
 	if !viewsIncludingTemplates[view] {
-		where += " AND " + repeatingPlaceholder + " = 0"
+		where += " AND " + repeatingPlaceholder + " IS NULL"
 	}
 
 	var args []any
@@ -251,9 +255,9 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 
 	// The recurrence column varies across Things schema versions, so the
 	// filters carry a placeholder that only a live DB can resolve. On a
-	// schema with no such column the expression degrades to 0: the exclusion
-	// becomes a no-op and the repeating view returns nothing.
-	where = strings.ReplaceAll(where, repeatingPlaceholder, d.repeatingExpr())
+	// schema with no such column it degrades to NULL: "IS NULL" makes the
+	// exclusion a no-op and "IS NOT NULL" leaves the repeating view empty.
+	where = strings.ReplaceAll(where, repeatingPlaceholder, d.recurrenceCol())
 
 	query := d.taskQuery() + " WHERE " + where + " GROUP BY t.uuid " + orderBy
 	return d.collectTasks(query, args...)

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -39,6 +39,8 @@ func seedTasks(t *testing.T, d *DB) {
 	//   t-trashed     → trashed
 	//   t-deadline    → has deadline
 	//   t-in-proj     → open task inside proj-1
+	//   t-repeat      → repeating template; shaped like t-someday but belongs
+	//                   to the repeating view, not someday (issue #147)
 	tomorrow := today + (1 << 7)
 	mustExec(t, d, `INSERT INTO TMTask
 		(uuid, title, notes, type, status, trashed, start, startBucket,
@@ -56,6 +58,12 @@ func seedTasks(t *testing.T, d *DB) {
 		('t-in-proj',   'Project task',  '',       0, 0, 0, 0, 0, NULL, NULL, NULL, 'proj-1', 'area-work', 19, 0)`,
 		today, today, today, tomorrow, tomorrow) // last arg is the deadline
 
+	// Templates carry the recurrence rule; Things files them under Repeating
+	// while their row otherwise looks exactly like a Someday to-do.
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, project, area, "index", rt1_recurrenceRule) VALUES
+		('t-repeat', 'Water plants', 0, 0, 0, 2, 0, 'proj-1', 'area-work', 20, x'0102')`)
+
 	// Tag the today task with urgent + home
 	mustExec(t, d, `INSERT INTO TMTaskTag (tasks, tags) VALUES
 		('t-today', 'tg-urgent'),
@@ -67,7 +75,7 @@ func seedTasks(t *testing.T, d *DB) {
 }
 
 func TestValidView(t *testing.T) {
-	known := []string{"today", "inbox", "upcoming", "anytime", "someday", "logbook", "trash", "deadlines", "project"}
+	known := []string{"today", "inbox", "upcoming", "anytime", "someday", "repeating", "logbook", "trash", "deadlines", "project"}
 	for _, v := range known {
 		if !ValidView(v) {
 			t.Errorf("%q should be valid", v)
@@ -102,7 +110,10 @@ func TestListTasksViews(t *testing.T) {
 		{"upcoming", []string{"t-upcoming"}},
 		// Anytime is everything with start=1 — Today, Evening, and undated.
 		{"anytime", []string{"t-today", "t-evening", "t-anytime", "t-deadline"}},
+		// t-repeat has the same start/startDate shape as t-someday but is a
+		// template, so it belongs to repeating and nowhere else (issue #147).
 		{"someday", []string{"t-someday"}},
+		{"repeating", []string{"t-repeat"}},
 		{"logbook", []string{"t-done"}},
 		{"trash", []string{"t-trashed"}},
 		{"deadlines", []string{"t-deadline"}},

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -25,7 +25,7 @@ Human output is styled with colors and aligned columns. Color auto-disables when
 
 ```
 things list [view] [--project P] [--area A] [--tag T] [--on D | --from D --to D] [--include-completed]
-    # views: today, inbox, upcoming, anytime, someday, logbook, trash, deadlines
+    # views: today, inbox, upcoming, anytime, someday, repeating, logbook, trash, deadlines
     # shortcut: `things today`, `things inbox`, etc.
     # No view: bare `things` is today, but --project/--area/--tag on their own
     # list every open task in that project/area/tag. Name a view to scope the
@@ -35,7 +35,7 @@ things list [view] [--project P] [--area A] [--tag T] [--on D | --from D --to D]
     # --project and the project's --area, and report projectTitle.
     # --on / --from / --to take YYYY-MM-DD (or RFC3339). They filter startDate
     # on most views and `deadline` on the `deadlines` view. Not supported on
-    # inbox/trash/logbook/someday (someday items have no start date).
+    # inbox/trash/logbook/someday/repeating (those items have no start date).
     # --on is mutually exclusive with --from/--to.
     # today shows only open tasks; --include-completed also lists completed/
     # cancelled items Things hasn't logged out of Today yet (today only).
@@ -56,7 +56,8 @@ things log                      # move Today → Logbook
 things --no-verify complete <task>   # skip the read-back (rarely needed)
 things open [<ref>] [-p P | -a A | -t T | -q Q] [--filter T1,T2] [--background]
     # ref: task/project UUID, numeric list index, title, or built-in list name
-    #      (today, inbox, upcoming, anytime, someday, logbook, trash, deadlines)
+    #      (today, inbox, upcoming, anytime, someday, repeating, logbook, trash,
+    #      deadlines)
     # exactly one of <ref> / -p / -a / -t / -q is required
     # --filter narrows the opened list by tags; --background keeps focus elsewhere
 
@@ -66,6 +67,8 @@ things import [--file F] [--reveal] [--strict-tags] < payload.json
 ```
 
 ### Repeating to-dos and projects
+
+A repeating to-do is stored as a template plus the to-dos it generates. `things repeating` lists the templates; they do not appear in `someday` or any other view. The generated to-dos carry no recurrence rule of their own, so they list as ordinary tasks under `today`, `upcoming` and the rest.
 
 Things refuses to update `when`, `deadline`, completed/canceled status, and duplication on repeating items, and drops the request silently rather than reporting an error. The CLI checks first and fails with a non-zero exit:
 

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -68,7 +68,7 @@ things import [--file F] [--reveal] [--strict-tags] < payload.json
 
 ### Repeating to-dos and projects
 
-A repeating to-do is stored as a template plus the to-dos it generates. `things repeating` lists the templates; they do not appear in `someday` or any other view. The generated to-dos carry no recurrence rule of their own, so they list as ordinary tasks under `today`, `upcoming` and the rest.
+A repeating to-do is stored as a template plus the to-dos it generates. `things repeating` lists the templates; they do not appear in `someday` or any other view except `trash` and `logbook`, which report what the database holds. The generated to-dos carry no recurrence rule of their own, so they list as ordinary tasks under `today`, `upcoming` and the rest.
 
 Things refuses to update `when`, `deadline`, completed/canceled status, and duplication on repeating items, and drops the request silently rather than reporting an error. The CLI checks first and fails with a non-zero exit:
 

--- a/internal/things/urlscheme.go
+++ b/internal/things/urlscheme.go
@@ -80,8 +80,9 @@ func SplitTags(s string) []string {
 }
 
 // BuiltinLists are the navigable list IDs the Things URL scheme accepts
-// verbatim as `id=…`. Some (e.g. repeating, all-projects) have no direct
-// DB equivalent — they're app-side views only.
+// verbatim as `id=…`. Some (e.g. all-projects, logged-projects) have no direct
+// DB equivalent — they're app-side views only. "repeating" does have one:
+// `things repeating` lists the same templates.
 var BuiltinLists = []string{
 	"inbox", "today", "anytime", "upcoming", "someday", "logbook",
 	"tomorrow", "deadlines", "repeating", "all-projects", "logged-projects",


### PR DESCRIPTION
## What changed

A repeating to-do in Things is stored as a **template** row carrying the recurrence rule, plus the ordinary to-dos that template generates. Confirmed against the real database: the template has `rt1_recurrenceRule` set, `rt1_repeatingTemplate` NULL, `type = 0`, `status = 0`, `trashed = 0`, `start = 2` and `startDate` NULL. That is character-for-character the someday filter, which is why `things someday` listed templates as if they were ordinary Someday tasks. Generated instances carry `rt1_repeatingTemplate` pointing at the template and no recurrence rule of their own, so they are already listed correctly as ordinary tasks under `today`, `upcoming` and the rest.

- Templates are excluded from every view except the new `repeating` one, plus `trash` and `logbook`, which stay literal about what the database holds. The catch-all `project` view behind `things --project/--area/--tag` is in the exclusion, so the leak does not just move there.
- New `things repeating` view lists the templates, plain and `--json`, and takes the same `--project`/`--area`/`--tag` filters as the other views. It is not date-filterable — a template has no start date, the same reason `someday` is excluded.
- The filter reuses the probed recurrence column rather than naming one, so on a schema without such a column the view is empty and the exclusion is a no-op.
- The probe now yields the bare column reference instead of a `CASE … THEN 1 ELSE 0 END` expression. SQLite matches partial indexes syntactically, so `IS NOT NULL` uses Things' `index_TMTask_id_where_recurrenceRuleNotNull` while the CASE form scanned every task through six LEFT JOINs.
- `things repeating` carries the `COALESCE(p.trashed, 0) = 0` guard that `today` and `project` carry: trashing a project leaves its child rows at `trashed = 0`.
- Docs updated in `README.md`, `internal/skill/SKILL.md` (the in-binary agent skill) and `docs/_tabs/commands.md`; the `BuiltinLists` comment in `internal/things/urlscheme.go` no longer claims `repeating` has no DB equivalent.

## Why

`things someday` was showing repeating templates that the Things app files under Repeating, and there was no way to list them.

## How tested

- `make test` (race) and `make lint` — both green.
- New tests: the `repeating` view and its filters, exclusion from `someday` and the catch-all `project` view, the trashed-project guard, and the degraded path where the recurrence column is absent. `TestListTasksViews` gained a template shaped like a Someday to-do, so `someday` returning only the real Someday task is now a regression test.
- Verified end-to-end against a read-only copy of the real Things database: `things repeating` returns exactly the two templates, and today/inbox/upcoming/anytime/someday/deadlines/logbook/trash contain none.

## Left out

Two pre-existing issues found while reviewing, both outside this diff:

- `someday`, `anytime`, `upcoming`, `inbox` and `deadlines` also lack the `COALESCE(p.trashed, 0) = 0` guard — same class as #142/#143.
- `GetTask`'s exact-title path uses `LIMIT 1`, so when a template and its generated to-do share a title, `things complete "Water plants"` can resolve to the template and hit the repeating-write refusal even though an actionable instance exists.

Closes #147