### PR TITLE
fix(cli): make --json non-interactive and emit errors as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,37 @@ for structured JSON suitable for piping into `jq` or another tool. List
 commands assign each result a stable index (`1`, `2`, `3`, …) you can use
 in follow-up commands like `show`, `edit`, `complete`, and `cancel`.
 
+`--json` also implies non-interactive: the CLI never prompts, so a reference
+matching several tasks returns an error listing the candidates instead of
+opening the picker, and `complete`/`cancel` on a project declines instead of
+asking to confirm.
+
+### Errors under `--json`
+
+A failing command prints a single JSON object to stdout and exits non-zero, so
+a consumer parsing stdout gets a structured failure either way. `error` is a
+stable token — `ambiguous task`, `not found`, or `error` for anything else —
+and `message` carries the same text plain-text mode prints.
+
+```console
+$ things show milk --json; echo "exit=$?"
+{
+  "error": "ambiguous task",
+  "message": "ambiguous task \"milk\" — matches 2 tasks: ...",
+  "kind": "task",
+  "query": "milk",
+  "matches": [
+    { "uuid": "A1B2...", "title": "Buy milk", "project": "Chores" },
+    { "uuid": "C3D4...", "title": "Buy oat milk" }
+  ]
+}
+exit=1
+```
+
+Retry with one of the `matches[].uuid` values. Argument and flag errors take
+the same route, so `--json` never leaves a usage block on stdout. Without
+`--json`, errors stay a plain `Error: ...` line on stderr, unchanged.
+
 ### Global flags
 
 | Flag | Description | Default |

--- a/cmd/things/errors.go
+++ b/cmd/things/errors.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/ryanlewis/things-cli/internal/db"
+	"github.com/ryanlewis/things-cli/internal/model"
+)
+
+// jsonErrorPayload is the machine-readable form of a command failure. Under
+// --json a failing command prints one of these to stdout and exits non-zero,
+// so a consumer reading stdout always gets JSON — success or failure — and can
+// branch on the "error" token instead of parsing English (issue #152).
+//
+// Error is a stable token: "ambiguous task", "not found", or "error" for a
+// failure with no structure worth naming. Message is the same text the
+// plain-text path prints, for a human reading the JSON.
+type jsonErrorPayload struct {
+	Error   string           `json:"error"`
+	Message string           `json:"message"`
+	Kind    string           `json:"kind,omitempty"`
+	Query   string           `json:"query,omitempty"`
+	Matches []jsonErrorMatch `json:"matches,omitempty"`
+}
+
+// jsonErrorMatch is one candidate of an ambiguous reference — enough for a
+// caller to pick one and retry with the UUID.
+type jsonErrorMatch struct {
+	UUID    string `json:"uuid"`
+	Title   string `json:"title"`
+	Project string `json:"project,omitempty"`
+}
+
+// notFoundError is a lookup that resolved to nothing. Kind names what was
+// looked up ("task", "area", "tag") and Query is the reference the user gave.
+// msg overrides the rendered text where the caller has something more specific
+// to say than "<kind> not found: <query>".
+type notFoundError struct {
+	Kind  string
+	Query string
+	msg   string
+}
+
+func (e *notFoundError) Error() string {
+	if e.msg != "" {
+		return e.msg
+	}
+	return fmt.Sprintf("%s not found: %s", e.Kind, e.Query)
+}
+
+// ambiguousRefError carries a *db.AmbiguousTaskError alongside the multi-line
+// "pick one" text resolveTask prints in non-interactive mode. Error() returns
+// that text unchanged so the plain-text path is untouched, while errors.As
+// still reaches the candidates for the JSON payload.
+type ambiguousRefError struct {
+	msg   string
+	inner *db.AmbiguousTaskError
+}
+
+func (e *ambiguousRefError) Error() string { return e.msg }
+
+func (e *ambiguousRefError) Unwrap() error { return e.inner }
+
+// errorPayload classifies err into the JSON shape. It is the single place that
+// maps Go error types onto the wire format — add a case here rather than
+// formatting JSON at a call site.
+func errorPayload(err error) jsonErrorPayload {
+	payload := jsonErrorPayload{Error: "error", Message: err.Error()}
+
+	var ambig *db.AmbiguousTaskError
+	if errors.As(err, &ambig) {
+		payload.Error = "ambiguous task"
+		payload.Kind = "task"
+		payload.Query = ambig.Query
+		payload.Matches = matchList(ambig.Matches)
+		return payload
+	}
+
+	var notFoundTask *db.TaskNotFoundError
+	if errors.As(err, &notFoundTask) {
+		payload.Error = "not found"
+		payload.Kind = "task"
+		payload.Query = notFoundTask.Query
+		return payload
+	}
+
+	var notFound *notFoundError
+	if errors.As(err, &notFound) {
+		payload.Error = "not found"
+		payload.Kind = notFound.Kind
+		payload.Query = notFound.Query
+		return payload
+	}
+
+	return payload
+}
+
+func matchList(tasks []model.Task) []jsonErrorMatch {
+	out := make([]jsonErrorMatch, len(tasks))
+	for i, t := range tasks {
+		out[i] = jsonErrorMatch{UUID: t.UUID, Title: t.Title, Project: t.ProjectTitle}
+	}
+	return out
+}
+
+// renderError writes a failed command's error. Under --json it goes to stdout
+// as a single JSON object so the consumer parsing stdout sees the failure;
+// otherwise it keeps the plain "Error: ..." line on stderr unchanged.
+func renderError(stdout, stderr io.Writer, asJSON bool, err error) {
+	if !asJSON {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if encErr := enc.Encode(errorPayload(err)); encErr != nil {
+		// Encoding a struct of strings can't realistically fail, but a broken
+		// stdout can — fall back to the plain line so the failure isn't silent.
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+	}
+}

--- a/cmd/things/errors_test.go
+++ b/cmd/things/errors_test.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ryanlewis/things-cli/internal/db"
+	"github.com/ryanlewis/things-cli/internal/db/dbtest"
+)
+
+// stubTTY makes isInteractive report that stdin is a terminal for the duration
+// of the test, so the --json guard can be exercised without a real TTY.
+func stubTTY(t *testing.T, tty bool) {
+	t.Helper()
+	prev := isInteractive
+	isInteractive = func() bool { return tty }
+	t.Cleanup(func() { isInteractive = prev })
+}
+
+// --json means a machine is reading stdout, so a prompt would hang it: the flag
+// implies non-interactive even on a terminal (issue #152).
+func TestDepsInteractiveJSONImpliesNonInteractive(t *testing.T) {
+	stubTTY(t, true)
+
+	if !(&Deps{}).interactive() {
+		t.Error("plain text on a TTY should be interactive")
+	}
+	if (&Deps{JSON: true}).interactive() {
+		t.Error("--json on a TTY must not be interactive")
+	}
+
+	stubTTY(t, false)
+	if (&Deps{}).interactive() {
+		t.Error("a non-TTY should not be interactive")
+	}
+}
+
+// captureStderr collects what fn writes to os.Stderr. confirmAction and the
+// picker write there directly, so this is how a test proves nothing prompted.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+	fn()
+	os.Stderr = orig
+	w.Close()
+	<-done
+	r.Close()
+	return buf.String()
+}
+
+// Completing or cancelling a project asks for confirmation. Under --json that
+// prompt would hang a machine reader, so it must decline without printing.
+func TestConfirmActionJSONDeclines(t *testing.T) {
+	stubTTY(t, true)
+
+	var answer bool
+	prompt := captureStderr(t, func() {
+		answer = confirmAction(&Deps{JSON: true}, "Really?")
+	})
+	if answer {
+		t.Error("--json must decline rather than prompt")
+	}
+	if prompt != "" {
+		t.Errorf("--json wrote a prompt: %q", prompt)
+	}
+}
+
+// seedAmbiguousDB gives two open tasks with the same title, so any substring
+// lookup is ambiguous.
+func seedAmbiguousDB(t *testing.T) *db.DB {
+	t.Helper()
+	sqlDB := dbtest.NewSQL(t)
+	if _, err := sqlDB.Exec(
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, project) VALUES
+			('amb-1', 'Shared title', 0, 0, 0, 'proj-x'),
+			('amb-2', 'Shared title', 0, 0, 0, NULL)`,
+	); err != nil {
+		t.Fatalf("seed tasks: %v", err)
+	}
+	if _, err := sqlDB.Exec(
+		`INSERT INTO TMTask (uuid, title, type, status, trashed) VALUES ('proj-x', 'Chores', 1, 0, 0)`,
+	); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	return db.NewFromSQL(sqlDB)
+}
+
+// On a TTY, --json must return the ambiguity as an error instead of printing
+// the picker and blocking on stdin.
+func TestResolveTaskJSONDoesNotPrompt(t *testing.T) {
+	stubTTY(t, true)
+	database := seedAmbiguousDB(t)
+
+	_, err := resolveTask(&Deps{JSON: true}, "Shared", database)
+	if err == nil {
+		t.Fatal("expected an ambiguity error, not a prompt")
+	}
+	var ambig *db.AmbiguousTaskError
+	if !errors.As(err, &ambig) {
+		t.Fatalf("error should carry the candidates: %T: %v", err, err)
+	}
+	if len(ambig.Matches) != 2 {
+		t.Errorf("got %d matches, want 2", len(ambig.Matches))
+	}
+}
+
+// The plain-text message is unchanged by the typed wrapper.
+func TestResolveTaskAmbiguousPlainTextUnchanged(t *testing.T) {
+	stubTTY(t, false)
+	database := seedAmbiguousDB(t)
+
+	_, err := resolveTask(&Deps{}, "Shared", database)
+	if err == nil {
+		t.Fatal("expected an ambiguity error")
+	}
+	msg := err.Error()
+	if !strings.HasPrefix(msg, `ambiguous task "Shared" — matches 2 tasks:`) {
+		t.Errorf("message changed: %q", msg)
+	}
+	if !strings.HasSuffix(msg, "Re-run with a UUID or more specific string.") {
+		t.Errorf("message changed: %q", msg)
+	}
+}
+
+func decodePayload(t *testing.T, err error) (jsonErrorPayload, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	renderError(&stdout, &stderr, true, err)
+	if stderr.Len() != 0 {
+		t.Errorf("--json wrote to stderr: %q", stderr.String())
+	}
+	var payload jsonErrorPayload
+	if jsonErr := json.Unmarshal(stdout.Bytes(), &payload); jsonErr != nil {
+		t.Fatalf("stdout is not JSON (%v): %q", jsonErr, stdout.String())
+	}
+	return payload, stdout.String()
+}
+
+func TestRenderErrorAmbiguous(t *testing.T) {
+	stubTTY(t, true)
+	database := seedAmbiguousDB(t)
+
+	_, err := resolveTask(&Deps{JSON: true}, "Shared", database)
+	if err == nil {
+		t.Fatal("expected an ambiguity error")
+	}
+	payload, raw := decodePayload(t, err)
+
+	if payload.Error != "ambiguous task" {
+		t.Errorf("error = %q, want %q (%s)", payload.Error, "ambiguous task", raw)
+	}
+	if payload.Query != "Shared" {
+		t.Errorf("query = %q", payload.Query)
+	}
+	if payload.Message == "" {
+		t.Error("message should carry the human text")
+	}
+	if len(payload.Matches) != 2 {
+		t.Fatalf("matches = %+v", payload.Matches)
+	}
+	byUUID := map[string]jsonErrorMatch{}
+	for _, m := range payload.Matches {
+		byUUID[m.UUID] = m
+	}
+	if got := byUUID["amb-1"]; got.Title != "Shared title" || got.Project != "Chores" {
+		t.Errorf("amb-1 = %+v", got)
+	}
+	if got, ok := byUUID["amb-2"]; !ok || got.Project != "" {
+		t.Errorf("amb-2 = %+v (ok=%v)", got, ok)
+	}
+}
+
+func TestRenderErrorTaskNotFound(t *testing.T) {
+	stubTTY(t, true)
+	database := db.NewFromSQL(dbtest.NewSQL(t))
+
+	_, err := resolveTask(&Deps{JSON: true}, "no-such-task", database)
+	if err == nil {
+		t.Fatal("expected a not-found error")
+	}
+	payload, raw := decodePayload(t, err)
+
+	if payload.Error != "not found" {
+		t.Errorf("error = %q, want %q (%s)", payload.Error, "not found", raw)
+	}
+	if payload.Kind != "task" || payload.Query != "no-such-task" {
+		t.Errorf("kind = %q, query = %q", payload.Kind, payload.Query)
+	}
+	if len(payload.Matches) != 0 {
+		t.Errorf("matches should be omitted: %s", raw)
+	}
+}
+
+func TestRenderErrorStaleIndex(t *testing.T) {
+	payload, _ := decodePayload(t, &notFoundError{
+		Kind:  "task",
+		Query: "3",
+		msg:   "task #3 no longer exists (stale list cache — re-run list)",
+	})
+	if payload.Error != "not found" || payload.Kind != "task" || payload.Query != "3" {
+		t.Errorf("payload = %+v", payload)
+	}
+	if !strings.Contains(payload.Message, "stale list cache") {
+		t.Errorf("message = %q", payload.Message)
+	}
+}
+
+// Anything without a classification still comes back as JSON, so a consumer
+// reading stdout never has to fall back to parsing stderr.
+func TestRenderErrorGeneric(t *testing.T) {
+	payload, raw := decodePayload(t, fmt.Errorf("querying tasks: disk gone"))
+	if payload.Error != "error" {
+		t.Errorf("error = %q, want %q (%s)", payload.Error, "error", raw)
+	}
+	if payload.Message != "querying tasks: disk gone" {
+		t.Errorf("message = %q", payload.Message)
+	}
+	if payload.Kind != "" || payload.Query != "" {
+		t.Errorf("unclassified payload should carry no kind/query: %+v", payload)
+	}
+}
+
+// Plain-text mode is untouched: the line still goes to stderr, and stdout stays
+// empty so a `things ... > file` redirect is unaffected.
+func TestRenderErrorPlainTextUnchanged(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	renderError(&stdout, &stderr, false, fmt.Errorf("boom"))
+
+	if stdout.Len() != 0 {
+		t.Errorf("plain text wrote to stdout: %q", stdout.String())
+	}
+	if stderr.String() != "Error: boom\n" {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+// Every command that resolves a task reference reports ambiguity as JSON under
+// --json, rather than printing the picker and waiting on stdin (issue #152).
+func TestCommandsEmitJSONErrors(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		wantError string
+		wantKind  string
+		wantQuery string
+	}{
+		{"show ambiguous", []string{"--json", "show", "Shared"}, "ambiguous task", "task", "Shared"},
+		{"edit ambiguous", []string{"--json", "edit", "Shared", "--title", "New"}, "ambiguous task", "task", "Shared"},
+		{"complete ambiguous", []string{"--json", "complete", "Shared"}, "ambiguous task", "task", "Shared"},
+		{"cancel ambiguous", []string{"--json", "cancel", "Shared"}, "ambiguous task", "task", "Shared"},
+		{"open ambiguous", []string{"--json", "open", "Shared"}, "ambiguous task", "task", "Shared"},
+		{"show missing", []string{"--json", "show", "no-such-ref"}, "not found", "task", "no-such-ref"},
+		{"complete missing", []string{"--json", "complete", "no-such-ref"}, "not found", "task", "no-such-ref"},
+		{"open missing area", []string{"--json", "open", "--area", "Nowhere"}, "not found", "area", "Nowhere"},
+		{"open missing tag", []string{"--json", "open", "--tag", "nope"}, "not found", "tag", "nope"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubTTY(t, true)
+			database := seedAmbiguousDB(t)
+
+			err := runWith(t, database, tc.args...)
+			if err == nil {
+				t.Fatalf("run %v: expected an error", tc.args)
+			}
+			payload, raw := decodePayload(t, err)
+			if payload.Error != tc.wantError {
+				t.Errorf("error = %q, want %q (%s)", payload.Error, tc.wantError, raw)
+			}
+			if payload.Kind != tc.wantKind {
+				t.Errorf("kind = %q, want %q", payload.Kind, tc.wantKind)
+			}
+			if payload.Query != tc.wantQuery {
+				t.Errorf("query = %q, want %q", payload.Query, tc.wantQuery)
+			}
+		})
+	}
+}
+
+// search doesn't resolve a reference, so its failures are unclassified — they
+// still have to reach a --json consumer as JSON rather than a bare stderr line.
+func TestSearchErrorEmitsJSON(t *testing.T) {
+	database := seedAmbiguousDB(t)
+	database.Close()
+
+	err := runWith(t, database, "--json", "search", "Shared")
+	if err == nil {
+		t.Fatal("expected a query error against a closed database")
+	}
+	payload, raw := decodePayload(t, err)
+	if payload.Error != "error" {
+		t.Errorf("error = %q, want %q (%s)", payload.Error, "error", raw)
+	}
+	if payload.Message == "" {
+		t.Errorf("message should carry the failure: %s", raw)
+	}
+}
+
+// A parse error is still a failure a --json consumer has to read off stdout,
+// so main has to know the flag was asked for before kong has parsed it.
+func TestJSONRequested(t *testing.T) {
+	cases := []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"show", "milk"}, false},
+		{[]string{"--json", "show"}, true},
+		{[]string{"show", "milk", "--json"}, true},
+		{[]string{"show", "-j"}, true},
+		{[]string{"--json=true", "show"}, true},
+		{[]string{"--json=false", "show"}, false},
+		{[]string{"--json", "--json=false", "show"}, false},
+		{[]string{"add", "--", "--json"}, false},
+	}
+	for _, tc := range cases {
+		if got := jsonRequested(tc.args); got != tc.want {
+			t.Errorf("jsonRequested(%v) = %v, want %v", tc.args, got, tc.want)
+		}
+	}
+}
+
+// Declining for lack of a terminal is not the same as a user answering "n" —
+// under --json the payload has to say why, or the caller just sees "cancelled".
+func TestConfirmProjectStatusChangeNonInteractiveExplains(t *testing.T) {
+	stubTTY(t, true)
+
+	err := confirmProjectStatusChange(&Deps{JSON: true}, "Complete", "Chores")
+	if err == nil {
+		t.Fatal("--json must decline")
+	}
+	if !strings.Contains(err.Error(), "cancelled") {
+		t.Errorf("message should still read as cancelled: %q", err)
+	}
+	if !strings.Contains(err.Error(), "cannot prompt") {
+		t.Errorf("message should explain why: %q", err)
+	}
+	if !strings.Contains(err.Error(), "without --json") {
+		t.Errorf("--json run should point at the flag: %q", err)
+	}
+
+	// Piped stdin without --json hits the same branch; the advice there is to
+	// use a terminal, not to drop a flag that was never passed.
+	stubTTY(t, false)
+	err = confirmProjectStatusChange(&Deps{}, "Cancel", "Chores")
+	if err == nil {
+		t.Fatal("a non-terminal run must decline")
+	}
+	if strings.Contains(err.Error(), "--json") {
+		t.Errorf("should not mention a flag the caller did not pass: %q", err)
+	}
+	if !strings.Contains(err.Error(), "in a terminal") {
+		t.Errorf("message should explain why: %q", err)
+	}
+}

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -80,6 +80,13 @@ func (d *Deps) errOut() io.Writer {
 	return d.Stderr
 }
 
+// interactive reports whether the process may prompt the user. --json means a
+// machine is reading stdout, so a prompt would hang it — the flag implies
+// non-interactive regardless of whether stdin is a terminal (issue #152).
+func (d *Deps) interactive() bool {
+	return !d.JSON && isInteractive()
+}
+
 // Database returns the lazily-opened DB. Subsequent calls return the same
 // handle. Callers must call (*Deps).Close to release it.
 func (d *Deps) Database() (*db.DB, error) {
@@ -283,7 +290,7 @@ func (c *ShowCmd) Run(d *Deps) error {
 	if err != nil {
 		return err
 	}
-	task, err := resolveTask(c.Task, database)
+	task, err := resolveTask(d, c.Task, database)
 	if err != nil {
 		return err
 	}
@@ -391,7 +398,7 @@ func (c *ProjectEditCmd) Run(d *Deps) error {
 	if err != nil {
 		return err
 	}
-	project, err := resolveTask(c.Project, database)
+	project, err := resolveTask(d, c.Project, database)
 	if err != nil {
 		return err
 	}
@@ -468,7 +475,7 @@ func (c *EditCmd) Run(d *Deps) error {
 	if err != nil {
 		return err
 	}
-	task, err := resolveTask(c.Task, database)
+	task, err := resolveTask(d, c.Task, database)
 	if err != nil {
 		return err
 	}
@@ -519,7 +526,7 @@ func (c *CompleteCmd) Run(d *Deps) error {
 	if err != nil {
 		return err
 	}
-	task, err := resolveTask(c.Task, database)
+	task, err := resolveTask(d, c.Task, database)
 	if err != nil {
 		return err
 	}
@@ -528,8 +535,8 @@ func (c *CompleteCmd) Run(d *Deps) error {
 	}
 	write := func() error { return things.CompleteTask(task.UUID) }
 	if task.Type == model.TypeProject {
-		if !confirmAction(fmt.Sprintf("Complete project %q? This will also complete all its tasks.", task.Title)) {
-			return fmt.Errorf("cancelled")
+		if err := confirmProjectStatusChange(d, "Complete", task.Title); err != nil {
+			return err
 		}
 		write = func() error { return things.CompleteProject(task.UUID) }
 	}
@@ -545,7 +552,7 @@ func (c *CancelCmd) Run(d *Deps) error {
 	if err != nil {
 		return err
 	}
-	task, err := resolveTask(c.Task, database)
+	task, err := resolveTask(d, c.Task, database)
 	if err != nil {
 		return err
 	}
@@ -554,8 +561,8 @@ func (c *CancelCmd) Run(d *Deps) error {
 	}
 	write := func() error { return things.CancelTask(task.UUID) }
 	if task.Type == model.TypeProject {
-		if !confirmAction(fmt.Sprintf("Cancel project %q? This will also cancel all its tasks.", task.Title)) {
-			return fmt.Errorf("cancelled")
+		if err := confirmProjectStatusChange(d, "Cancel", task.Title); err != nil {
+			return err
 		}
 		write = func() error { return things.CancelProject(task.UUID) }
 	}
@@ -608,10 +615,10 @@ func (c *SkillInstallCmd) Run(d *Deps) error {
 		return err
 	}
 	if skill.Exists(agent, dir) && !c.Yes {
-		if !isInteractive() {
+		if !d.interactive() {
 			return fmt.Errorf("skill already installed at %s — pass -y to overwrite", dir)
 		}
-		if !confirmAction(fmt.Sprintf("Skill already installed at %s. Overwrite?", dir)) {
+		if !confirmAction(d, fmt.Sprintf("Skill already installed at %s. Overwrite?", dir)) {
 			return fmt.Errorf("cancelled")
 		}
 	}
@@ -646,10 +653,10 @@ func (c *SkillUninstallCmd) Run(d *Deps) error {
 		fmt.Fprintf(os.Stderr, "  - %s\n", f)
 	}
 	if !c.Yes {
-		if !isInteractive() {
+		if !d.interactive() {
 			return fmt.Errorf("refusing to uninstall non-interactively — pass -y to confirm")
 		}
-		if !confirmAction(fmt.Sprintf("Remove %s skill at %s?", agent.Name(), dir)) {
+		if !confirmAction(d, fmt.Sprintf("Remove %s skill at %s?", agent.Name(), dir)) {
 			return fmt.Errorf("cancelled")
 		}
 	}
@@ -777,7 +784,7 @@ func (c *OpenCmd) Run(d *Deps) error {
 			return "", err
 		}
 		if uuid == "" {
-			return "", fmt.Errorf("%s not found: %s", kind, name)
+			return "", &notFoundError{Kind: kind, Query: name}
 		}
 		return uuid, nil
 	}
@@ -798,7 +805,7 @@ func (c *OpenCmd) Run(d *Deps) error {
 		}
 		params.ID = uuid
 	case c.Project != "":
-		task, err := resolveTask(c.Project, database)
+		task, err := resolveTask(d, c.Project, database)
 		if err != nil {
 			return err
 		}
@@ -806,7 +813,7 @@ func (c *OpenCmd) Run(d *Deps) error {
 	case things.IsBuiltinList(c.Ref):
 		params.ID = c.Ref
 	default:
-		task, err := resolveTask(c.Ref, database)
+		task, err := resolveTask(d, c.Ref, database)
 		if err != nil {
 			return err
 		}
@@ -836,10 +843,20 @@ func main() {
 	kongplete.Complete(parser)
 
 	ctx, err := parser.Parse(os.Args[1:])
-	parser.FatalIfErrorf(err)
+	if err != nil {
+		// kong's UsageOnError writes the usage block to stdout, which under
+		// --json would leave a consumer parsing help text instead of the JSON
+		// object it was promised. Render the failure as JSON instead — the
+		// flag has to come from argv because parsing is what just failed.
+		if jsonRequested(os.Args[1:]) {
+			renderError(os.Stdout, os.Stderr, true, err)
+			os.Exit(1)
+		}
+		parser.FatalIfErrorf(err)
+	}
 
 	if err := output.SetColorMode(cli.Color); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		renderError(os.Stdout, os.Stderr, cli.JSON, err)
 		os.Exit(2)
 	}
 
@@ -847,12 +864,34 @@ func main() {
 	defer deps.Close()
 
 	if err := ctx.Run(deps); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		renderError(os.Stdout, os.Stderr, cli.JSON, err)
 		os.Exit(1)
 	}
 }
 
-func isInteractive() bool {
+// jsonRequested reports whether argv asks for --json. main needs the answer
+// before kong has parsed anything, because a parse error still has to be
+// rendered in the mode the caller asked for.
+func jsonRequested(args []string) bool {
+	asJSON := false
+	for _, a := range args {
+		if a == "--" {
+			break
+		}
+		switch a {
+		case "-j", "--json", "--json=true":
+			asJSON = true
+		case "--json=false":
+			asJSON = false
+		}
+	}
+	return asJSON
+}
+
+// isInteractive reports whether stdin is a terminal. It is a var so tests can
+// stub the terminal check — see (*Deps).interactive, which is what callers
+// should use.
+var isInteractive = func() bool {
 	fd := os.Stdin.Fd()
 	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
 }
@@ -872,7 +911,7 @@ func expandNewlinesPtr(p *string) *string {
 	return &v
 }
 
-func resolveTask(ref string, database *db.DB) (*model.Task, error) {
+func resolveTask(d *Deps, ref string, database *db.DB) (*model.Task, error) {
 	// Try numeric index from last list
 	if n, err := strconv.Atoi(ref); err == nil && n >= 1 {
 		uuids, cacheErr := cache.ReadLastList()
@@ -884,7 +923,11 @@ func resolveTask(ref string, database *db.DB) (*model.Task, error) {
 			if t != nil {
 				return t, nil
 			}
-			return nil, fmt.Errorf("task #%d no longer exists (stale list cache — re-run list)", n)
+			return nil, &notFoundError{
+				Kind:  "task",
+				Query: ref,
+				msg:   fmt.Sprintf("task #%d no longer exists (stale list cache — re-run list)", n),
+			}
 		}
 	}
 
@@ -898,14 +941,16 @@ func resolveTask(ref string, database *db.DB) (*model.Task, error) {
 		return nil, err
 	}
 
-	if !isInteractive() {
+	if !d.interactive() {
 		var b strings.Builder
 		fmt.Fprintf(&b, "ambiguous task %q — matches %d tasks:\n", ambig.Query, len(ambig.Matches))
 		for i, m := range ambig.Matches {
 			fmt.Fprintf(&b, "  %d. %s  (%s)\n", i+1, m.Title, m.UUID)
 		}
 		fmt.Fprint(&b, "Re-run with a UUID or more specific string.")
-		return nil, fmt.Errorf("%s", b.String())
+		// Wrap rather than replace: the plain-text message stays exactly as
+		// it was, while --json still sees the candidates (issue #152).
+		return nil, &ambiguousRefError{msg: b.String(), inner: ambig}
 	}
 
 	// Interactive: prompt user to pick
@@ -930,8 +975,27 @@ func resolveTask(ref string, database *db.DB) (*model.Task, error) {
 	return &ambig.Matches[choice-1], nil
 }
 
-func confirmAction(msg string) bool {
-	if !isInteractive() {
+// confirmProjectStatusChange gates a project-wide complete/cancel behind a
+// confirmation. When the run cannot prompt — piped stdin, or --json, which
+// never prompts — say so instead of returning a bare "cancelled" the caller
+// has no way to interpret.
+func confirmProjectStatusChange(d *Deps, verb, title string) error {
+	action := strings.ToLower(verb)
+	if !d.interactive() {
+		reason := "re-run in a terminal"
+		if d.JSON {
+			reason = "re-run without --json"
+		}
+		return fmt.Errorf("cancelled: %s project %q needs confirmation, and this run cannot prompt — %s", action, title, reason)
+	}
+	if !confirmAction(d, fmt.Sprintf("%s project %q? This will also %s all its tasks.", verb, title, action)) {
+		return fmt.Errorf("cancelled")
+	}
+	return nil
+}
+
+func confirmAction(d *Deps, msg string) bool {
+	if !d.interactive() {
 		return false
 	}
 	fmt.Fprintf(os.Stderr, "%s [y/N]: ", msg)

--- a/cmd/things/main_test.go
+++ b/cmd/things/main_test.go
@@ -200,7 +200,7 @@ func TestResolveTaskNumericFromCache(t *testing.T) {
 	}
 	database := seedResolveTaskDB(t)
 
-	got, err := resolveTask("1", database)
+	got, err := resolveTask(&Deps{}, "1", database)
 	if err != nil {
 		t.Fatalf("resolveTask: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestResolveTaskStaleCacheIndex(t *testing.T) {
 	}
 	database := seedResolveTaskDB(t)
 
-	_, err := resolveTask("1", database)
+	_, err := resolveTask(&Deps{}, "1", database)
 	if err == nil {
 		t.Fatal("expected stale cache error")
 	}

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -310,7 +310,7 @@ func TestResolveTaskAmbiguousNonInteractive(t *testing.T) {
 	database := db.NewFromSQL(sqlDB)
 
 	// Ensure stdin is not a TTY in the test process — it shouldn't be.
-	_, err := resolveTask("Shared", database)
+	_, err := resolveTask(&Deps{}, "Shared", database)
 	if err == nil {
 		t.Fatal("expected ambiguity error")
 	}
@@ -322,7 +322,7 @@ func TestResolveTaskAmbiguousNonInteractive(t *testing.T) {
 func TestResolveTaskNotFound(t *testing.T) {
 	sqlDB := dbtest.NewSQL(t)
 	database := db.NewFromSQL(sqlDB)
-	_, err := resolveTask("nope", database)
+	_, err := resolveTask(&Deps{}, "nope", database)
 	if err == nil {
 		t.Fatal("expected not-found error")
 	}
@@ -340,7 +340,7 @@ func TestResolveTaskNumericWithoutCache(t *testing.T) {
 
 	// "1" has no cache — falls through to treating "1" as a title, which
 	// should return not-found.
-	_, err := resolveTask("1", database)
+	_, err := resolveTask(&Deps{}, "1", database)
 	if err == nil {
 		t.Fatal("expected not-found when no cache and no title match")
 	}
@@ -379,7 +379,7 @@ func TestRunOpenTagNotFound(t *testing.T) {
 }
 
 func TestConfirmActionNonInteractive(t *testing.T) {
-	if confirmAction("Really?") {
+	if confirmAction(&Deps{}, "Really?") {
 		t.Error("expected false in non-interactive test run")
 	}
 }

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -273,7 +273,7 @@ func (d *DB) GetTask(uuidOrTitle string) (*model.Task, error) {
 	}
 	switch len(matches) {
 	case 0:
-		return nil, fmt.Errorf("task not found: %s", uuidOrTitle)
+		return nil, &TaskNotFoundError{Query: uuidOrTitle}
 	case 1:
 		return &matches[0], nil
 	default:
@@ -284,6 +284,16 @@ func (d *DB) GetTask(uuidOrTitle string) (*model.Task, error) {
 func (d *DB) FindTasksByTitle(substr string) ([]model.Task, error) {
 	query := d.taskQuery() + " WHERE t.title LIKE ? AND t.trashed = 0 AND t.status = 0 GROUP BY t.uuid ORDER BY t.\"index\" ASC"
 	return d.collectTasks(query, "%"+substr+"%")
+}
+
+// TaskNotFoundError reports a reference that matched no task. It is typed so
+// callers can render it as structured output instead of matching on the text.
+type TaskNotFoundError struct {
+	Query string
+}
+
+func (e *TaskNotFoundError) Error() string {
+	return fmt.Sprintf("task not found: %s", e.Query)
 }
 
 type AmbiguousTaskError struct {

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -454,6 +454,17 @@ func TestGetTaskNotFound(t *testing.T) {
 	if errors.As(err, &ambig) {
 		t.Errorf("should not be ambiguous: %v", err)
 	}
+	// Typed so callers can render it as structured output (issue #152).
+	var notFound *TaskNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("wrong error type: %T: %v", err, err)
+	}
+	if notFound.Query != "zzz-does-not-exist-xyz" {
+		t.Errorf("Query = %q", notFound.Query)
+	}
+	if notFound.Error() != "task not found: zzz-does-not-exist-xyz" {
+		t.Errorf("Error() = %q", notFound.Error())
+	}
 }
 
 func TestSearchTasksTitleAndNotes(t *testing.T) {

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -19,6 +19,19 @@ Tasks and projects carry `"repeating": true` in JSON when Things treats them as 
 
 In JSON, `status` is a string enum — `"open"`, `"cancelled"`, or `"completed"` (not the raw Things integer) — on tasks, projects, and checklist items. Filter with e.g. `jq 'select(.status=="open")'`.
 
+`--json` also means "never prompt": a reference that matches several tasks returns an error listing the candidates instead of dropping into the interactive picker, and a project `complete`/`cancel` declines rather than asking for confirmation.
+
+Under `--json`, a failure prints a single JSON object to **stdout** and exits non-zero, so parse stdout whether the command succeeded or not. The `error` field is a stable token; `message` is the human text.
+
+```json
+{"error": "ambiguous task", "message": "...", "kind": "task", "query": "milk",
+ "matches": [{"uuid": "...", "title": "Buy milk", "project": "Chores"}]}
+{"error": "not found", "message": "task not found: milk", "kind": "task", "query": "milk"}
+{"error": "error", "message": "..."}
+```
+
+This covers argument and flag errors too — `things --json show` with no argument returns the JSON object rather than a usage block. On `ambiguous task`, retry with one of the `matches[].uuid`. Without `--json`, errors stay as a plain `Error: ...` line on stderr.
+
 Human output is styled with colors and aligned columns. Color auto-disables when piping or when `NO_COLOR` is set. Override with `--color=always|never` (default `auto`). JSON output is unaffected.
 
 ## Core commands
@@ -158,6 +171,6 @@ things --json list today | jq '.[] | .title'
 
 ## Tips
 
-- Prefer `--json` in scripted contexts.
+- Prefer `--json` in scripted contexts — it also guarantees the command never blocks on a prompt.
 - After a `list`/`search`, numeric indices stay valid until the next one.
 - Use `things open` when the user wants to *see* something in the app rather than read data back.


### PR DESCRIPTION
## What changed

`--json` now implies non-interactive, and failures under `--json` are machine-readable.

**Never prompt.** New `(*Deps).interactive()` returns `!d.JSON && isInteractive()`. `resolveTask` and `confirmAction` use it, so neither the ambiguity picker nor the project `complete`/`cancel` confirmation can block a machine reader. `resolveTask` and `confirmAction` take `*Deps` now; that is the only signature churn.

**Structured errors.** Under `--json` a failing command prints one JSON object to stdout and exits non-zero:

```json
{"error": "ambiguous task", "message": "...", "kind": "task", "query": "milk",
 "matches": [{"uuid": "...", "title": "Buy milk", "project": "Chores"}]}
{"error": "not found", "message": "task not found: milk", "kind": "task", "query": "milk"}
{"error": "error", "message": "..."}
```

`error` is a stable token; `message` is the same text plain-text mode prints. Classification lives in one function, `errorPayload`, over typed error values: a new `db.TaskNotFoundError`, a cmd-level `notFoundError` for area/tag/stale-index lookups, and the existing `db.AmbiguousTaskError`. `ambiguousRefError` wraps the latter so the multi-line "pick one" text is preserved verbatim while `errors.As` still reaches the candidates.

Parse and flag errors take the same route. kong's `UsageOnError` writes its usage block to stdout, which would have handed a `--json` consumer help text instead of the object the docs promise, so `main` renders those as JSON itself when `--json` is in argv (`jsonRequested`, which scans argv because parsing is what just failed). `--help` and `--version` are untouched.

Plain-text output is byte-for-byte unchanged: same messages, same stderr, same exit codes, same prompts on a terminal.

## Why

`things show <ref> --json` with a ref matching more than one task printed the picker and waited on stdin, because `resolveTask` gated the prompt on `isInteractive()` alone and never consulted `--json`. Run from a terminal — which is exactly where an agent shells out — it hung. And every failure was plain-text-only on stderr with nothing on stdout, so a JSON consumer had no structured failure to branch on and no way to retry with a UUID.

`ImportCmd`'s remaining `isInteractive()` call is deliberately left alone: it asks "does stdin have piped data", which `--json` must not change.

## How tested

`make test` and `make lint` clean. New `cmd/things/errors_test.go`:

- `TestDepsInteractiveJSONImpliesNonInteractive`, `TestConfirmActionJSONDeclines` — `isInteractive` is now a stubbable var, so these assert the guard against a simulated TTY rather than against the test runner's pipe. The confirm test captures stderr to prove nothing was printed.
- `TestResolveTaskJSONDoesNotPrompt` — TTY plus `--json` returns the ambiguity as an error carrying the candidates.
- `TestResolveTaskAmbiguousPlainTextUnchanged` — the wrapper did not alter the plain message.
- `TestCommandsEmitJSONErrors` — table over `show`, `edit`, `complete`, `cancel`, `open`, covering ambiguous refs, missing refs, and missing `--area`/`--tag`, asserting the decoded payload.
- `TestSearchErrorEmitsJSON` — `search` has no reference to resolve, so this drives an unclassified DB failure and checks it still arrives as JSON.
- `TestRenderError*` — payload shape per error type, plus `TestRenderErrorPlainTextUnchanged` asserting plain mode writes `Error: ...` to stderr and nothing to stdout.
- `TestJSONRequested`, `TestConfirmProjectStatusChangeNonInteractiveExplains`.

I checked the tests are not vacuous by reverting `interactive()` to `isInteractive()` — the picker prompt reappeared in the test output and every `--json` test failed. I also ran the built binary: `things --json show` returns `{"error":"error","message":"expected \"<task>\""}` on stdout with exit 1 and empty stderr, while `things show` keeps kong's usage block and exit 80.

Docs: `README.md` gains an "Errors under `--json`" section, and `internal/skill/SKILL.md` documents the contract for agents.

## Known gap

`things complete <project> --json` still cannot succeed. The confirmation is unskippable, so under `--json` it now declines with `cancelled: complete project "X" needs confirmation, and this run cannot prompt — re-run without --json` instead of a bare `cancelled`. Giving `complete`/`cancel` a `-y`/`--yes` flag would close it, but that changes the subcommand surface and is a separate decision.

Closes #152