### PR TITLE
fix(views): hide to-dos whose project is in the trash

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ project literally called `Inbox` would need `things -p Inbox`.
 | `trash` | Trashed tasks |
 | `deadlines` | Tasks with a deadline |
 
+Trashing a project in Things leaves its to-dos untrashed in the database, so
+every view above hides to-dos whose project is in the trash — `trash` and
+`logbook` excepted, since those report what the database holds.
+
 Filters:
 
 | Flag | Description |

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -140,7 +140,7 @@ func todayWhere(includeCompleted bool) string {
 	if includeCompleted {
 		status = "(t.status = 0 OR (t.status IN (2, 3) AND t.stopDate > COALESCE((SELECT manualLogDate FROM TMSettings LIMIT 1), 0)))"
 	}
-	return "t.start = 1 AND t.startBucket IN (0, 1) AND t.startDate IS NOT NULL AND " + status + " AND t.trashed = 0 AND COALESCE(p.trashed, 0) = 0 AND t.type = 0"
+	return "t.start = 1 AND t.startBucket IN (0, 1) AND t.startDate IS NOT NULL AND " + status + " AND t.trashed = 0 AND t.type = 0"
 }
 
 var viewFilters = map[string]string{
@@ -156,14 +156,10 @@ var viewFilters = map[string]string{
 	// to-dos they generate. A template carries the recurrence rule; each
 	// generated instance is an ordinary row with no rule of its own, so
 	// "{{repeating}} IS NOT NULL" selects templates alone (issue #147).
-	// Trashing a project leaves its rows trashed = 0, so the template of a
-	// repeating to-do in a trashed project needs the same guard the today
-	// and project views apply or it outlives the project it lived in.
-	"repeating": repeatingPlaceholder + " IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0 AND COALESCE(p.trashed, 0) = 0",
+	"repeating": repeatingPlaceholder + " IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
 	// The catch-all open set: also the default view for a bare --project/
-	// --area/--tag filter, so it has to exclude tasks living in a trashed
-	// project the way the today view does.
-	"project": "t.status = 0 AND t.trashed = 0 AND t.type = 0 AND COALESCE(p.trashed, 0) = 0",
+	// --area/--tag filter.
+	"project": "t.status = 0 AND t.trashed = 0 AND t.type = 0",
 }
 
 // notHeading excludes project headings (TMTask type 2) from the lookup
@@ -191,6 +187,17 @@ var viewOrderBy = map[string]string{
 	"project": "ORDER BY COALESCE(a.\"index\", pa.\"index\", 0), COALESCE(p.\"index\", 0), t.start ASC, t.\"index\" ASC",
 }
 
+// viewsIncludingTrashedProjects lists the views that keep to-dos whose project
+// is in the trash. Trashing a project in Things leaves its child rows at
+// trashed = 0, so without a guard they outlive the project and go on listing
+// as ordinary open tasks (issue #155, the same class as #142/#143). trash and
+// logbook are the exceptions: they report what the database holds, and a to-do
+// whose project was trashed belongs in trash.
+var viewsIncludingTrashedProjects = map[string]bool{
+	"trash":   true,
+	"logbook": true,
+}
+
 // viewsIncludingTemplates lists the views that keep repeating templates in
 // their results. Everywhere else templates are filtered out: Things files a
 // template under Repeating, not under the start bucket its row happens to
@@ -215,6 +222,9 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 	}
 	if view == "today" && opts.IncludeCompleted {
 		where = todayWhere(true)
+	}
+	if !viewsIncludingTrashedProjects[view] {
+		where += " AND COALESCE(p.trashed, 0) = 0"
 	}
 	if !viewsIncludingTemplates[view] {
 		where += " AND " + repeatingPlaceholder + " IS NULL"

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -704,6 +705,103 @@ func TestListTasksProjectViewExcludesTrashedProject(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("got %v, want no tasks from a trashed project", uuidsOf(got))
+	}
+}
+
+// Trashing a project in Things leaves its child rows at trashed = 0, so every
+// open view has to check the project as well as the task or those children
+// outlive the project they lived in (issue #155). One case per view, each
+// seeding the row shape that view selects on, all of them inside a trashed
+// project.
+func TestListTasksViewsExcludeTrashedProject(t *testing.T) {
+	today := int64(model.ThingsDateFromTime(time.Now()))
+	tomorrow := today + (1 << 7)
+
+	// view → the columns beyond the shared ones that put a row in that view.
+	cases := []struct {
+		view    string
+		columns string
+		values  string
+	}{
+		{"inbox", "start, startBucket", "0, 0"},
+		{"today", "start, startBucket, startDate", fmt.Sprintf("1, 0, %d", today)},
+		{"upcoming", "start, startBucket, startDate", fmt.Sprintf("2, 0, %d", tomorrow)},
+		{"anytime", "start, startBucket", "1, 0"},
+		{"someday", "start, startBucket", "2, 0"},
+		{"deadlines", "start, startBucket, deadline", fmt.Sprintf("1, 0, %d", tomorrow)},
+		{"project", "start, startBucket", "1, 0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.view, func(t *testing.T) {
+			d := newTestDB(t)
+			mustExec(t, d, `INSERT INTO TMTask (uuid, title, type, status, trashed, "index") VALUES
+				('proj-gone', 'Trashed project', 1, 0, 1, 1)`)
+			mustExec(t, d, `INSERT INTO TMTask
+				(uuid, title, type, status, trashed, project, "index", `+tc.columns+`) VALUES
+				('t-orphan', 'Child of trashed', 0, 0, 0, 'proj-gone', 1, `+tc.values+`)`)
+
+			got, err := d.ListTasks(tc.view, TaskFilter{})
+			if err != nil {
+				t.Fatalf("ListTasks(%q): %v", tc.view, err)
+			}
+			if len(got) != 0 {
+				t.Errorf("view %q: got %v, want no tasks from a trashed project", tc.view, uuidsOf(got))
+			}
+		})
+	}
+}
+
+// A task under a heading carries t.heading and leaves t.project NULL, so the
+// guard has to reach the project through the heading the way --project does
+// (issue #139), or heading-nested children of a trashed project slip past it.
+func TestListTasksExcludesTrashedProjectThroughHeading(t *testing.T) {
+	d := newTestDB(t)
+
+	mustExec(t, d, `INSERT INTO TMTask (uuid, title, type, status, trashed, "index") VALUES
+		('proj-gone', 'Trashed project', 1, 0, 1, 1),
+		('head-1',    'A heading',       2, 0, 0, 2)`)
+	mustExec(t, d, `UPDATE TMTask SET project = 'proj-gone' WHERE uuid = 'head-1'`)
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, heading, "index") VALUES
+		('t-orphan', 'Under the heading', 0, 0, 0, 1, 0, 'head-1', 1)`)
+
+	got, err := d.ListTasks("anytime", TaskFilter{})
+	if err != nil {
+		t.Fatalf("ListTasks(anytime): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want no heading-nested tasks from a trashed project", uuidsOf(got))
+	}
+}
+
+// trash and logbook report what the database holds rather than what Things
+// would show as actionable, so they keep the children of a trashed project.
+// Without this the guard would silently swallow them.
+func TestTrashAndLogbookKeepTrashedProjectChildren(t *testing.T) {
+	d := newTestDB(t)
+
+	mustExec(t, d, `INSERT INTO TMTask (uuid, title, type, status, trashed, "index") VALUES
+		('proj-gone', 'Trashed project', 1, 0, 1, 1)`)
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, project, "index") VALUES
+		('t-binned', 'Trashed child',   0, 0, 1, 1, 0, 'proj-gone', 1),
+		('t-logged', 'Completed child', 0, 3, 0, 1, 0, 'proj-gone', 2)`)
+
+	for _, tc := range []struct {
+		view string
+		want string
+	}{
+		{"trash", "t-binned"},
+		{"logbook", "t-logged"},
+	} {
+		got, err := d.ListTasks(tc.view, TaskFilter{})
+		if err != nil {
+			t.Fatalf("ListTasks(%q): %v", tc.view, err)
+		}
+		if !sameSet(uuidsOf(got), []string{tc.want}) {
+			t.Errorf("view %q: got %v, want [%s]", tc.view, uuidsOf(got), tc.want)
+		}
 	}
 }
 

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -50,6 +50,8 @@ things list [view] [--project P] [--area A] [--tag T] [--on D | --from D --to D]
     # on most views and `deadline` on the `deadlines` view. Not supported on
     # inbox/trash/logbook/someday/repeating (those items have no start date).
     # --on is mutually exclusive with --from/--to.
+    # Trashing a project leaves its to-dos untrashed in the database; every
+    # view hides them anyway, except trash and logbook.
     # today shows only open tasks; --include-completed also lists completed/
     # cancelled items Things hasn't logged out of Today yet (today only).
 


### PR DESCRIPTION
## What changed

Trashing a project in Things leaves its child rows at `trashed = 0`, so `someday`, `anytime`, `upcoming`, `inbox` and `deadlines` went on listing to-dos whose project had been deleted. `today`, `project` and `repeating` already carried a `COALESCE(p.trashed, 0) = 0` guard against exactly this (#142/#143, #154).

With eight of the ten views wanting the guard, it moves out of the individual filter strings in `viewFilters` and into `ListTasks`, alongside the repeating-template exclusion that works the same way. `trash` and `logbook` opt out through a `viewsIncludingTrashedProjects` set: they report what the database holds, and a to-do trashed along with its project belongs in `trash`. That leaves the registry with one guard instead of eight copies, and the `todayWhere`, `repeating` and `project` strings lose the clause they were carrying.

The guard resolves the project through `COALESCE(t.project, h.project)`, so a to-do nested under a heading in a trashed project is covered too (#139).

## How tested

- `make test` (race) and `make lint` — both green.
- `TestListTasksViewsExcludeTrashedProject` is table-driven, one case per view (`inbox`, `today`, `upcoming`, `anytime`, `someday`, `deadlines`, `project`), each seeding the row shape that view selects on inside a trashed project. `TestListTasksExcludesTrashedProjectThroughHeading` covers the heading-nested path.
- `TestTrashAndLogbookKeepTrashedProjectChildren` asserts the two opt-out views still return those children, so the hoist cannot quietly over-filter.
- I confirmed every new case fails without the guard.
- Checked against a read-only copy of the real Things database: `anytime` drops from 96 to 93 — the three orphaned open tasks — and every other view is unchanged.

## Notes

Docs get a short note in `README.md` and `internal/skill/SKILL.md`; the CLI surface is unchanged.

Closes #155