### PR TITLE
fix(db): resolve a shared title to the to-do, not the repeating template

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ tasks and show up in `today`, `upcoming` and the rest as usual. Templates are
 kept out of every other view except `trash` and `logbook`, which report what
 the database holds.
 
+A template and the to-do it generated share a title, so a title lookup —
+`things show`, `edit`, `complete`, `cancel` — resolves to the generated to-do,
+which is the one that can be completed. Reach the template by UUID, or by the
+numeric index from `things repeating`.
+
 The date filters (`--on`, `--from`, `--to`) apply to date-filterable views —
 `today`, `upcoming`, `anytime`, `deadlines`, and project listings (`someday`
 items have no start date, so they can't be date-filtered, and neither can

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -566,3 +566,36 @@ func TestRunListHeadingTaskShowsProject(t *testing.T) {
 		t.Errorf("headingTitle = %q, want Weekly", task.HeadingTitle)
 	}
 }
+
+// A repeating template and the to-do it generated share a title. `things show
+// "Water plants"` has to land on the generated to-do — the template refuses
+// completes and cancels, so resolving to it strands the user (issue #156).
+func TestRunShowPrefersGeneratedTodoOverTemplate(t *testing.T) {
+	sqlDB := dbtest.NewSQL(t)
+	today := int64(model.ThingsDateFromTime(time.Now()))
+	if _, err := sqlDB.Exec(
+		`INSERT INTO TMTask
+			(uuid, title, type, status, trashed, start, startBucket, startDate, "index", rt1_recurrenceRule) VALUES
+			('tpl-water',  'Water plants', 0, 0, 0, 2, 0, NULL, 1, x'0102'),
+			('inst-water', 'Water plants', 0, 0, 0, 1, 0, ?,    2, NULL)`,
+		today,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	database := db.NewFromSQL(sqlDB)
+
+	out, err := runOut(t, database, "--json", "show", "Water plants")
+	if err != nil {
+		t.Fatalf("run show: %v", err)
+	}
+	var task model.Task
+	if err := json.Unmarshal([]byte(out), &task); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if task.UUID != "inst-water" {
+		t.Errorf("uuid = %q, want inst-water", task.UUID)
+	}
+	if task.Repeating {
+		t.Error("resolved the template, not the generated to-do")
+	}
+}

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -292,8 +292,10 @@ func (d *DB) GetTask(uuidOrTitle string) (*model.Task, error) {
 		return t, nil
 	}
 
-	// Try exact title match
-	query := d.taskQuery() + " WHERE t.title = ? AND t.trashed = 0 AND t.status = 0 AND " + notHeading + " GROUP BY t.uuid LIMIT 1"
+	// Try exact title match. Only one row comes back, so the ordering is the
+	// whole decision: templates last (issue #156).
+	query := d.taskQuery() + " WHERE t.title = ? AND t.trashed = 0 AND t.status = 0 AND " + notHeading +
+		" GROUP BY t.uuid " + d.templatesLastOrder() + " LIMIT 1"
 	row := d.db.QueryRow(query, uuidOrTitle)
 	task, err := scanTask(row)
 	if err == nil {
@@ -319,8 +321,28 @@ func (d *DB) GetTask(uuidOrTitle string) (*model.Task, error) {
 }
 
 func (d *DB) FindTasksByTitle(substr string) ([]model.Task, error) {
-	query := d.taskQuery() + " WHERE t.title LIKE ? AND t.trashed = 0 AND t.status = 0 AND " + notHeading + " GROUP BY t.uuid ORDER BY t.\"index\" ASC"
+	query := d.taskQuery() + " WHERE t.title LIKE ? AND t.trashed = 0 AND t.status = 0 AND " + notHeading +
+		" GROUP BY t.uuid " + d.templatesLastOrder()
 	return d.collectTasks(query, "%"+substr+"%")
+}
+
+// templatesLastOrder orders a title lookup so repeating templates sort after
+// ordinary to-dos, keeping t."index" as the tiebreak the lookups have always
+// used.
+//
+// A repeating to-do exists twice: the template carrying the recurrence rule,
+// and the instance Things generated from it, sharing its title. The template
+// is never what "complete Water plants" means — writes to it are refused
+// outright (issue #143) — so a lookup that picked it stranded the user on an
+// error while an actionable instance sat next to it (issue #156). Ordering
+// rather than filtering keeps the template reachable when it is the only match,
+// which is what `things show` on a template-only title should still do.
+//
+// "<col> IS NOT NULL" yields 0 for instances and 1 for templates, so ASC puts
+// instances first. On a schema with no recurrence column the expression is
+// "NULL IS NOT NULL" — 0 for every row, leaving the index order untouched.
+func (d *DB) templatesLastOrder() string {
+	return `ORDER BY ` + d.recurrenceCol() + ` IS NOT NULL ASC, t."index" ASC`
 }
 
 // TaskNotFoundError reports a reference that matched no task. It is typed so

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ryanlewis/things-cli/internal/db/dbtest"
 	"github.com/ryanlewis/things-cli/internal/model"
 )
 
@@ -883,5 +884,126 @@ func TestSearchTasksExcludesHeadings(t *testing.T) {
 	}
 	if !sameSet(uuidsOf(proj), []string{"proj-1"}) {
 		t.Errorf("project search: got %v, want [proj-1]", uuidsOf(proj))
+	}
+}
+
+// --- repeating template vs. its instance in title lookups (issue #156) ---
+
+// seedTemplateAndInstance creates a repeating to-do the way Things stores one:
+// a template carrying the recurrence rule (start=2/someday-ish, no startDate)
+// and the instance generated from it (start=1, scheduled, no rule), sharing a
+// title. The template is given the lower "index" so index order alone would
+// pick it — the ordering under test is what puts the instance first.
+func seedTemplateAndInstance(t *testing.T, d *DB) {
+	t.Helper()
+
+	today := int64(model.ThingsDateFromTime(time.Now()))
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, startDate, "index", rt1_recurrenceRule) VALUES
+		('tpl-water',  'Water plants', 0, 0, 0, 2, 0, NULL, 1, x'0102'),
+		('inst-water', 'Water plants', 0, 0, 0, 1, 0, ?,    2, NULL)`,
+		today)
+}
+
+// `things complete "Water plants"` must land on the instance: the template
+// refuses writes (issue #143), so resolving to it strands the user.
+func TestGetTaskExactTitlePrefersInstance(t *testing.T) {
+	d := newTestDB(t)
+	seedTemplateAndInstance(t, d)
+
+	got, err := d.GetTask("Water plants")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.UUID != "inst-water" {
+		t.Errorf("got %q (repeating=%v), want inst-water", got.UUID, got.Repeating)
+	}
+	if got.Repeating {
+		t.Error("resolved row should not be the template")
+	}
+}
+
+// The template is still reachable when nothing else matches — ordering, not
+// filtering, so `things show` on a template-only title keeps working.
+func TestGetTaskExactTitleTemplateOnly(t *testing.T) {
+	d := newTestDB(t)
+
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, "index", rt1_recurrenceRule) VALUES
+		('tpl-only', 'Pay rent', 0, 0, 0, 2, 1, x'0102')`)
+
+	got, err := d.GetTask("Pay rent")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.UUID != "tpl-only" || !got.Repeating {
+		t.Errorf("got %+v, want the template", got)
+	}
+}
+
+// The LIKE path feeds the disambiguation picker, so the instance has to be the
+// first thing offered there too.
+func TestFindTasksByTitleOrdersTemplatesLast(t *testing.T) {
+	d := newTestDB(t)
+	seedTemplateAndInstance(t, d)
+
+	got, err := d.FindTasksByTitle("Water")
+	if err != nil {
+		t.Fatalf("FindTasksByTitle: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %v, want both rows", uuidsOf(got))
+	}
+	if got[0].UUID != "inst-water" || got[1].UUID != "tpl-water" {
+		t.Errorf("order = %v, want [inst-water tpl-water]", uuidsOf(got))
+	}
+}
+
+// A partial title matching only the pair resolves through the LIKE path's
+// ambiguity branch; the candidates it reports are ordered the same way.
+func TestGetTaskAmbiguousListsInstanceFirst(t *testing.T) {
+	d := newTestDB(t)
+	seedTemplateAndInstance(t, d)
+
+	_, err := d.GetTask("ater plant")
+	var ambig *AmbiguousTaskError
+	if !errors.As(err, &ambig) {
+		t.Fatalf("wrong error type: %T: %v", err, err)
+	}
+	if len(ambig.Matches) != 2 || ambig.Matches[0].UUID != "inst-water" {
+		t.Errorf("matches = %v, want inst-water first", uuidsOf(ambig.Matches))
+	}
+}
+
+// With no recurrence column the ordering expression is a constant, so title
+// lookups fall back to plain index order rather than failing.
+func TestTitleLookupsWithoutRecurrenceColumn(t *testing.T) {
+	sqlDB := dbtest.NewSQL(t)
+	if _, err := sqlDB.Exec(`ALTER TABLE TMTask DROP COLUMN rt1_recurrenceRule`); err != nil {
+		t.Fatalf("drop column: %v", err)
+	}
+	if _, err := sqlDB.Exec(
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, "index") VALUES
+			('a', 'Water plants', 0, 0, 0, 1),
+			('b', 'Water plants', 0, 0, 0, 2)`,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	d := &DB{db: sqlDB}
+
+	got, err := d.GetTask("Water plants")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.UUID != "a" {
+		t.Errorf("got %q, want the lowest index", got.UUID)
+	}
+
+	matches, err := d.FindTasksByTitle("Water")
+	if err != nil {
+		t.Fatalf("FindTasksByTitle: %v", err)
+	}
+	if !sameSet(uuidsOf(matches), []string{"a", "b"}) {
+		t.Errorf("got %v", uuidsOf(matches))
 	}
 }

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -85,6 +85,8 @@ things import [--file F] [--reveal] [--strict-tags | --create-tags] < payload.js
 
 A repeating to-do is stored as a template plus the to-dos it generates. `things repeating` lists the templates; they do not appear in `someday` or any other view except `trash` and `logbook`, which report what the database holds. The generated to-dos carry no recurrence rule of their own, so they list as ordinary tasks under `today`, `upcoming` and the rest.
 
+A template and its generated to-do share a title, so a title lookup — `things show/edit/complete/cancel <title>` — resolves to the generated to-do, the one that can actually be completed. To reach the template, use its UUID or the numeric index from `things repeating`.
+
 Things refuses to update `when`, `deadline`, completed/canceled status, and duplication on repeating items, and drops the request silently rather than reporting an error. The CLI checks first and fails with a non-zero exit:
 
 ```


### PR DESCRIPTION
## What changed

Both title lookups in `internal/db` now sort repeating templates last, through a shared `templatesLastOrder()`:

```
ORDER BY <recurrence column> IS NOT NULL ASC, t."index" ASC
```

`GetTask`'s exact-title path gains that ordering ahead of its `LIMIT 1`, so the single row it returns is the generated to-do. `FindTasksByTitle`, which feeds the disambiguation picker, keeps returning both but offers the instance first.

## Why

A repeating to-do exists twice in the database: the template carrying the recurrence rule, and the instance Things generated from it, sharing its title. The exact-title path took whichever row came first under `LIMIT 1`, so `things complete "Water plants"` could land on the template and hit the repeating-write refusal from #143 while a perfectly completable instance sat next to it.

I ordered rather than raised an `AmbiguousTaskError`, which was the other option on the table. Three reasons:

- The template is never what a user means by "complete X" or "cancel X" — Things itself won't accept those writes, which is exactly why #143 refuses them. Offering it as a candidate asks the user to choose between an answer and a dead end.
- Ambiguity is a breaking change for scripts. A title that resolves fine today would start demanding a UUID, and `--json` consumers would have to handle a new failure for a case that has an obvious right answer.
- Ordering keeps the template reachable. Filtering templates out of the lookups would have been simpler still, but then `things show "Pay rent"` on a template with no live instance — a real state, between generated occurrences — would report "not found". With ordering it is only deprioritised, so it still resolves when nothing else matches.

To reach a template deliberately, use its UUID or the numeric index from `things repeating`. That is now documented in both `README.md` and `internal/skill/SKILL.md`.

`SearchTasks` is deliberately untouched: search is a listing, and a user searching for "water" should see both rows in index order rather than have the CLI express a preference.

## How tested

`make test` (race) and `make lint` clean.

New tests in `internal/db/tasks_test.go`, seeding a template (recurrence rule, `start=2`, no `startDate`) and an instance (`start=1`, scheduled, no rule) with the same title — and giving the template the *lower* `"index"`, so plain index order alone would still pick it:

- `TestGetTaskExactTitlePrefersInstance` — the exact-title path returns the instance.
- `TestGetTaskExactTitleTemplateOnly` — a template with no instance still resolves, proving this orders rather than filters.
- `TestFindTasksByTitleOrdersTemplatesLast` — the LIKE path returns both, instance first.
- `TestGetTaskAmbiguousListsInstanceFirst` — the candidates in `AmbiguousTaskError` carry the same order, so the picker offers the instance as option 1.
- `TestTitleLookupsWithoutRecurrenceColumn` — with the column dropped the ordering expression is constant, and lookups fall back to index order instead of failing.

And `TestRunShowPrefersGeneratedTodoOverTemplate` in `cmd/things`, driving `things --json show "Water plants"` end to end.

I checked the tests are not vacuous by reverting the ordering to plain `t."index" ASC` — the three ordering tests failed, the template-only and no-column tests stayed green.

Closes #156