### PR TITLE
feat(config): add a TOML config file for persistent flag defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,16 @@ snake_case form.
 | `db` | `--db` | string path (must exist) | auto-detected |
 | `no_verify` | `--no-verify` | boolean | `false` |
 | `strict_tags` | `--strict-tags` | boolean | `false` |
+| `create_tags` | `--create-tags` | boolean | `false` |
 
 ```toml
 color = "always"
 strict_tags = true
 ```
+
+`strict_tags` and `create_tags` are mutually exclusive; setting both to
+`true` is an error. Either one is still overridden by the other's flag on
+the command line.
 
 An unknown key, a value of the wrong type, or malformed TOML is an error
 that names the file and the key. Anything set here still loses to a flag,

--- a/README.md
+++ b/README.md
@@ -89,9 +89,53 @@ the same route, so `--json` never leaves a usage block on stdout. Without
 | Flag | Description | Default |
 | --- | --- | --- |
 | `-j, --json` | Output as JSON instead of plain text | `false` |
+| `--color MODE` | Colour output: `auto`, `always`, or `never` | `auto` |
 | `--db PATH` | Override the Things3 SQLite database path | auto-detected |
+| `--config PATH` | Read defaults from this config file instead of the default location | see [Configuration](#configuration) |
 | `--no-verify` | Skip the read-back that confirms a `complete`/`cancel` actually landed | `false` |
 | `-v, --version` | Print version, commit, and build date and exit (same as `things version`) | — |
+
+### Configuration
+
+A TOML file supplies defaults for the flags below, so you can set them once
+instead of typing them every time. Precedence is flag > config file >
+built-in default.
+
+The file is read from `$XDG_CONFIG_HOME/things-cli/config.toml`, falling
+back to `~/.config/things-cli/config.toml`. Override the location with
+`--config PATH` or the `THINGS_CLI_CONFIG` environment variable. A missing
+file is not an error — `things` runs on its built-in defaults.
+
+```sh
+things config init     # write a commented template (refuses to overwrite; --force to replace)
+things config path     # print the file in use and whether it exists
+things config show     # print the defaults the file establishes
+```
+
+Keys are the flag name in snake_case. The hyphenated spelling
+(`no-verify`) is accepted too, but `things config init` writes the
+snake_case form.
+
+| Key | Flag it sets | Type | Default |
+| --- | --- | --- | --- |
+| `json` | `--json` | boolean | `false` |
+| `color` | `--color` | `"auto"`, `"always"`, `"never"` | `"auto"` |
+| `db` | `--db` | string path (must exist) | auto-detected |
+| `no_verify` | `--no-verify` | boolean | `false` |
+| `strict_tags` | `--strict-tags` | boolean | `false` |
+
+```toml
+color = "always"
+strict_tags = true
+```
+
+An unknown key, a value of the wrong type, or malformed TOML is an error
+that names the file and the key. Anything set here still loses to a flag,
+so `things --color never today` wins over `color = "always"`.
+
+Note for scripts and agents: `json = true` changes the output of every
+command. Pass `--json` (or `--json=false`) explicitly rather than relying
+on whatever the config file happens to say.
 
 ### Listing tasks
 

--- a/cmd/things/config.go
+++ b/cmd/things/config.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/ryanlewis/things-cli/internal/config"
+	"github.com/ryanlewis/things-cli/internal/output"
+	"github.com/ryanlewis/things-cli/internal/skill"
+	"github.com/ryanlewis/things-cli/internal/things"
+)
+
+// parserOptions is the one place the kong parser is configured. main and the
+// test harness both build from it, so an option cannot be added to one and
+// forgotten in the other. A nil cfg leaves kong's built-in defaults alone.
+func parserOptions(cfg *config.File) []kong.Option {
+	opts := []kong.Option{
+		kong.Name("things"),
+		kong.Description("CLI for Things3"),
+		kong.UsageOnError(),
+		kong.Vars{
+			"version":       fmt.Sprintf("things %s (commit %s, built %s)", version, commit, date),
+			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
+			"skill_agents":  skill.AgentNames(),
+		},
+	}
+	if cfg != nil {
+		opts = append(opts, kong.Resolvers(cfg.Resolver()))
+	}
+	return opts
+}
+
+// loadConfig resolves which config file applies to this invocation and reads
+// it. The file has to be found before kong parses, because it supplies the
+// defaults kong parses against, so --config is read straight off the argv.
+func loadConfig(args []string) (*config.File, error) {
+	path, source, err := config.ResolvePath(configPathFromArgs(args))
+	if err != nil {
+		return nil, err
+	}
+	f, err := config.Load(path)
+	if err != nil {
+		return nil, err
+	}
+	f.Source = source
+	return f, nil
+}
+
+// configPathFromArgs returns the value of a --config flag in args, or "".
+// It reads the flag the same way kong would: both spellings, and nothing after
+// the -- terminator.
+func configPathFromArgs(args []string) string {
+	for i, a := range args {
+		switch {
+		case a == "--":
+			return ""
+		case a == "--config":
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+			return ""
+		case strings.HasPrefix(a, "--config="):
+			return strings.TrimPrefix(a, "--config=")
+		}
+	}
+	return ""
+}
+
+type ConfigCmd struct {
+	Path ConfigPathCmd `cmd:"" help:"Print the config file in use and whether it exists."`
+	Show ConfigShowCmd `cmd:"" help:"Print the defaults the config file establishes."`
+	Init ConfigInitCmd `cmd:"" help:"Write a commented config file template."`
+}
+
+type ConfigPathCmd struct{}
+
+func (c *ConfigPathCmd) Run(d *Deps) error {
+	cfg := d.config()
+	if d.JSON {
+		return output.Print(d.Stdout, struct {
+			Path   string `json:"path"`
+			Exists bool   `json:"exists"`
+			Source string `json:"source"`
+		}{cfg.Path, cfg.Exists, cfg.Source}, true)
+	}
+	state := "not found"
+	if cfg.Exists {
+		state = "exists"
+	}
+	fmt.Fprintf(d.Stdout, "%s (%s)\n", cfg.Path, state)
+	return nil
+}
+
+type ConfigShowCmd struct{}
+
+func (c *ConfigShowCmd) Run(d *Deps) error {
+	cfg := d.config()
+	settings := cfg.Settings()
+
+	if d.JSON {
+		return output.Print(d.Stdout, struct {
+			Path     string           `json:"path"`
+			Exists   bool             `json:"exists"`
+			Source   string           `json:"source"`
+			Settings []config.Setting `json:"settings"`
+		}{cfg.Path, cfg.Exists, cfg.Source, settings}, true)
+	}
+
+	state := "not found"
+	if cfg.Exists {
+		state = "exists"
+	}
+	fmt.Fprintf(d.Stdout, "config: %s (%s)\n", cfg.Path, state)
+	fmt.Fprintf(d.Stdout, "These apply when no flag overrides them.\n\n")
+
+	keyW := 0
+	for _, s := range settings {
+		if len(s.Key) > keyW {
+			keyW = len(s.Key)
+		}
+	}
+	valW := 0
+	rendered := make([]string, len(settings))
+	for i, s := range settings {
+		rendered[i] = showValue(s.Value)
+		if len(rendered[i]) > valW {
+			valW = len(rendered[i])
+		}
+	}
+	for i, s := range settings {
+		fmt.Fprintf(d.Stdout, "  %-*s  %-*s  %s\n", keyW, s.Key, valW, rendered[i], s.Source)
+	}
+	return nil
+}
+
+// showValue renders a setting for the plain listing. An empty string is a key
+// with nothing set, which reads better as a placeholder than as blank space.
+func showValue(v any) string {
+	if s, ok := v.(string); ok {
+		if s == "" {
+			return "(unset)"
+		}
+		return s
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+type ConfigInitCmd struct {
+	Force bool `help:"Overwrite an existing config file." short:"f"`
+}
+
+func (c *ConfigInitCmd) Run(d *Deps) error {
+	cfg := d.config()
+	if cfg.Exists && !c.Force {
+		return fmt.Errorf("config file already exists: %s — pass --force to overwrite", cfg.Path)
+	}
+	if dir := filepath.Dir(cfg.Path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(cfg.Path, []byte(config.Template()), 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(d.Stdout, "Wrote config template to %s\n", cfg.Path)
+	return nil
+}

--- a/cmd/things/config_test.go
+++ b/cmd/things/config_test.go
@@ -1,0 +1,341 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/ryanlewis/things-cli/internal/config"
+)
+
+// writeConfig puts a config file in a temp directory and returns its path.
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// TestConfigKeysMatchFlags is the guard against the config registry drifting
+// away from the CLI: every key must name a flag that exists, and carry the
+// same built-in default kong does.
+func TestConfigKeysMatchFlags(t *testing.T) {
+	var cli CLI
+	parser, err := kong.New(&cli, parserOptions(nil)...)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+
+	defaults := map[string]string{}
+	err = kong.Visit(parser.Model, func(node kong.Visitable, next kong.Next) error {
+		if flag, ok := node.(*kong.Flag); ok {
+			if _, seen := defaults[flag.Name]; !seen {
+				defaults[flag.Name] = flag.Default
+			}
+		}
+		return next(nil)
+	})
+	if err != nil {
+		t.Fatalf("visit model: %v", err)
+	}
+
+	for _, k := range config.Keys {
+		got, ok := defaults[k.Flag]
+		if !ok {
+			t.Errorf("config key %q names --%s, which is not a flag on the CLI", k.Name, k.Flag)
+			continue
+		}
+		if got == "" {
+			// No default tag means the field's zero value applies.
+			got = fmt.Sprintf("%v", reflect.Zero(reflect.TypeOf(k.Default)).Interface())
+		}
+		if want := fmt.Sprintf("%v", k.Default); got != want {
+			t.Errorf("config key %q default = %q, but --%s defaults to %q", k.Name, want, k.Flag, got)
+		}
+	}
+}
+
+func TestConfigPathFromArgs(t *testing.T) {
+	cases := []struct {
+		args []string
+		want string
+	}{
+		{nil, ""},
+		{[]string{"today"}, ""},
+		{[]string{"--config", "a.toml"}, "a.toml"},
+		{[]string{"--config=a.toml"}, "a.toml"},
+		{[]string{"add", "buy milk", "--config", "a.toml"}, "a.toml"},
+		{[]string{"--config"}, ""},
+		{[]string{"--", "--config", "a.toml"}, ""},
+	}
+	for _, tc := range cases {
+		if got := configPathFromArgs(tc.args); got != tc.want {
+			t.Errorf("configPathFromArgs(%v) = %q, want %q", tc.args, got, tc.want)
+		}
+	}
+}
+
+func TestConfigSeedsGlobalFlagDefaults(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "json = true\nno_verify = true\ncolor = \"never\"\n")
+
+	var cli CLI
+	cfg, err := loadConfig([]string{"--config", path, "today"})
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	parser, err := kong.New(&cli, parserOptions(cfg)...)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse([]string{"--config", path, "today"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cli.JSON {
+		t.Error("json = true in the config file did not reach --json")
+	}
+	if !cli.NoVerify {
+		t.Error("no_verify = true in the config file did not reach --no-verify")
+	}
+	if cli.Color != "never" {
+		t.Errorf("color = %q, want never", cli.Color)
+	}
+}
+
+func TestFlagBeatsConfig(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "json = true\ncolor = \"never\"\n")
+
+	var cli CLI
+	cfg, err := loadConfig([]string{"--config", path})
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	parser, err := kong.New(&cli, parserOptions(cfg)...)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	args := []string{"--config", path, "--json=false", "--color", "always", "today"}
+	if _, err := parser.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cli.JSON {
+		t.Error("--json=false did not override json = true from the config file")
+	}
+	if cli.Color != "always" {
+		t.Errorf("color = %q, want always (the flag should beat the config file)", cli.Color)
+	}
+}
+
+func TestConfigSeedsPerCommandFlag(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "strict_tags = true\n")
+
+	var cli CLI
+	cfg, err := loadConfig([]string{"--config", path})
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	parser, err := kong.New(&cli, parserOptions(cfg)...)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse([]string{"--config", path, "add", "buy milk"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cli.Add.StrictTags.StrictTags {
+		t.Error("strict_tags = true in the config file did not reach add --strict-tags")
+	}
+}
+
+func TestConfigUsesEnvVar(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "json = true\n")
+	t.Setenv(config.EnvVar, path)
+
+	cfg, err := loadConfig(nil)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Path != path || cfg.Source != config.SourceEnv {
+		t.Errorf("loadConfig = (%q, %q), want (%q, %q)", cfg.Path, cfg.Source, path, config.SourceEnv)
+	}
+}
+
+func TestConfigLoadReportsBadFile(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "nope = 1\n")
+	_, err := loadConfig([]string{"--config", path})
+	if err == nil {
+		t.Fatal("loadConfig: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), path) || !strings.Contains(err.Error(), "unknown key") {
+		t.Errorf("error = %q, want it to name the file and the unknown key", err)
+	}
+}
+
+func TestConfigPathCmd(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "json = false\n")
+
+	out, err := runOut(t, nil, "--config", path, "config", "path")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	if !strings.Contains(out, path) || !strings.Contains(out, "exists") {
+		t.Errorf("config path = %q, want the path and its existence", out)
+	}
+
+	absent := filepath.Join(t.TempDir(), "absent.toml")
+	out, err = runOut(t, nil, "--config", absent, "config", "path")
+	if err != nil {
+		t.Fatalf("config path (absent): %v", err)
+	}
+	if !strings.Contains(out, absent) || !strings.Contains(out, "not found") {
+		t.Errorf("config path = %q, want the path and \"not found\"", out)
+	}
+}
+
+func TestConfigPathCmdJSON(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "")
+
+	out, err := runOut(t, nil, "--config", path, "--json", "config", "path")
+	if err != nil {
+		t.Fatalf("config path --json: %v", err)
+	}
+	var got struct {
+		Path   string `json:"path"`
+		Exists bool   `json:"exists"`
+		Source string `json:"source"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if got.Path != path || !got.Exists || got.Source != config.SourceFlag {
+		t.Errorf("config path --json = %+v, want path %q, exists, source flag", got, path)
+	}
+}
+
+func TestConfigShowCmd(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "color = \"never\"\n")
+
+	out, err := runOut(t, nil, "--config", path, "config", "show")
+	if err != nil {
+		t.Fatalf("config show: %v", err)
+	}
+	for _, want := range []string{path, "color", "never", "config", "json", "false", "default", "(unset)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("config show = %q, missing %q", out, want)
+		}
+	}
+}
+
+func TestConfigShowCmdJSON(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "strict_tags = true\n")
+
+	out, err := runOut(t, nil, "--config", path, "--json", "config", "show")
+	if err != nil {
+		t.Fatalf("config show --json: %v", err)
+	}
+	var got struct {
+		Path     string           `json:"path"`
+		Exists   bool             `json:"exists"`
+		Settings []config.Setting `json:"settings"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if got.Path != path || !got.Exists {
+		t.Errorf("path = %q exists = %v, want %q true", got.Path, got.Exists, path)
+	}
+	if len(got.Settings) != len(config.Keys) {
+		t.Fatalf("got %d settings, want %d", len(got.Settings), len(config.Keys))
+	}
+	for _, s := range got.Settings {
+		if s.Key != "strict_tags" {
+			continue
+		}
+		if s.Value != true || s.Source != "config" {
+			t.Errorf("strict_tags = %v (%s), want true (config)", s.Value, s.Source)
+		}
+	}
+}
+
+func TestConfigInitCmd(t *testing.T) {
+	isolateHome(t)
+	path := filepath.Join(t.TempDir(), "nested", "config.toml")
+
+	out, err := runOut(t, nil, "--config", path, "config", "init")
+	if err != nil {
+		t.Fatalf("config init: %v", err)
+	}
+	if !strings.Contains(out, path) {
+		t.Errorf("config init = %q, want it to name the file written", out)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written config: %v", err)
+	}
+	if string(body) != config.Template() {
+		t.Error("config init did not write the template")
+	}
+}
+
+func TestConfigInitRefusesToOverwrite(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "json = true\n")
+
+	_, err := runOut(t, nil, "--config", path, "config", "init")
+	if err == nil {
+		t.Fatal("config init over an existing file: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error = %q, want it to name the file", err)
+	}
+	body, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read config: %v", readErr)
+	}
+	if string(body) != "json = true\n" {
+		t.Errorf("config init overwrote the file: %q", body)
+	}
+}
+
+func TestConfigInitForceOverwrites(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "json = true\n")
+
+	if _, err := runOut(t, nil, "--config", path, "config", "init", "--force"); err != nil {
+		t.Fatalf("config init --force: %v", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(body) != config.Template() {
+		t.Error("config init --force did not rewrite the template")
+	}
+}
+
+func TestConfigInitDefaultPathStaysUnderHome(t *testing.T) {
+	home := isolateHome(t)
+
+	if _, err := runOut(t, nil, "config", "init"); err != nil {
+		t.Fatalf("config init: %v", err)
+	}
+	want := filepath.Join(home, ".config", "things-cli", "config.toml")
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("config init did not write %s: %v", want, err)
+	}
+}

--- a/cmd/things/config_test.go
+++ b/cmd/things/config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -151,8 +152,72 @@ func TestConfigSeedsPerCommandFlag(t *testing.T) {
 	if _, err := parser.Parse([]string{"--config", path, "add", "buy milk"}); err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if !cli.Add.StrictTags.StrictTags {
+	if !cli.Add.StrictTags {
 		t.Error("strict_tags = true in the config file did not reach add --strict-tags")
+	}
+}
+
+// A db path in the config that no longer exists must not stop a --db flag
+// from overriding it — the file always loses to the command line.
+func TestFlagBeatsStaleConfigDB(t *testing.T) {
+	isolateHome(t)
+	real := filepath.Join(t.TempDir(), "main.sqlite")
+	if err := os.WriteFile(real, nil, 0o600); err != nil {
+		t.Fatalf("write db: %v", err)
+	}
+	path := writeConfig(t, `db = "/nonexistent/things.sqlite"`+"\n")
+
+	var cli CLI
+	cfg, err := loadConfig([]string{"--config", path})
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	parser, err := kong.New(&cli, parserOptions(cfg)...)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse([]string{"--config", path, "--db", real, "today"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cli.DB != real {
+		t.Errorf("db = %q, want %q (the flag should beat the config file)", cli.DB, real)
+	}
+
+	// Without the flag, the stale entry is reported and names the file.
+	var bare CLI
+	parser, err = kong.New(&bare, parserOptions(cfg)...)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	_, err = parser.Parse([]string{"--config", path, "today"})
+	if err == nil {
+		t.Fatal("parse with a stale config db: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("error %q does not name the config file", err)
+	}
+}
+
+// An empty db in the config means "unset"; handing "" to kong's existingfile
+// check would stat the working directory instead.
+func TestEmptyConfigDBIsUnset(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "db = \"\"\n")
+
+	var cli CLI
+	cfg, err := loadConfig([]string{"--config", path})
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	parser, err := kong.New(&cli, parserOptions(cfg)...)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse([]string{"--config", path, "today"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cli.DB != "" {
+		t.Errorf("db = %q, want empty", cli.DB)
 	}
 }
 
@@ -337,5 +402,93 @@ func TestConfigInitDefaultPathStaysUnderHome(t *testing.T) {
 	want := filepath.Join(home, ".config", "things-cli", "config.toml")
 	if _, err := os.Stat(want); err != nil {
 		t.Errorf("config init did not write %s: %v", want, err)
+	}
+}
+
+// TestConfigParseErrorIsRecognisable guards the branch in main that prints a
+// bad config value on its own instead of under a usage dump: the error kong
+// returns has to stay unwrappable to *config.Error.
+func TestConfigParseErrorIsRecognisable(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, `db = "/nonexistent/things.sqlite"`+"\n")
+
+	var cli CLI
+	cfg, err := loadConfig([]string{"--config", path})
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	parser, err := kong.New(&cli, parserOptions(cfg)...)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	_, err = parser.Parse([]string{"--config", path, "today"})
+	if err == nil {
+		t.Fatal("parse with a stale config db path: want error, got nil")
+	}
+	var cfgErr *config.Error
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error %q (%T) does not unwrap to *config.Error", err, err)
+	}
+	if cfgErr.Path != path {
+		t.Errorf("cfgErr.Path = %q, want %q", cfgErr.Path, path)
+	}
+}
+
+// TestConfigTagPolicyExclusivity covers the interaction between the config
+// file and the --strict-tags / --create-tags exclusive pair. Kong counts a
+// resolved value as set, so a file that turns one on must not make the other
+// unusable on the command line.
+func TestConfigTagPolicyExclusivity(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		args       []string
+		wantStrict bool
+		wantCreate bool
+	}{
+		{"config strict", "strict_tags = true\n", nil, true, false},
+		{"config create", "create_tags = true\n", nil, false, true},
+		{"flag strict beats config create", "create_tags = true\n", []string{"--strict-tags"}, true, false},
+		{"flag create beats config strict", "strict_tags = true\n", []string{"--create-tags"}, false, true},
+		{"both false", "strict_tags = false\ncreate_tags = false\n", nil, false, false},
+		{"one true one false", "strict_tags = true\ncreate_tags = false\n", nil, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			path := writeConfig(t, tc.body)
+			args := append([]string{"--config", path, "add", "buy milk"}, tc.args...)
+
+			var cli CLI
+			cfg, err := loadConfig(args)
+			if err != nil {
+				t.Fatalf("loadConfig: %v", err)
+			}
+			parser, err := kong.New(&cli, parserOptions(cfg)...)
+			if err != nil {
+				t.Fatalf("kong.New: %v", err)
+			}
+			if _, err := parser.Parse(args); err != nil {
+				t.Fatalf("parse %v: %v", args, err)
+			}
+			if got := cli.Add.StrictTags; got != tc.wantStrict {
+				t.Errorf("strict-tags = %v, want %v", got, tc.wantStrict)
+			}
+			if got := cli.Add.CreateTags; got != tc.wantCreate {
+				t.Errorf("create-tags = %v, want %v", got, tc.wantCreate)
+			}
+		})
+	}
+}
+
+func TestConfigRejectsBothTagPolicies(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "strict_tags = true\ncreate_tags = true\n")
+	_, err := loadConfig([]string{"--config", path})
+	if err == nil {
+		t.Fatal("both tag policies true: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), path) || !strings.Contains(err.Error(), "cannot both be true") {
+		t.Errorf("error = %q, want it to name the file and the conflict", err)
 	}
 }

--- a/cmd/things/errors_test.go
+++ b/cmd/things/errors_test.go
@@ -331,7 +331,7 @@ func TestJSONRequested(t *testing.T) {
 		{[]string{"add", "--", "--json"}, false},
 	}
 	for _, tc := range cases {
-		if got := jsonRequested(tc.args); got != tc.want {
+		if got := jsonRequested(false, tc.args); got != tc.want {
 			t.Errorf("jsonRequested(%v) = %v, want %v", tc.args, got, tc.want)
 		}
 	}

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/willabides/kongplete"
 
 	"github.com/ryanlewis/things-cli/internal/cache"
+	"github.com/ryanlewis/things-cli/internal/config"
 	"github.com/ryanlewis/things-cli/internal/db"
 	"github.com/ryanlewis/things-cli/internal/model"
 	"github.com/ryanlewis/things-cli/internal/output"
@@ -33,6 +34,7 @@ type CLI struct {
 	JSON    bool             `help:"Output as JSON." short:"j" default:"false"`
 	Color   string           `help:"Color mode (auto|always|never)." enum:"auto,always,never" default:"auto"`
 	DB      string           `help:"Override database path." type:"existingfile"`
+	Config  string           `help:"Path to the TOML config file (default ~/.config/things-cli/config.toml)." placeholder:"PATH"`
 	Version kong.VersionFlag `help:"Print version and exit." short:"v"`
 
 	NoVerify bool `help:"Skip the read-back that confirms a complete/cancel, tag creation, or an import's status changes actually landed." name:"no-verify" default:"false"`
@@ -53,6 +55,7 @@ type CLI struct {
 	Open     OpenCmd     `cmd:"" help:"Reveal a task, project, area, tag, or built-in list in Things3."`
 	Import   ImportCmd   `cmd:"" help:"Batch create/update via the Things JSON URL scheme. Reads JSON from stdin or --file."`
 	Skill    SkillCmd    `cmd:"" help:"Manage the bundled agent skill (Claude Code, etc.)."`
+	Conf     ConfigCmd   `cmd:"" name:"config" help:"Inspect and create the config file that supplies flag defaults."`
 	Ver      VersionCmd  `cmd:"" name:"version" help:"Print version and exit."`
 
 	Completions CompletionsCmd `cmd:"" help:"Print a shell completion script (bash|zsh|fish)."`
@@ -70,6 +73,25 @@ type Deps struct {
 
 	// NoVerify skips the post-write read-back on complete/cancel.
 	NoVerify bool
+
+	// Config is the config file that seeded the flag defaults. `things config`
+	// reports on it; every other command has already had its defaults applied
+	// by the time it runs.
+	Config *config.File
+}
+
+// config returns the loaded config file, falling back to an unread file at the
+// default location so a Deps built without one (tests, direct construction)
+// still reports a sensible path.
+func (d *Deps) config() *config.File {
+	if d.Config == nil {
+		path, source, err := config.ResolvePath("")
+		if err != nil {
+			source = config.SourceDefault
+		}
+		d.Config = &config.File{Path: path, Source: source}
+	}
+	return d.Config
 }
 
 // errOut is where warnings go. Tests leave Stderr nil and capture os.Stderr,
@@ -835,16 +857,16 @@ func (c *OpenCmd) Run(d *Deps) error {
 
 func main() {
 	var cli CLI
-	parser := kong.Must(&cli,
-		kong.Name("things"),
-		kong.Description("CLI for Things3"),
-		kong.UsageOnError(),
-		kong.Vars{
-			"version":       fmt.Sprintf("things %s (commit %s, built %s)", version, commit, date),
-			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
-			"skill_agents":  skill.AgentNames(),
-		},
-	)
+
+	// The config file supplies the defaults kong parses against, so it has to
+	// be read before the parser is built.
+	cfg, err := loadConfig(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(2)
+	}
+
+	parser := kong.Must(&cli, parserOptions(cfg)...)
 
 	// Answer shell completion requests. When the shell invokes us with COMP_LINE
 	// set — via the script emitted by `things completions <shell>` — this
@@ -870,7 +892,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	deps := &Deps{DBPath: cli.DB, JSON: cli.JSON, Stdout: os.Stdout, Stderr: os.Stderr, NoVerify: cli.NoVerify}
+	deps := &Deps{DBPath: cli.DB, JSON: cli.JSON, Stdout: os.Stdout, Stderr: os.Stderr, NoVerify: cli.NoVerify, Config: cfg}
 	defer deps.Close()
 
 	if err := ctx.Run(deps); err != nil {

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -862,7 +862,9 @@ func main() {
 	// be read before the parser is built.
 	cfg, err := loadConfig(os.Args[1:])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		// Nothing is parsed yet, so --json has to come off argv. The config
+		// file cannot supply the answer here: reading it is what just failed.
+		renderError(os.Stdout, os.Stderr, jsonRequested(false, os.Args[1:]), err)
 		os.Exit(2)
 	}
 
@@ -876,11 +878,20 @@ func main() {
 
 	ctx, err := parser.Parse(os.Args[1:])
 	if err != nil {
+		asJSON := jsonRequested(cfg.JSON(), os.Args[1:])
+		// A bad value in the config file is not a usage mistake, so it is
+		// reported on its own rather than under a usage dump for a command
+		// that was typed correctly.
+		var cfgErr *config.Error
+		if errors.As(err, &cfgErr) {
+			renderError(os.Stdout, os.Stderr, asJSON, cfgErr)
+			os.Exit(2)
+		}
 		// kong's UsageOnError writes the usage block to stdout, which under
 		// --json would leave a consumer parsing help text instead of the JSON
 		// object it was promised. Render the failure as JSON instead — the
 		// flag has to come from argv because parsing is what just failed.
-		if jsonRequested(os.Args[1:]) {
+		if asJSON {
 			renderError(os.Stdout, os.Stderr, true, err)
 			os.Exit(1)
 		}
@@ -901,11 +912,12 @@ func main() {
 	}
 }
 
-// jsonRequested reports whether argv asks for --json. main needs the answer
-// before kong has parsed anything, because a parse error still has to be
-// rendered in the mode the caller asked for.
-func jsonRequested(args []string) bool {
-	asJSON := false
+// jsonRequested reports whether argv asks for --json, starting from def — the
+// default the config file establishes. main needs the answer before kong has
+// parsed anything, because a parse error still has to be rendered in the mode
+// the caller asked for.
+func jsonRequested(def bool, args []string) bool {
+	asJSON := def
 	for _, a := range args {
 		if a == "--" {
 			break

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -12,11 +13,10 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/ryanlewis/things-cli/internal/cache"
+	"github.com/ryanlewis/things-cli/internal/config"
 	"github.com/ryanlewis/things-cli/internal/db"
 	"github.com/ryanlewis/things-cli/internal/db/dbtest"
 	"github.com/ryanlewis/things-cli/internal/model"
-	"github.com/ryanlewis/things-cli/internal/skill"
-	"github.com/ryanlewis/things-cli/internal/things"
 )
 
 // withSilentStdout replaces os.Stdout for the duration of fn with a pipe that
@@ -147,19 +147,39 @@ func runCapturingStderr(t *testing.T, database *db.DB, args ...string) (string, 
 	return stderr, err
 }
 
+// testHomeEnv marks a HOME that isolateHome has already redirected, so a test
+// that isolates first and then calls a run helper keeps the same directory
+// instead of being moved to a second temp dir mid-test.
+const testHomeEnv = "THINGS_CLI_TEST_HOME"
+
+// isolateHome points HOME and the config lookup at a temp directory, so a test
+// never reads or writes the developer's real cache or config file. Calling it
+// twice in one test is a no-op.
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	if home := os.Getenv(testHomeEnv); home != "" {
+		return home
+	}
+	home := t.TempDir()
+	t.Setenv(testHomeEnv, home)
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv(config.EnvVar, "")
+	return home
+}
+
 // runStreams parses args, runs the command against database, and returns both
 // of the handler's output streams.
 func runStreams(t *testing.T, database *db.DB, args ...string) (string, string, error) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
+	isolateHome(t)
 
 	var cli CLI
-	parser, err := kong.New(&cli, kong.Name("things"),
-		kong.Vars{
-			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
-			"skill_agents":  skill.AgentNames(),
-		},
-	)
+	cfg, err := loadConfig(args)
+	if err != nil {
+		t.Fatalf("load config %v: %v", args, err)
+	}
+	parser, err := kong.New(&cli, parserOptions(cfg)...)
 	if err != nil {
 		t.Fatalf("kong.New: %v", err)
 	}
@@ -168,7 +188,7 @@ func runStreams(t *testing.T, database *db.DB, args ...string) (string, string, 
 		t.Fatalf("parse %v: %v", args, err)
 	}
 	var stdout, stderr bytes.Buffer
-	deps := &Deps{DB: database, JSON: cli.JSON, Stdout: &stdout, Stderr: &stderr, NoVerify: cli.NoVerify}
+	deps := &Deps{DB: database, JSON: cli.JSON, Stdout: &stdout, Stderr: &stderr, NoVerify: cli.NoVerify, Config: cfg}
 	var runErr error
 	withSilentStdout(t, func() {
 		runErr = ctx.Run(deps)

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -203,6 +203,38 @@ things version       # or: things --version / things -v
 
 Prints the version, commit, and build date.
 
+## Configuration
+
+A TOML file supplies defaults for global and per-command flags. Precedence
+is flag > config file > built-in default.
+
+```sh
+things config init     # write a commented template (--force to overwrite)
+things config path     # print the file in use and whether it exists
+things config show     # print the defaults the file establishes
+things config show -j  # the same, as JSON
+```
+
+The file is read from `$XDG_CONFIG_HOME/things-cli/config.toml`, falling
+back to `~/.config/things-cli/config.toml`. Override it with `--config
+PATH` or `THINGS_CLI_CONFIG`. A missing file is not an error.
+
+| Key | Flag it sets | Type | Default |
+| --- | --- | --- | --- |
+| `json` | `--json` | boolean | `false` |
+| `color` | `--color` | `"auto"`, `"always"`, `"never"` | `"auto"` |
+| `db` | `--db` | string path (must exist) | auto-detected |
+| `no_verify` | `--no-verify` | boolean | `false` |
+| `strict_tags` | `--strict-tags` | boolean | `false` |
+
+```toml
+color = "always"
+strict_tags = true
+```
+
+Unknown keys, wrong types, and malformed TOML are errors that name the
+file and the key.
+
 ## Caching
 
 `things` caches the last list it printed in

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -226,11 +226,15 @@ PATH` or `THINGS_CLI_CONFIG`. A missing file is not an error.
 | `db` | `--db` | string path (must exist) | auto-detected |
 | `no_verify` | `--no-verify` | boolean | `false` |
 | `strict_tags` | `--strict-tags` | boolean | `false` |
+| `create_tags` | `--create-tags` | boolean | `false` |
 
 ```toml
 color = "always"
 strict_tags = true
 ```
+
+`strict_tags` and `create_tags` are mutually exclusive; setting both to
+`true` is an error.
 
 Unknown keys, wrong types, and malformed TOML are errors that name the
 file and the key.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/kong v1.16.1
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/mattn/go-isatty v0.0.24
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/willabides/kongplete v0.4.0
 	golang.org/x/term v0.45.0
 	modernc.org/sqlite v1.57.0

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,340 @@
+// Package config loads persistent defaults for the things CLI from a TOML
+// file. The file only seeds kong's flag resolution, so precedence stays
+// flag > config file > built-in default with no second code path.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// EnvVar names the environment variable that overrides the default path.
+const EnvVar = "THINGS_CLI_CONFIG"
+
+// Where the path in use came from, reported by `things config path`.
+const (
+	SourceFlag    = "flag"
+	SourceEnv     = "env"
+	SourceDefault = "default"
+)
+
+const (
+	dirName  = "things-cli"
+	fileName = "config.toml"
+)
+
+// Key describes one setting: the TOML key it is written as, the flag it seeds,
+// and the value that applies when neither the file nor a flag supplies one.
+type Key struct {
+	Name    string   // canonical TOML key, snake_case
+	Flag    string   // kong flag name this key resolves
+	Default any      // built-in default; bool or string
+	Enum    []string // permitted values, for keys with a fixed set
+	Comment []string // template comment, one line per entry
+	Example string   // template assignment, written commented out
+}
+
+// Keys is the full set of settings the config file may carry. Every entry must
+// name a flag that exists on the CLI; TestConfigKeysMatchFlags enforces that.
+var Keys = []Key{
+	{
+		Name:    "json",
+		Flag:    "json",
+		Default: false,
+		Comment: []string{
+			"Print JSON instead of the plain text listing. Same as --json / -j.",
+			"Turning this on changes the output of every command, including for",
+			"agents and scripts that expect plain text.",
+		},
+		Example: "json = false",
+	},
+	{
+		Name:    "color",
+		Flag:    "color",
+		Default: "auto",
+		Enum:    []string{"auto", "always", "never"},
+		Comment: []string{
+			`Color mode: "auto", "always" or "never". Same as --color.`,
+			`"auto" colours only when stdout is a terminal.`,
+		},
+		Example: `color = "auto"`,
+	},
+	{
+		Name:    "db",
+		Flag:    "db",
+		Default: "",
+		Comment: []string{
+			"Path to the Things3 SQLite database. Same as --db.",
+			"Leave unset to let things-cli find it. The file must exist.",
+		},
+		Example: `db = "~/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/Things Database.thingsdatabase/main.sqlite"`,
+	},
+	{
+		Name:    "no_verify",
+		Flag:    "no-verify",
+		Default: false,
+		Comment: []string{
+			"Skip the read-back that confirms a complete/cancel actually landed.",
+			"Same as --no-verify. Faster, but a write Things silently drops is",
+			"then reported as a success.",
+		},
+		Example: "no_verify = false",
+	},
+	{
+		Name:    "strict_tags",
+		Flag:    "strict-tags",
+		Default: false,
+		Comment: []string{
+			"Fail instead of writing when a tag does not exist in Things.",
+			"Same as --strict-tags. Off by default, which warns and writes anyway.",
+		},
+		Example: "strict_tags = false",
+	},
+}
+
+// KeyNames lists the canonical key names in declaration order.
+func KeyNames() []string {
+	names := make([]string, len(Keys))
+	for i, k := range Keys {
+		names[i] = k.Name
+	}
+	return names
+}
+
+// lookup finds the key a TOML name refers to. Both the canonical snake_case
+// name and the hyphenated flag spelling are accepted.
+func lookup(name string) (Key, bool) {
+	for _, k := range Keys {
+		if name == k.Name || name == k.Flag {
+			return k, true
+		}
+	}
+	return Key{}, false
+}
+
+// DefaultPath is $XDG_CONFIG_HOME/things-cli/config.toml, falling back to
+// ~/.config/things-cli/config.toml.
+func DefaultPath() (string, error) {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		home := os.Getenv("HOME")
+		if home == "" {
+			return "", fmt.Errorf("cannot locate the config file: neither $XDG_CONFIG_HOME nor $HOME is set")
+		}
+		base = filepath.Join(home, ".config")
+	}
+	return filepath.Join(base, dirName, fileName), nil
+}
+
+// ResolvePath picks the config file to use: an explicit --config path wins,
+// then $THINGS_CLI_CONFIG, then the default location.
+func ResolvePath(explicit string) (path, source string, err error) {
+	if explicit != "" {
+		return kong.ExpandPath(explicit), SourceFlag, nil
+	}
+	if env := os.Getenv(EnvVar); env != "" {
+		return kong.ExpandPath(env), SourceEnv, nil
+	}
+	p, err := DefaultPath()
+	if err != nil {
+		return "", "", err
+	}
+	return p, SourceDefault, nil
+}
+
+// File is a loaded config file. A file that does not exist loads fine with
+// Exists false and no values; a missing config file is not an error.
+type File struct {
+	Path   string
+	Source string
+	Exists bool
+
+	// values holds only the keys the file actually set, under their canonical
+	// names.
+	values map[string]any
+}
+
+// Load reads and validates the config file at path. A file that is not there
+// yields an empty File rather than an error.
+func Load(path string) (*File, error) {
+	f := &File{Path: path, Source: SourceDefault, values: map[string]any{}}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return f, nil
+		}
+		return nil, fmt.Errorf("cannot read config file %s: %w", path, err)
+	}
+	f.Exists = true
+
+	var raw map[string]any
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("invalid config file %s: %s", path, tomlErrorText(err))
+	}
+
+	for name, value := range raw {
+		key, ok := lookup(name)
+		if !ok {
+			return nil, fmt.Errorf("config file %s: unknown key %q (valid keys: %s)",
+				path, name, strings.Join(KeyNames(), ", "))
+		}
+		v, err := coerce(key, value)
+		if err != nil {
+			return nil, fmt.Errorf("config file %s: %w", path, err)
+		}
+		f.values[key.Name] = v
+	}
+
+	if err := f.checkDB(); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// checkDB reports a db path that does not exist here rather than letting it
+// surface later as a bare flag error with no mention of the config file.
+func (f *File) checkDB() error {
+	v, ok := f.values["db"].(string)
+	if !ok || v == "" {
+		return nil
+	}
+	if _, err := os.Stat(kong.ExpandPath(v)); err != nil {
+		return fmt.Errorf("config file %s: db: %s", f.Path, err)
+	}
+	return nil
+}
+
+// coerce checks a raw TOML value against the key's type and enum.
+func coerce(key Key, value any) (any, error) {
+	switch key.Default.(type) {
+	case bool:
+		b, ok := value.(bool)
+		if !ok {
+			return nil, fmt.Errorf("key %q must be a boolean, got %s", key.Name, typeName(value))
+		}
+		return b, nil
+	case string:
+		s, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("key %q must be a string, got %s", key.Name, typeName(value))
+		}
+		if len(key.Enum) > 0 && !contains(key.Enum, s) {
+			return nil, fmt.Errorf("key %q must be one of %s, got %q",
+				key.Name, strings.Join(key.Enum, ", "), s)
+		}
+		return s, nil
+	default:
+		return nil, fmt.Errorf("key %q has an unsupported type %T", key.Name, key.Default)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func typeName(v any) string {
+	switch v.(type) {
+	case bool:
+		return "boolean"
+	case string:
+		return "string"
+	case int64, float64:
+		return "number"
+	case map[string]any:
+		return "table"
+	case []any:
+		return "array"
+	default:
+		return fmt.Sprintf("%T", v)
+	}
+}
+
+// tomlErrorText renders a decode error on one line, with the row and column
+// the parser stopped at, instead of go-toml's multi-line excerpt.
+func tomlErrorText(err error) string {
+	var de *toml.DecodeError
+	if errors.As(err, &de) {
+		row, col := de.Position()
+		return fmt.Sprintf("line %d, column %d: %s", row, col, strings.TrimPrefix(de.Error(), "toml: "))
+	}
+	return err.Error()
+}
+
+// Setting is one key's effective value and where it came from, as reported by
+// `things config show`.
+type Setting struct {
+	Key    string `json:"key"`
+	Value  any    `json:"value"`
+	Source string `json:"source"` // "config" or "default"
+}
+
+// Settings reports the default that applies to each key once the file is taken
+// into account — that is, the value a command sees when no flag overrides it.
+func (f *File) Settings() []Setting {
+	out := make([]Setting, 0, len(Keys))
+	for _, k := range Keys {
+		s := Setting{Key: k.Name, Value: k.Default, Source: "default"}
+		if f != nil {
+			if v, ok := f.values[k.Name]; ok {
+				s.Value, s.Source = v, "config"
+			}
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// Resolver seeds kong's flag resolution from the file. It returns nil for any
+// flag the file does not mention, leaving kong's own default in place.
+func (f *File) Resolver() kong.Resolver {
+	values := map[string]any{}
+	if f != nil {
+		for _, k := range Keys {
+			if v, ok := f.values[k.Name]; ok {
+				values[k.Flag] = v
+			}
+		}
+	}
+	return kong.ResolverFunc(func(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (any, error) {
+		v, ok := values[flag.Name]
+		if !ok {
+			return nil, nil
+		}
+		return v, nil
+	})
+}
+
+// Template is the commented file `things config init` writes: every key, its
+// built-in value, all commented out.
+func Template() string {
+	var b strings.Builder
+	b.WriteString("# things-cli configuration\n")
+	b.WriteString("#\n")
+	b.WriteString("# Defaults for the flags below. A flag passed on the command line always\n")
+	b.WriteString("# wins: flag > this file > built-in default.\n")
+	b.WriteString("#\n")
+	b.WriteString("# Read from $XDG_CONFIG_HOME/things-cli/config.toml, or\n")
+	b.WriteString("# ~/.config/things-cli/config.toml. Override with --config PATH or\n")
+	b.WriteString("# $" + EnvVar + ". A missing file is not an error.\n")
+	b.WriteString("#\n")
+	b.WriteString("# Uncomment a line to change the default.\n")
+	for _, k := range Keys {
+		b.WriteString("\n")
+		for _, line := range k.Comment {
+			b.WriteString("# " + line + "\n")
+		}
+		b.WriteString("# " + k.Example + "\n")
+	}
+	return b.String()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,17 +27,37 @@ const (
 const (
 	dirName  = "things-cli"
 	fileName = "config.toml"
+
+	// dbKey is both the TOML key and the flag name for the database path; it
+	// is the one setting that needs validating before it reaches kong.
+	dbKey = "db"
 )
+
+// Error is a problem with the config file itself: unreadable, malformed, or
+// carrying a key or value the CLI cannot use. It is reported on its own rather
+// than through kong's usage output, because usage is not what is wrong.
+type Error struct {
+	Path string
+	Err  error
+}
+
+func (e *Error) Error() string { return fmt.Sprintf("config file %s: %v", e.Path, e.Err) }
+func (e *Error) Unwrap() error { return e.Err }
+
+func configErr(path string, format string, args ...any) *Error {
+	return &Error{Path: path, Err: fmt.Errorf(format, args...)}
+}
 
 // Key describes one setting: the TOML key it is written as, the flag it seeds,
 // and the value that applies when neither the file nor a flag supplies one.
 type Key struct {
-	Name    string   // canonical TOML key, snake_case
-	Flag    string   // kong flag name this key resolves
-	Default any      // built-in default; bool or string
-	Enum    []string // permitted values, for keys with a fixed set
-	Comment []string // template comment, one line per entry
-	Example string   // template assignment, written commented out
+	Name     string   // canonical TOML key, snake_case
+	Flag     string   // kong flag name this key resolves
+	Default  any      // built-in default; bool or string
+	Enum     []string // permitted values, for keys with a fixed set
+	Excludes []string // keys this one cannot be combined with
+	Comment  []string // template comment, one line per entry
+	Example  string   // template assignment, written commented out
 }
 
 // Keys is the full set of settings the config file may carry. Every entry must
@@ -87,14 +107,27 @@ var Keys = []Key{
 		Example: "no_verify = false",
 	},
 	{
-		Name:    "strict_tags",
-		Flag:    "strict-tags",
-		Default: false,
+		Name:     "strict_tags",
+		Flag:     "strict-tags",
+		Default:  false,
+		Excludes: []string{"create_tags"},
 		Comment: []string{
 			"Fail instead of writing when a tag does not exist in Things.",
 			"Same as --strict-tags. Off by default, which warns and writes anyway.",
+			"Mutually exclusive with create_tags.",
 		},
 		Example: "strict_tags = false",
+	},
+	{
+		Name:     "create_tags",
+		Flag:     "create-tags",
+		Default:  false,
+		Excludes: []string{"strict_tags"},
+		Comment: []string{
+			"Create tags that do not exist in Things before writing.",
+			"Same as --create-tags. Mutually exclusive with strict_tags.",
+		},
+		Example: "create_tags = false",
 	},
 }
 
@@ -169,43 +202,51 @@ func Load(path string) (*File, error) {
 		if os.IsNotExist(err) {
 			return f, nil
 		}
-		return nil, fmt.Errorf("cannot read config file %s: %w", path, err)
+		return nil, configErr(path, "cannot read: %w", err)
 	}
 	f.Exists = true
 
 	var raw map[string]any
 	if err := toml.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("invalid config file %s: %s", path, tomlErrorText(err))
+		return nil, configErr(path, "invalid TOML: %s", tomlErrorText(err))
 	}
 
 	for name, value := range raw {
 		key, ok := lookup(name)
 		if !ok {
-			return nil, fmt.Errorf("config file %s: unknown key %q (valid keys: %s)",
-				path, name, strings.Join(KeyNames(), ", "))
+			return nil, configErr(path, "unknown key %q (valid keys: %s)",
+				name, strings.Join(KeyNames(), ", "))
+		}
+		if _, dup := f.values[key.Name]; dup {
+			return nil, configErr(path, "key %q is set twice (%q and %q name the same setting)",
+				key.Name, key.Name, key.Flag)
 		}
 		v, err := coerce(key, value)
 		if err != nil {
-			return nil, fmt.Errorf("config file %s: %w", path, err)
+			return nil, &Error{Path: path, Err: err}
 		}
 		f.values[key.Name] = v
 	}
 
-	if err := f.checkDB(); err != nil {
+	if err := f.checkExclusions(); err != nil {
 		return nil, err
 	}
 	return f, nil
 }
 
-// checkDB reports a db path that does not exist here rather than letting it
-// surface later as a bare flag error with no mention of the config file.
-func (f *File) checkDB() error {
-	v, ok := f.values["db"].(string)
-	if !ok || v == "" {
-		return nil
-	}
-	if _, err := os.Stat(kong.ExpandPath(v)); err != nil {
-		return fmt.Errorf("config file %s: db: %s", f.Path, err)
+// checkExclusions rejects two mutually exclusive settings both turned on. Kong
+// would catch it too, but only once a command that carries the flags is run,
+// and its message says nothing about the config file.
+func (f *File) checkExclusions() error {
+	for _, k := range Keys {
+		if f.values[k.Name] != true {
+			continue
+		}
+		for _, name := range k.Excludes {
+			if f.values[name] == true {
+				return configErr(f.Path, "%q and %q cannot both be true", k.Name, name)
+			}
+		}
 	}
 	return nil
 }
@@ -295,24 +336,92 @@ func (f *File) Settings() []Setting {
 	return out
 }
 
+// JSON reports the json default the file establishes. It exists for the one
+// decision that has to be made before kong parses: whether a failure is
+// rendered as JSON or as a plain line.
+func (f *File) JSON() bool {
+	if f == nil {
+		return false
+	}
+	v, _ := f.values["json"].(bool)
+	return v
+}
+
 // Resolver seeds kong's flag resolution from the file. It returns nil for any
 // flag the file does not mention, leaving kong's own default in place.
 func (f *File) Resolver() kong.Resolver {
 	values := map[string]any{}
+	excludes := map[string][]string{}
+	path := ""
 	if f != nil {
+		path = f.Path
 		for _, k := range Keys {
-			if v, ok := f.values[k.Name]; ok {
-				values[k.Flag] = v
+			v, ok := f.values[k.Name]
+			if !ok {
+				continue
 			}
+			// An empty db path is how a file says "leave it unset". Passing it
+			// on would make kong's existingfile check stat the empty string,
+			// which expands to the working directory.
+			if k.Name == dbKey && v == "" {
+				continue
+			}
+			// For a key in an exclusive pair, false means the same as absent,
+			// and kong's exclusivity check counts any resolved value as set —
+			// so `strict_tags = true` alongside `create_tags = false` would
+			// read as both flags being passed at once.
+			if len(k.Excludes) > 0 && v == false {
+				continue
+			}
+			values[k.Flag] = v
+			excludes[k.Flag] = excludingFlags(k)
 		}
 	}
-	return kong.ResolverFunc(func(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (any, error) {
+	return kong.ResolverFunc(func(_ *kong.Context, parent *kong.Path, flag *kong.Flag) (any, error) {
 		v, ok := values[flag.Name]
 		if !ok {
 			return nil, nil
 		}
+		// A flag on the command line beats the file, and so does the flag it
+		// is mutually exclusive with: kong counts a resolved value as set, so
+		// answering here would turn `--strict-tags` against a file that says
+		// `create_tags = true` into "can't be used together" rather than the
+		// override it is. Only one of a pair ever reaches this map, so a set
+		// partner can only have come from the command line.
+		for _, name := range excludes[flag.Name] {
+			for _, other := range parent.Flags {
+				if other.Name == name && other.Set {
+					return nil, nil
+				}
+			}
+		}
+		// A db path that does not exist is reported here, naming the config
+		// file, rather than as a bare flag error. Kong skips resolvers for
+		// flags given on the command line, so --db still overrides a stale
+		// entry instead of tripping over it.
+		if flag.Name == dbKey {
+			if s, ok := v.(string); ok {
+				if _, err := os.Stat(kong.ExpandPath(s)); err != nil {
+					return nil, configErr(path, "db: %s", err)
+				}
+			}
+		}
 		return v, nil
 	})
+}
+
+// excludingFlags maps a key's excluded keys onto the flag names they seed.
+func excludingFlags(k Key) []string {
+	if len(k.Excludes) == 0 {
+		return nil
+	}
+	flags := make([]string, 0, len(k.Excludes))
+	for _, name := range k.Excludes {
+		if other, ok := lookup(name); ok {
+			flags = append(flags, other.Flag)
+		}
+	}
+	return flags
 }
 
 // Template is the commented file `things config init` writes: every key, its

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/alecthomas/kong"
 )
 
 // isolate points the default-path lookup at a temp directory so a test never
@@ -133,8 +135,8 @@ strict_tags = true
 	if !f.Exists {
 		t.Error("Exists = false for a file that is there")
 	}
-	want := map[string]any{"json": true, "color": "never", "no_verify": true, "strict_tags": true, "db": ""}
-	source := map[string]string{"json": "config", "color": "config", "no_verify": "config", "strict_tags": "config", "db": "default"}
+	want := map[string]any{"json": true, "color": "never", "no_verify": true, "strict_tags": true, "db": "", "create_tags": false}
+	source := map[string]string{"json": "config", "color": "config", "no_verify": "config", "strict_tags": "config", "db": "default", "create_tags": "default"}
 	for _, s := range f.Settings() {
 		if s.Value != want[s.Key] {
 			t.Errorf("%s = %v, want %v", s.Key, s.Value, want[s.Key])
@@ -166,12 +168,12 @@ func TestLoadRejectsBadFiles(t *testing.T) {
 		body string
 		want []string
 	}{
-		{"unknown key", "nope = 1\n", []string{"unknown key", `"nope"`, "json, color, db, no_verify, strict_tags"}},
-		{"malformed", "json = \n", []string{"invalid config file", "line 1"}},
+		{"unknown key", "nope = 1\n", []string{"unknown key", `"nope"`, "json, color, db, no_verify, strict_tags, create_tags"}},
+		{"malformed", "json = \n", []string{"invalid TOML", "line 1"}},
 		{"wrong type", `json = "yes"` + "\n", []string{`key "json" must be a boolean`, "got string"}},
 		{"table value", "[json]\na = 1\n", []string{`key "json" must be a boolean`, "got table"}},
 		{"bad enum", `color = "pink"` + "\n", []string{`key "color" must be one of`, "auto, always, never"}},
-		{"missing db", `db = "/nonexistent/things.sqlite"` + "\n", []string{"db:", "/nonexistent/things.sqlite"}},
+		{"duplicate spelling", "no_verify = true\nno-verify = false\n", []string{`key "no_verify" is set twice`}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -192,6 +194,50 @@ func TestLoadRejectsBadFiles(t *testing.T) {
 				t.Errorf("error spans multiple lines: %q", err)
 			}
 		})
+	}
+}
+
+// resolveFlag runs a file's resolver for one flag name, the way kong does.
+func resolveFlag(t *testing.T, f *File, name string) (any, error) {
+	t.Helper()
+	return f.Resolver().Resolve(nil, nil, &kong.Flag{Value: &kong.Value{Name: name}})
+}
+
+// A db path that has gone missing must not fail until kong actually asks for
+// it, so that a --db flag on the command line still overrides it.
+func TestResolverReportsMissingDB(t *testing.T) {
+	path := write(t, `db = "/nonexistent/things.sqlite"`+"\n")
+	f, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, err := resolveFlag(t, f, "json"); err != nil {
+		t.Fatalf("resolving an unrelated flag: %v", err)
+	}
+	_, err = resolveFlag(t, f, "db")
+	if err == nil {
+		t.Fatal("resolving db: want error, got nil")
+	}
+	for _, want := range []string{path, "db:", "/nonexistent/things.sqlite"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err, want)
+		}
+	}
+}
+
+// An empty db is how a file says "unset". Handing "" to kong's existingfile
+// check would stat the working directory and fail.
+func TestResolverSkipsEmptyDB(t *testing.T) {
+	f, err := Load(write(t, "db = \"\"\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	v, err := resolveFlag(t, f, "db")
+	if err != nil {
+		t.Fatalf("resolving db: %v", err)
+	}
+	if v != nil {
+		t.Errorf("db resolved to %#v, want nil so kong keeps its own default", v)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,257 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// isolate points the default-path lookup at a temp directory so a test never
+// reads or writes the developer's real config file.
+func isolate(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv(EnvVar, "")
+	return home
+}
+
+func write(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestDefaultPathUsesHome(t *testing.T) {
+	home := isolate(t)
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := filepath.Join(home, ".config", "things-cli", "config.toml")
+	if got != want {
+		t.Errorf("DefaultPath = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultPathPrefersXDG(t *testing.T) {
+	isolate(t)
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := filepath.Join(xdg, "things-cli", "config.toml")
+	if got != want {
+		t.Errorf("DefaultPath = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultPathWithoutHome(t *testing.T) {
+	isolate(t)
+	t.Setenv("HOME", "")
+	if _, err := DefaultPath(); err == nil {
+		t.Fatal("DefaultPath with no $HOME: want error, got nil")
+	}
+}
+
+func TestResolvePathPrecedence(t *testing.T) {
+	home := isolate(t)
+	envPath := filepath.Join(t.TempDir(), "env.toml")
+	flagPath := filepath.Join(t.TempDir(), "flag.toml")
+
+	path, source, err := ResolvePath("")
+	if err != nil {
+		t.Fatalf("ResolvePath: %v", err)
+	}
+	if want := filepath.Join(home, ".config", "things-cli", "config.toml"); path != want || source != SourceDefault {
+		t.Errorf("no override = (%q, %q), want (%q, %q)", path, source, want, SourceDefault)
+	}
+
+	t.Setenv(EnvVar, envPath)
+	path, source, err = ResolvePath("")
+	if err != nil {
+		t.Fatalf("ResolvePath: %v", err)
+	}
+	if path != envPath || source != SourceEnv {
+		t.Errorf("env = (%q, %q), want (%q, %q)", path, source, envPath, SourceEnv)
+	}
+
+	path, source, err = ResolvePath(flagPath)
+	if err != nil {
+		t.Fatalf("ResolvePath: %v", err)
+	}
+	if path != flagPath || source != SourceFlag {
+		t.Errorf("flag = (%q, %q), want (%q, %q)", path, source, flagPath, SourceFlag)
+	}
+}
+
+func TestResolvePathMakesRelativeAbsolute(t *testing.T) {
+	isolate(t)
+	path, _, err := ResolvePath("relative.toml")
+	if err != nil {
+		t.Fatalf("ResolvePath: %v", err)
+	}
+	if !filepath.IsAbs(path) {
+		t.Errorf("ResolvePath(%q) = %q, want an absolute path", "relative.toml", path)
+	}
+}
+
+func TestLoadMissingFileIsNotAnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.toml")
+	f, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if f.Exists {
+		t.Error("Exists = true for a file that is not there")
+	}
+	for _, s := range f.Settings() {
+		if s.Source != "default" {
+			t.Errorf("%s: source = %q, want default", s.Key, s.Source)
+		}
+	}
+}
+
+func TestLoadReadsEveryKey(t *testing.T) {
+	path := write(t, `
+json = true
+color = "never"
+no_verify = true
+strict_tags = true
+`)
+	f, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !f.Exists {
+		t.Error("Exists = false for a file that is there")
+	}
+	want := map[string]any{"json": true, "color": "never", "no_verify": true, "strict_tags": true, "db": ""}
+	source := map[string]string{"json": "config", "color": "config", "no_verify": "config", "strict_tags": "config", "db": "default"}
+	for _, s := range f.Settings() {
+		if s.Value != want[s.Key] {
+			t.Errorf("%s = %v, want %v", s.Key, s.Value, want[s.Key])
+		}
+		if s.Source != source[s.Key] {
+			t.Errorf("%s: source = %q, want %q", s.Key, s.Source, source[s.Key])
+		}
+	}
+}
+
+func TestLoadAcceptsHyphenatedSpelling(t *testing.T) {
+	path := write(t, "no-verify = true\nstrict-tags = true\n")
+	f, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, s := range f.Settings() {
+		if s.Key == "no_verify" || s.Key == "strict_tags" {
+			if s.Value != true {
+				t.Errorf("%s = %v, want true", s.Key, s.Value)
+			}
+		}
+	}
+}
+
+func TestLoadRejectsBadFiles(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"unknown key", "nope = 1\n", []string{"unknown key", `"nope"`, "json, color, db, no_verify, strict_tags"}},
+		{"malformed", "json = \n", []string{"invalid config file", "line 1"}},
+		{"wrong type", `json = "yes"` + "\n", []string{`key "json" must be a boolean`, "got string"}},
+		{"table value", "[json]\na = 1\n", []string{`key "json" must be a boolean`, "got table"}},
+		{"bad enum", `color = "pink"` + "\n", []string{`key "color" must be one of`, "auto, always, never"}},
+		{"missing db", `db = "/nonexistent/things.sqlite"` + "\n", []string{"db:", "/nonexistent/things.sqlite"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := write(t, tc.body)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("Load: want error, got nil")
+			}
+			if !strings.Contains(err.Error(), path) {
+				t.Errorf("error %q does not name the file %q", err, path)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err, want)
+				}
+			}
+			if strings.Count(err.Error(), "\n") != 0 {
+				t.Errorf("error spans multiple lines: %q", err)
+			}
+		})
+	}
+}
+
+func TestLoadAcceptsExistingDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "main.sqlite")
+	if err := os.WriteFile(dbPath, nil, 0o600); err != nil {
+		t.Fatalf("write db: %v", err)
+	}
+	f, err := Load(write(t, "db = "+quote(dbPath)+"\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, s := range f.Settings() {
+		if s.Key == "db" && s.Value != dbPath {
+			t.Errorf("db = %v, want %v", s.Value, dbPath)
+		}
+	}
+}
+
+func quote(s string) string { return `"` + s + `"` }
+
+func TestTemplateCoversEveryKeyAndReloads(t *testing.T) {
+	tpl := Template()
+	for _, k := range Keys {
+		if !strings.Contains(tpl, k.Example) {
+			t.Errorf("template is missing the example for %q", k.Name)
+		}
+	}
+	// Everything is commented out, so the template must load as an empty file.
+	f, err := Load(write(t, tpl))
+	if err != nil {
+		t.Fatalf("Load(template): %v", err)
+	}
+	for _, s := range f.Settings() {
+		if s.Source != "default" {
+			t.Errorf("%s: template set a value; every line should be commented out", s.Key)
+		}
+	}
+	for _, line := range strings.Split(tpl, "\n") {
+		if line != "" && !strings.HasPrefix(line, "# ") && line != "#" {
+			t.Errorf("uncommented template line: %q", line)
+		}
+	}
+}
+
+func TestKeyNamesAreUniqueAndSnakeCase(t *testing.T) {
+	seen := map[string]bool{}
+	for _, k := range Keys {
+		spellings := []string{k.Name}
+		if k.Flag != k.Name {
+			spellings = append(spellings, k.Flag)
+		}
+		for _, name := range spellings {
+			if seen[name] {
+				t.Errorf("duplicate config key spelling %q", name)
+			}
+			seen[name] = true
+		}
+		if strings.Contains(k.Name, "-") {
+			t.Errorf("key %q should be snake_case", k.Name)
+		}
+	}
+}

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -34,6 +34,16 @@ This covers argument and flag errors too — `things --json show` with no argume
 
 Human output is styled with colors and aligned columns. Color auto-disables when piping or when `NO_COLOR` is set. Override with `--color=always|never` (default `auto`). JSON output is unaffected.
 
+## Config file changes the defaults
+
+The user may have a TOML config file (`~/.config/things-cli/config.toml`, or `$XDG_CONFIG_HOME/things-cli/config.toml`) that changes what the flags default to. Precedence is flag > config file > built-in default. Keys: `json`, `color`, `db`, `no_verify`, `strict_tags`.
+
+This means the defaults you would otherwise assume may not hold — `json = true` makes every command emit JSON, and `no_verify = true` turns off the read-back that confirms a `complete`/`cancel` landed.
+
+- Pass the flags you depend on explicitly. Use `--json` when you want JSON and `--json=false` when you want the plain listing; do not infer the format from a bare invocation.
+- `things config show` prints the file in use and the defaults it establishes (`--json` for machine-readable). `things config path` prints just the path and whether it exists.
+- `things config init` writes a commented template. It refuses to overwrite an existing file unless given `--force` — do not run it on a user's behalf without asking.
+
 ## Core commands
 
 ```
@@ -81,6 +91,10 @@ things import [--file F] [--reveal] [--strict-tags | --create-tags] < payload.js
     # payload is the array documented at culturedcode.com/things/support/articles/2803573/
     # update items on repeating to-dos/projects are refused up front (see below)
     # update items setting completed/canceled are read back afterwards
+
+things config path              # config file in use, and whether it exists
+things config show              # the defaults that file establishes
+things config init [--force]    # write a commented template
 ```
 
 ### Repeating to-dos and projects
@@ -204,3 +218,4 @@ things --json list today | jq '.[] | .title'
 - Prefer `--json` in scripted contexts — it also guarantees the command never blocks on a prompt.
 - After a `list`/`search`, numeric indices stay valid until the next one.
 - Use `things open` when the user wants to *see* something in the app rather than read data back.
+- Check `things config show` before assuming a default. Pass `--json` explicitly rather than relying on the config file.

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -36,7 +36,7 @@ Human output is styled with colors and aligned columns. Color auto-disables when
 
 ## Config file changes the defaults
 
-The user may have a TOML config file (`~/.config/things-cli/config.toml`, or `$XDG_CONFIG_HOME/things-cli/config.toml`) that changes what the flags default to. Precedence is flag > config file > built-in default. Keys: `json`, `color`, `db`, `no_verify`, `strict_tags`.
+The user may have a TOML config file (`~/.config/things-cli/config.toml`, or `$XDG_CONFIG_HOME/things-cli/config.toml`) that changes what the flags default to. Precedence is flag > config file > built-in default. Keys: `json`, `color`, `db`, `no_verify`, `strict_tags`, `create_tags`.
 
 This means the defaults you would otherwise assume may not hold — `json = true` makes every command emit JSON, and `no_verify = true` turns off the read-back that confirms a `complete`/`cancel` landed.
 


### PR DESCRIPTION
## What changed

A TOML config file supplies defaults for existing flags, so they can be set once instead of typed every time.

The file is read from `$XDG_CONFIG_HOME/things-cli/config.toml`, falling back to `~/.config/things-cli/config.toml`. `--config PATH` and `$THINGS_CLI_CONFIG` override the location. A missing file is not an error.

Keys are the flag name in snake_case, and each maps onto a flag that already exists:

| Key | Flag | Type | Default |
| --- | --- | --- | --- |
| `json` | `--json` | boolean | `false` |
| `color` | `--color` | `"auto"`, `"always"`, `"never"` | `"auto"` |
| `db` | `--db` | path (must exist) | auto-detected |
| `no_verify` | `--no-verify` | boolean | `false` |
| `strict_tags` | `--strict-tags` | boolean | `false` |
| `create_tags` | `--create-tags` | boolean | `false` |

The hyphenated spelling (`no-verify`) is accepted too; writing a setting under both spellings in one file is an error rather than a coin flip. `strict_tags` and `create_tags` are mutually exclusive, and setting both to `true` is an error that names the file.

New subcommands:

- `things config path` — the file in use and whether it exists (`--json` gives path, exists, source).
- `things config show` — the defaults the file establishes, each marked `config` or `default`.
- `things config init` — writes a fully commented template. Refuses to overwrite; `--force` replaces.

## Why

Closes #159, and unblocks #153, which needs somewhere to keep a persistent setting.

## How it works

The file only seeds kong's flag resolution — it registers a `kong.Resolver`, and kong skips resolvers for flags already given on the command line. So precedence is flag > config file > built-in default with no second code path, and no command reads config values itself.

`--strict-tags` and `--create-tags` are `xor`-ed, and kong counts a resolved value as set for that check, so the resolver takes care not to break the precedence rule for them: a `false` value for either is never passed on (false means the same as absent), and neither is passed on when the other was given on the command line. So `things add x --strict-tags` still wins over `create_tags = true` in the file rather than failing with "can't be used together".

`--config` has to be read before the parser exists, because the file supplies the defaults the parser resolves against, so it is picked off `os.Args` the same way kong would read it (both `--config PATH` and `--config=PATH`, nothing after `--`).

Config problems carry a `*config.Error`, which `main` prints on its own rather than under a usage dump for a command that was typed correctly:

```
Error: config file ~/.config/things-cli/config.toml: unknown key "verbose" (valid keys: json, color, db, no_verify, strict_tags)
Error: config file ~/.config/things-cli/config.toml: invalid TOML: line 3, column 8: incomplete number
Error: config file ~/.config/things-cli/config.toml: key "color" must be one of auto, always, never, got "pink"
```

## Adding a key later

`config.Keys` in `internal/config/config.go` is the single registry. One entry — the TOML name, the flag name it seeds, the built-in default, and the template comment — feeds the resolver, `config show`, and the `config init` template at once. So a new key is: the flag itself (wherever it lives), one `config.Keys` entry, and the docs tables in `README.md` and `docs/_tabs/commands.md`.

`TestConfigKeysMatchFlags` walks the kong model and fails if a key names a flag that does not exist or disagrees with kong about its default, so the registry cannot drift away from the CLI silently.

The `--yes` flag from #158 is one registry entry plus its docs-table rows once it lands.

## How tested

`make test` (`go test -race ./...`) and `make lint` both clean.

New tests cover: default path from `$HOME` and `$XDG_CONFIG_HOME`; `--config` > env > default precedence; missing file; every key round-tripping; the hyphenated alias; unknown key, malformed TOML, wrong type, table value, bad enum value, duplicate spelling, and a `db` path that does not exist; the template being fully commented out and reloading as empty.

At the CLI level: the six cases of the `strict_tags`/`create_tags` interaction (either from the file, either flag beating the other's config value, both false, one true one false) and both true being rejected at load; config values reaching global flags and the per-command `--strict-tags`; a flag beating the config file; a flag beating a stale `db` entry; an empty `db` staying unset; env var selection; `config path` / `show` / `init` in both plain and JSON form; `init` refusing to overwrite and `--force` overwriting; and the parse error staying unwrappable to `*config.Error`.

The test harness in `run_test.go` now builds its parser from the same `parserOptions` function `main` uses, so a kong option cannot be added to one and forgotten in the other. It also points `HOME`, `XDG_CONFIG_HOME`, and `THINGS_CLI_CONFIG` at a temp directory, so tests never read or write a real config file.

## Notes

- Uses `github.com/pelletier/go-toml/v2` v2.2.4 with a hand-written resolver rather than `alecthomas/kong-toml`. kong-toml keys off the hyphenated flag name (`no-verify`), and #159 specifies snake_case; it also reports unknown keys through kong's validation, which prints a usage dump. The resolver is ~30 lines and gives the key spelling and the error shape the issue asks for. kong-toml also still pins go-toml v1, which is deprecated.
- A config file that fails to load stops every command, including `things --help` and `things config show`. The error names the file, the key, and the problem, so the file can be edited or removed; making `config show` able to report on a file it could not load would need a second parse pass, which did not seem worth it.
- An explicit `--config` path that does not exist is silently ignored, per "missing file is not an error" in #159. `things config path` reports `(not found)`, which is how a typo is diagnosed. Erroring instead would break `things --config /new/path.toml config init`.
- Rebased onto main after #150 and #157 merged. `jsonRequested` now takes the default the config file establishes as its starting point, so a parse failure under `json = true` is still rendered as JSON.
- `internal/skill/SKILL.md` gained a section telling agents that a config file can flip `json` and `no_verify`, and to pass the flags they depend on explicitly.

Closes #159
