### PR TITLE
feat(json): add per-item details to import failures under --json

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ asking to confirm.
 
 A failing command prints a single JSON object to stdout and exits non-zero, so
 a consumer parsing stdout gets a structured failure either way. `error` is a
-stable token — `ambiguous task`, `not found`, or `error` for anything else —
-and `message` carries the same text plain-text mode prints.
+stable token — `ambiguous task`, `not found`, `import refused`, `import
+partially applied`, or `error` for anything else — and `message` carries the
+same text plain-text mode prints.
 
 ```console
 $ things show milk --json; echo "exit=$?"
@@ -83,6 +84,62 @@ exit=1
 Retry with one of the `matches[].uuid` values. Argument and flag errors take
 the same route, so `--json` never leaves a usage block on stdout. Without
 `--json`, errors stay a plain `Error: ...` line on stderr, unchanged.
+
+#### Batch failures: `items`
+
+`import` acts on many items at once, so its two failures add an `items` array
+naming exactly which ones failed — enough to act per item without parsing the
+message. The two are separate tokens because the recovery differs: `import
+refused` sent nothing, so the payload can be fixed and re-run whole, while
+`import partially applied` already changed things and must be re-run with only
+the items listed.
+
+A refusal ([repeating items](#repeating-items-in-an-import-payload)) sets
+`blocked`, the attributes Things will not accept on that item:
+
+```console
+$ things import --file reschedule.json --json; echo "exit=$?"
+{
+  "error": "import refused",
+  "message": "1 of 1 update items change attributes Things does not allow on repeating items, ...",
+  "items": [
+    {
+      "path": "[0]",
+      "id": "rep-1",
+      "title": "Water plants",
+      "blocked": ["when", "deadline"]
+    }
+  ]
+}
+exit=1
+```
+
+A [read-back failure](#reading-back-an-imports-status-changes) sets `wanted`
+and `got` — the status the payload asked for, and the one the item is still in:
+
+```console
+$ things import --file finish.json --json; echo "exit=$?"
+{
+  "error": "import partially applied",
+  "message": "1 of 1 requested status changes did not apply. ...",
+  "items": [
+    {
+      "path": "[0]",
+      "id": "one-1",
+      "title": "Post letter",
+      "wanted": "completed",
+      "got": "open"
+    }
+  ]
+}
+exit=1
+```
+
+`path` locates the item in the payload you sent — `[0]` at the top level,
+`[2].attributes.items[0]` for one nested in a project — so it maps back to the
+JSON you wrote. `got` is omitted when there was nothing to observe, because the
+row could not be read or no longer exists. Every other field of the payload is
+unchanged, and commands that fail on a single item carry no `items` at all.
 
 ### Global flags
 

--- a/cmd/things/errors.go
+++ b/cmd/things/errors.go
@@ -24,6 +24,25 @@ type jsonErrorPayload struct {
 	Kind    string           `json:"kind,omitempty"`
 	Query   string           `json:"query,omitempty"`
 	Matches []jsonErrorMatch `json:"matches,omitempty"`
+	Items   []jsonErrorItem  `json:"items,omitempty"`
+}
+
+// jsonErrorItem is one item of a batch failure. An import acts on many items
+// at once, so a caller needs to know which of them failed and why rather than
+// reading it back out of the message (issue #161).
+//
+// Two failures share the shape, and each fills the half that applies:
+// a refusal sets Blocked, naming the attributes Things will not accept on that
+// item; a read-back failure sets Wanted and Got, naming the status the payload
+// asked for and the one the item is still in. Got is empty when there was
+// nothing to observe — the row could not be read, or no longer exists.
+type jsonErrorItem struct {
+	Path    string   `json:"path"`
+	ID      string   `json:"id,omitempty"`
+	Title   string   `json:"title,omitempty"`
+	Blocked []string `json:"blocked,omitempty"`
+	Wanted  string   `json:"wanted,omitempty"`
+	Got     string   `json:"got,omitempty"`
 }
 
 // jsonErrorMatch is one candidate of an ambiguous reference — enough for a
@@ -84,6 +103,24 @@ func errorPayload(err error) jsonErrorPayload {
 		payload.Error = "not found"
 		payload.Kind = "task"
 		payload.Query = notFoundTask.Query
+		return payload
+	}
+
+	// Batch import failures. The two are kept apart because the recovery
+	// differs: a refusal sent nothing, so the payload can be fixed and re-run
+	// whole, while a partially applied import already changed things and must
+	// be re-run with only the items named here.
+	var refused *importRefusalError
+	if errors.As(err, &refused) {
+		payload.Error = "import refused"
+		payload.Items = refused.jsonItems()
+		return payload
+	}
+
+	var unapplied *importVerifyError
+	if errors.As(err, &unapplied) {
+		payload.Error = "import partially applied"
+		payload.Items = unapplied.jsonItems()
 		return payload
 	}
 

--- a/cmd/things/importcheck.go
+++ b/cmd/things/importcheck.go
@@ -146,6 +146,64 @@ func wantedStatus(attrs map[string]any) (model.Status, bool) {
 	return model.StatusOpen, false
 }
 
+// importRefusalItem is one payload item the pre-write check refused, and one
+// entry of the `items` array a --json consumer reads (issue #161).
+type importRefusalItem struct {
+	Path    string
+	ID      string
+	Title   string
+	Kind    string // "to-do" or "project", as the message names it
+	Blocked []string
+}
+
+// importRefusalError is the whole-payload refusal. It carries the offending
+// items so --json can hand them over one by one instead of a consumer having
+// to parse them back out of the message.
+type importRefusalError struct {
+	items []importRefusalItem
+	total int // update items in the payload, offending or not
+}
+
+func (e *importRefusalError) Error() string {
+	lines := make([]string, len(e.items))
+	for i, it := range e.items {
+		lines[i] = fmt.Sprintf("  %s (id %s): %q is a repeating %s — %s",
+			it.Path, it.ID, it.Title, it.Kind, strings.Join(it.Blocked, ", "))
+	}
+	return fmt.Sprintf("%d of %d update items change attributes Things does not allow on repeating items, and drops the request silently (%s). Nothing was sent to Things — fix these and run the import again, or make the changes in the Things app:\n%s",
+		len(e.items), e.total, repeatingDocsURL, strings.Join(lines, "\n"))
+}
+
+// importVerifyItem is one status change that never landed. wanted and got name
+// the statuses either side of the failure; got is absent when there was
+// nothing to observe, because the row could not be read or no longer exists.
+type importVerifyItem struct {
+	Path     string
+	ID       string
+	Title    string
+	Wanted   model.Status
+	Got      model.Status
+	Observed bool
+
+	err error // the read-back error, verbatim, for the plain-text message
+}
+
+// importVerifyError is a partially applied import: the payload reached Things,
+// and some of the status changes it asked for did not take.
+type importVerifyError struct {
+	items []importVerifyItem
+	total int // status changes the payload requested, landed or not
+}
+
+func (e *importVerifyError) Error() string {
+	lines := make([]string, len(e.items))
+	for i, it := range e.items {
+		lines[i] = fmt.Sprintf("  %s: %v", it.Path, it.err)
+	}
+	return fmt.Sprintf("%d of %d requested status changes did not apply. The rest of the import was still applied; re-run the import with only the failed items, or make the changes in the Things app:\n%s",
+		len(e.items), e.total, strings.Join(lines, "\n"))
+}
+
 // prepareImport is the pre-write pass over an import payload. It refuses the
 // whole import when any `operation: update` item would change an attribute
 // Things drops silently on a repeating to-do or project — the same check
@@ -158,7 +216,8 @@ func wantedStatus(attrs map[string]any) (model.Status, bool) {
 func prepareImport(d *Deps, database *db.DB, data []byte) (*importPlan, error) {
 	plan := &importPlan{updates: importUpdates(data), tasks: map[string]*model.Task{}}
 
-	var refusals, missing []string
+	var refusals []importRefusalItem
+	var missing []string
 	for _, u := range plan.updates {
 		if !u.resolvable() {
 			continue
@@ -184,16 +243,16 @@ func prepareImport(d *Deps, database *db.DB, data []byte) (*importPlan, error) {
 		if task.Type == model.TypeProject {
 			kind = "project"
 		}
-		refusals = append(refusals, fmt.Sprintf("  %s (id %s): %q is a repeating %s — %s",
-			u.path, u.id, task.Title, kind, strings.Join(blocked, ", ")))
+		refusals = append(refusals, importRefusalItem{
+			Path: u.path, ID: u.id, Title: task.Title, Kind: kind, Blocked: blocked,
+		})
 	}
 
 	// Refuse first: the warnings below promise that Things will report the
 	// unknown ids itself, which is only true when the payload is actually
 	// sent. A refused import never reaches Things.
 	if len(refusals) > 0 {
-		return nil, fmt.Errorf("%d of %d update items change attributes Things does not allow on repeating items, and drops the request silently (%s). Nothing was sent to Things — fix these and run the import again, or make the changes in the Things app:\n%s",
-			len(refusals), len(plan.updates), repeatingDocsURL, strings.Join(refusals, "\n"))
+		return nil, &importRefusalError{items: refusals, total: len(plan.updates)}
 	}
 
 	for _, m := range missing {
@@ -216,7 +275,7 @@ func verifyImportStatuses(d *Deps, database *db.DB, plan *importPlan) error {
 	}
 
 	var wants []statusWant
-	var paths []string
+	var items []importVerifyItem
 	for _, u := range plan.updates {
 		if !u.resolvable() {
 			continue
@@ -232,7 +291,7 @@ func verifyImportStatuses(d *Deps, database *db.DB, plan *importPlan) error {
 			continue
 		}
 		wants = append(wants, statusWant{uuid: u.id, title: task.Title, want: want})
-		paths = append(paths, u.path)
+		items = append(items, importVerifyItem{Path: u.path, ID: u.id, Title: task.Title, Wanted: want})
 	}
 	if len(wants) == 0 {
 		return nil
@@ -243,16 +302,50 @@ func verifyImportStatuses(d *Deps, database *db.DB, plan *importPlan) error {
 	// anything written to stderr never reaches the reader, so a summary
 	// pointing at a list printed elsewhere would name detail the consumer
 	// cannot see.
-	var failures []string
-	for i, err := range verifyStatuses(database, wants, verifyTimeout) {
-		if err == nil {
+	var failures []importVerifyItem
+	for i, res := range verifyStatuses(database, wants, verifyTimeout) {
+		if res.err == nil {
 			continue
 		}
-		failures = append(failures, fmt.Sprintf("  %s: %v", paths[i], err))
+		failed := items[i]
+		failed.Got, failed.Observed, failed.err = res.got, res.observed, res.err
+		failures = append(failures, failed)
 	}
 	if len(failures) == 0 {
 		return nil
 	}
-	return fmt.Errorf("%d of %d requested status changes did not apply. The rest of the import was still applied; re-run the import with only the failed items, or make the changes in the Things app:\n%s",
-		len(failures), len(wants), strings.Join(failures, "\n"))
+	return &importVerifyError{items: failures, total: len(wants)}
+}
+
+// jsonItems renders the refused items for the --json error payload. Blocked is
+// copied rather than shared: the payload outlives the error only in tests, but
+// aliasing a slice into the wire format invites a caller to mutate it.
+func (e *importRefusalError) jsonItems() []jsonErrorItem {
+	out := make([]jsonErrorItem, len(e.items))
+	for i, it := range e.items {
+		out[i] = jsonErrorItem{
+			Path:    it.Path,
+			ID:      it.ID,
+			Title:   it.Title,
+			Blocked: append([]string(nil), it.Blocked...),
+		}
+	}
+	return out
+}
+
+// jsonItems renders the unapplied status changes for the --json error payload.
+func (e *importVerifyError) jsonItems() []jsonErrorItem {
+	out := make([]jsonErrorItem, len(e.items))
+	for i, it := range e.items {
+		out[i] = jsonErrorItem{
+			Path:   it.Path,
+			ID:     it.ID,
+			Title:  it.Title,
+			Wanted: it.Wanted.String(),
+		}
+		if it.Observed {
+			out[i].Got = it.Got.String()
+		}
+	}
+	return out
 }

--- a/cmd/things/importcheck.go
+++ b/cmd/things/importcheck.go
@@ -10,11 +10,17 @@ import (
 	"github.com/ryanlewis/things-cli/internal/model"
 )
 
-// checklistItemType is the one payload item type that does not live in TMTask.
-// Checklist items have their own table and cannot repeat, so the repeating
-// check and the read-back both skip them rather than look up an id that
-// GetTaskByUUID could never resolve.
-const checklistItemType = "checklist-item"
+// unresolvableItemTypes are the payload item types GetTaskByUUID will never
+// return a row for, so the repeating check and the read-back skip them rather
+// than warn that Things does not know an id it knows perfectly well.
+//
+// Checklist items live in their own table, not TMTask. Headings are TMTask
+// rows but the lookups exclude the heading type (issue #146). Neither can
+// repeat or carry a status, so nothing is lost by skipping them.
+var unresolvableItemTypes = map[string]bool{
+	"checklist-item": true,
+	"heading":        true,
+}
 
 // importUpdate is one `operation: update` item found in an import payload,
 // reduced to the parts the repeating check and the status read-back need.
@@ -29,10 +35,10 @@ type importUpdate struct {
 }
 
 // resolvable reports whether the item names a row the CLI can look up. Items
-// without an id are Things' problem to report, and checklist items are not in
-// TMTask.
+// without an id are Things' problem to report, and checklist items and
+// headings are not reachable through GetTaskByUUID.
 func (u importUpdate) resolvable() bool {
-	return u.id != "" && u.itemType != checklistItemType
+	return u.id != "" && !unresolvableItemTypes[u.itemType]
 }
 
 // importPlan is what the pre-write pass learned about a payload: the update
@@ -112,11 +118,20 @@ func restrictedImportAttrs(attrs map[string]any) []string {
 
 // wantedStatus reports the status an update item asks Things to move the item
 // to. Both status fields are two-way, per the `update` command's parameter
-// table at repeatingDocsURL: `completed` is "Complete a to-do or set a to-do
-// to incomplete", `canceled` likewise, and each documents that setting the
-// other one to false on an item in that state also marks it incomplete. So a
-// literal `false` is a real request for `open`, not a no-op, and a dropped
-// reopen is as invisible as a dropped completion.
+// table at repeatingDocsURL, which is worth quoting because the cross-status
+// cases are the surprising ones:
+//
+//	completed: "Complete a to-do or set a to-do to incomplete. […] Setting
+//	           completed=false on a canceled to-do will also mark it as
+//	           incomplete."
+//	canceled:  "Cancel a to-do or set a to-do to incomplete. […] Setting
+//	           canceled=false on a completed to-do will also mark it as
+//	           incomplete."
+//
+// So a literal `false` asks for `open` whichever status the item is in — the
+// two sentences above cover the mismatched pairs explicitly — and a dropped
+// reopen is as invisible as a dropped completion. The item's current status is
+// therefore not needed here.
 //
 // `canceled` "Takes priority over `completed`", so it decides the outcome
 // whenever it is present — with one exception. The two entries disagree about

--- a/cmd/things/importcheck_test.go
+++ b/cmd/things/importcheck_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/json"
 	"os"
@@ -480,41 +481,164 @@ func TestImportReadsBackCanceledOverCompleted(t *testing.T) {
 	}
 }
 
-// Both import failures have to survive the --json error path (issue #152):
-// under --json the rendered object on stdout is all a consumer reads, so the
-// per-item detail must be inside it rather than on stderr.
-func TestImportFailuresRenderAsJSON(t *testing.T) {
-	t.Run("refusal", func(t *testing.T) {
-		database, _ := seedWritable(t)
-		stubExecDropping(t)
+// findItem returns the payload item at path, so an assertion names what it
+// wants instead of depending on slice order.
+func findItem(t *testing.T, items []jsonErrorItem, path string) jsonErrorItem {
+	t.Helper()
+	for _, it := range items {
+		if it.Path == path {
+			return it
+		}
+	}
+	t.Fatalf("no item at path %q in %+v", path, items)
+	return jsonErrorItem{}
+}
 
-		payload := `[{"type":"to-do","operation":"update","id":"rep-1","attributes":{"when":"today"}}]`
-		err := runWith(t, database, "--json", "import", "--file", importPayload(t, payload))
-		if err == nil {
-			t.Fatal("expected a refusal")
+// A refusal carries every offending item under --json, so an agent can fix the
+// payload per item rather than parsing them back out of the message (#161).
+func TestImportRefusalJSONItems(t *testing.T) {
+	database, _ := seedWritable(t)
+	calls := stubExecDropping(t)
+
+	payload := `[
+	  {"type":"to-do","operation":"update","id":"one-1","attributes":{"when":"today"}},
+	  {"type":"to-do","operation":"update","id":"rep-1","attributes":{"when":"today","deadline":"2026-05-01"}},
+	  {"type":"project","operation":"update","id":"repproj-1","attributes":{"canceled":true}}
+	]`
+	err := runWith(t, database, "--json", "import", "--file", importPayload(t, payload))
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	p, raw := decodePayload(t, err)
+
+	if p.Error != "import refused" {
+		t.Errorf("error token = %q, want %q (%s)", p.Error, "import refused", raw)
+	}
+	if len(p.Items) != 2 {
+		t.Fatalf("got %d items, want 2 (%s)", len(p.Items), raw)
+	}
+
+	todo := findItem(t, p.Items, "[1]")
+	if todo.ID != "rep-1" || todo.Title != "Water plants" {
+		t.Errorf("item = %+v, want id rep-1 / Water plants", todo)
+	}
+	if strings.Join(todo.Blocked, ",") != "when,deadline" {
+		t.Errorf("blocked = %v, want [when deadline]", todo.Blocked)
+	}
+	proj := findItem(t, p.Items, "[2]")
+	if proj.ID != "repproj-1" || strings.Join(proj.Blocked, ",") != "canceled" {
+		t.Errorf("item = %+v, want id repproj-1 blocked [canceled]", proj)
+	}
+
+	// The non-repeating item is not an offender and must not appear.
+	for _, it := range p.Items {
+		if it.ID == "one-1" {
+			t.Errorf("allowed item reported as an offender: %+v", it)
 		}
-		p, raw := decodePayload(t, err)
-		if !strings.Contains(p.Message, `[0] (id rep-1): "Water plants" is a repeating to-do — when`) {
-			t.Errorf("payload lost the per-item detail: %s", raw)
+	}
+	// The message still carries everything, for a human reading the JSON.
+	if !strings.Contains(p.Message, "2 of 3 update items") {
+		t.Errorf("message lost its summary: %s", p.Message)
+	}
+	if *calls != 0 {
+		t.Errorf("payload was sent to Things anyway (%d calls)", *calls)
+	}
+}
+
+// A read-back failure names the status asked for and the one the item is
+// actually in, so a caller can tell a dropped write from an unexpected state.
+func TestImportVerifyJSONItems(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	if _, err := sqlDB.Exec(`INSERT INTO TMTask (uuid, title, type, status, trashed, start) VALUES ('one-2', 'File taxes', 0, 0, 0, 2)`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Things applies the first and drops the second.
+	stubExecApplyingAll(t, sqlDB, map[string]int{"one-1": int(model.StatusCompleted)})
+
+	payload := `[
+	  {"type":"to-do","operation":"update","id":"one-1","attributes":{"completed":true}},
+	  {"type":"to-do","operation":"update","id":"one-2","attributes":{"canceled":true}}
+	]`
+	err := runWith(t, database, "--json", "import", "--file", importPayload(t, payload))
+	if err == nil {
+		t.Fatal("expected a read-back failure")
+	}
+	p, raw := decodePayload(t, err)
+
+	if p.Error != "import partially applied" {
+		t.Errorf("error token = %q, want %q (%s)", p.Error, "import partially applied", raw)
+	}
+	if len(p.Items) != 1 {
+		t.Fatalf("got %d items, want only the dropped one (%s)", len(p.Items), raw)
+	}
+	it := p.Items[0]
+	if it.Path != "[1]" || it.ID != "one-2" || it.Title != "File taxes" {
+		t.Errorf("item = %+v, want [1] / one-2 / File taxes", it)
+	}
+	if it.Wanted != "cancelled" || it.Got != "open" {
+		t.Errorf("wanted/got = %q/%q, want cancelled/open", it.Wanted, it.Got)
+	}
+	if len(it.Blocked) != 0 {
+		t.Errorf("read-back item should not carry blocked attributes: %+v", it)
+	}
+}
+
+// Nothing to observe means no `got`: the field is omitted rather than
+// reported as the zero status, which would read as "still open".
+func TestImportVerifyJSONOmitsGotWhenUnobserved(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	// Things reports success, then the row disappears before the read-back.
+	prev := things.SetExecCommandForTest(func(string, ...string) *exec.Cmd {
+		if _, err := sqlDB.Exec(`DELETE FROM TMTask WHERE uuid = 'one-1'`); err != nil {
+			t.Errorf("simulating deletion: %v", err)
 		}
+		return exec.Command("true")
 	})
+	t.Cleanup(func() { things.SetExecCommandForTest(prev) })
 
-	t.Run("readBack", func(t *testing.T) {
-		fastVerify(t)
-		database, sqlDB := seedWritable(t)
-		stubExecApplyingAll(t, sqlDB, nil)
+	payload := `[{"type":"to-do","operation":"update","id":"one-1","attributes":{"completed":true}}]`
+	err := runWith(t, database, "--json", "import", "--file", importPayload(t, payload))
+	if err == nil {
+		t.Fatal("expected a read-back failure")
+	}
+	p, raw := decodePayload(t, err)
+	if len(p.Items) != 1 {
+		t.Fatalf("got %d items, want 1 (%s)", len(p.Items), raw)
+	}
+	if p.Items[0].Got != "" {
+		t.Errorf("got = %q, want it omitted when nothing was observed", p.Items[0].Got)
+	}
+	if p.Items[0].Wanted != "completed" {
+		t.Errorf("wanted = %q, want completed", p.Items[0].Wanted)
+	}
+	if !strings.Contains(raw, `"wanted"`) || strings.Contains(raw, `"got"`) {
+		t.Errorf("payload should carry wanted but not got: %s", raw)
+	}
+}
 
-		payload := `[{"type":"to-do","operation":"update","id":"one-1","attributes":{"completed":true}}]`
-		err := runWith(t, database, "--json", "import", "--file", importPayload(t, payload))
-		if err == nil {
-			t.Fatal("expected a read-back failure")
-		}
-		p, raw := decodePayload(t, err)
-		if strings.Contains(p.Message, "listed above") {
-			t.Errorf("message points at detail a JSON reader never sees: %s", raw)
-		}
-		if !strings.Contains(p.Message, `"Post letter" (one-1) is still open`) {
-			t.Errorf("payload lost the per-item detail: %s", raw)
-		}
-	})
+// Plain text is unchanged by the typed errors: same message, on stderr, with
+// nothing on stdout.
+func TestImportFailuresPlainTextUnchanged(t *testing.T) {
+	database, _ := seedWritable(t)
+	stubExecDropping(t)
+
+	payload := `[{"type":"to-do","operation":"update","id":"rep-1","attributes":{"when":"today"}}]`
+	err := runWith(t, database, "import", "--file", importPayload(t, payload))
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	var stdout, stderr bytes.Buffer
+	renderError(&stdout, &stderr, false, err)
+	if stdout.Len() != 0 {
+		t.Errorf("plain text wrote to stdout: %q", stdout.String())
+	}
+	want := `Error: 1 of 1 update items change attributes Things does not allow on repeating items`
+	if !strings.HasPrefix(stderr.String(), want) {
+		t.Errorf("stderr = %q, want prefix %q", stderr.String(), want)
+	}
+	if !strings.Contains(stderr.String(), `  [0] (id rep-1): "Water plants" is a repeating to-do — when`) {
+		t.Errorf("stderr lost the per-item line: %q", stderr.String())
+	}
 }

--- a/cmd/things/importcheck_test.go
+++ b/cmd/things/importcheck_test.go
@@ -270,19 +270,37 @@ func TestImportWarnsAboutUnknownIDs(t *testing.T) {
 	}
 }
 
-// A checklist item lives outside TMTask, so looking its id up would always
-// come back empty and warn about an item that is perfectly valid.
-func TestImportDoesNotLookUpChecklistItems(t *testing.T) {
-	database, _ := seedWritable(t)
-	stubExecDropping(t)
-
-	payload := `[{"type":"checklist-item","operation":"update","id":"chk-1","attributes":{"completed":true}}]`
-	stderr, err := runImport(t, database, payload)
-	if err != nil {
-		t.Fatalf("import: %v", err)
+// Neither a checklist item nor a heading is reachable through GetTaskByUUID —
+// checklist items are in their own table, and the lookups exclude the heading
+// type (#149) — so looking either up would warn that Things does not know an
+// id it knows perfectly well.
+func TestImportDoesNotLookUpUnresolvableTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		item string
+		id   string
+	}{
+		{"checklistItem", `{"type":"checklist-item","operation":"update","id":"chk-1","attributes":{"completed":true}}`, "chk-1"},
+		{"heading", `{"type":"heading","operation":"update","id":"head-1","attributes":{"title":"Phase 2"}}`, "head-1"},
 	}
-	if strings.Contains(stderr, "chk-1") {
-		t.Errorf("checklist item was looked up:\n%s", stderr)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			database, sqlDB := seedWritable(t)
+			// A real heading row: the lookup filters it out by type, not by
+			// absence, so seeding it proves the skip is what keeps us quiet.
+			if _, err := sqlDB.Exec(`INSERT INTO TMTask (uuid, title, type, status, trashed) VALUES ('head-1', 'Phase 2', 2, 0, 0)`); err != nil {
+				t.Fatalf("seed heading: %v", err)
+			}
+			stubExecDropping(t)
+
+			stderr, err := runImport(t, database, "["+c.item+"]")
+			if err != nil {
+				t.Fatalf("import: %v", err)
+			}
+			if strings.Contains(stderr, c.id) {
+				t.Errorf("%s was looked up and warned about:\n%s", c.name, stderr)
+			}
+		})
 	}
 }
 

--- a/cmd/things/verify.go
+++ b/cmd/things/verify.go
@@ -68,9 +68,20 @@ type statusWant struct {
 	want  model.Status
 }
 
+// statusResult is the outcome for one item of a batch read-back. err is nil
+// when the change landed. got is the status actually seen on the final read,
+// which exists only when the item was read successfully and simply never
+// changed — observed says whether it does, since a read error or a deleted row
+// leaves nothing to report.
+type statusResult struct {
+	err      error
+	got      model.Status
+	observed bool
+}
+
 // verifyStatuses re-reads each item until its status matches the one requested,
 // and reports per item whether the change landed. The returned slice is
-// parallel to wants; a nil entry means that item is confirmed. Without this a
+// parallel to wants; a nil err means that item is confirmed. Without this a
 // write Things ignored is indistinguishable from one it applied.
 //
 // One budget covers the whole batch and items are polled in rounds, so an
@@ -82,8 +93,8 @@ type statusWant struct {
 // database while we poll, and a transient SQLITE_BUSY there must not turn a
 // write that landed into a reported failure. A read that keeps failing is
 // surfaced once the deadline passes.
-func verifyStatuses(database *db.DB, wants []statusWant, budget time.Duration) []error {
-	results := make([]error, len(wants))
+func verifyStatuses(database *db.DB, wants []statusWant, budget time.Duration) []statusResult {
+	results := make([]statusResult, len(wants))
 	pending := make([]int, len(wants))
 	for i := range wants {
 		pending[i] = i
@@ -101,17 +112,21 @@ func verifyStatuses(database *db.DB, wants []statusWant, budget time.Duration) [
 			switch {
 			case err != nil:
 				if expired {
-					results[i] = fmt.Errorf("verifying status change: %w", err)
+					results[i].err = fmt.Errorf("verifying status change: %w", err)
 					continue
 				}
 			case current == nil:
-				results[i] = fmt.Errorf("verifying status change: %s no longer exists in the Things database", w.uuid)
+				results[i].err = fmt.Errorf("verifying status change: %s no longer exists in the Things database", w.uuid)
 				continue
 			case current.Status == w.want:
 				continue
 			case expired:
-				results[i] = fmt.Errorf("status change did not apply: %q (%s) is still %s after %s. Things accepted the command and then dropped it silently — check that Things3 is running, or make the change in the app",
-					w.title, w.uuid, current.Status, budget)
+				results[i] = statusResult{
+					err: fmt.Errorf("status change did not apply: %q (%s) is still %s after %s. Things accepted the command and then dropped it silently — check that Things3 is running, or make the change in the app",
+						w.title, w.uuid, current.Status, budget),
+					got:      current.Status,
+					observed: true,
+				}
 				continue
 			}
 			next = append(next, i)
@@ -132,7 +147,7 @@ func verifyStatuses(database *db.DB, wants []statusWant, budget time.Duration) [
 // verifyStatus re-reads a single item until its status matches want, and
 // reports an error if it never does.
 func verifyStatus(database *db.DB, task *model.Task, want model.Status) error {
-	return verifyStatuses(database, []statusWant{{uuid: task.UUID, title: task.Title, want: want}}, verifyTimeout)[0]
+	return verifyStatuses(database, []statusWant{{uuid: task.UUID, title: task.Title, want: want}}, verifyTimeout)[0].err
 }
 
 // applyStatusWrite runs a status-changing write and confirms it landed, unless

--- a/cmd/things/verify_test.go
+++ b/cmd/things/verify_test.go
@@ -280,12 +280,15 @@ func TestVerifyStatusesShareOneDeadline(t *testing.T) {
 	}
 	errs := verifyStatuses(database, wants, verifyTimeout)
 
-	for i, err := range errs {
-		if err == nil {
+	for i, res := range errs {
+		if res.err == nil {
 			t.Fatalf("item %d reported as landed, but nothing changed its status", i)
 		}
-		if !strings.Contains(err.Error(), "status change did not apply") {
-			t.Errorf("item %d: unexpected error %v", i, err)
+		if !strings.Contains(res.err.Error(), "status change did not apply") {
+			t.Errorf("item %d: unexpected error %v", i, res.err)
+		}
+		if !res.observed || res.got != model.StatusOpen {
+			t.Errorf("item %d: want the observed status recorded as open, got (%v, observed=%v)", i, res.got, res.observed)
 		}
 	}
 	// One sleep per round, and rounds stop at the shared deadline: at most

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -32,6 +32,17 @@ Under `--json`, a failure prints a single JSON object to **stdout** and exits no
 
 This covers argument and flag errors too — `things --json show` with no argument returns the JSON object rather than a usage block. On `ambiguous task`, retry with one of the `matches[].uuid`. Without `--json`, errors stay as a plain `Error: ...` line on stderr.
 
+`import` fails per item, so its two failures add an `items` array — act on that rather than parsing `message`:
+
+```json
+{"error": "import refused", "message": "...",
+ "items": [{"path": "[0]", "id": "rep-1", "title": "Water plants", "blocked": ["when", "deadline"]}]}
+{"error": "import partially applied", "message": "...",
+ "items": [{"path": "[0]", "id": "one-1", "title": "Post letter", "wanted": "completed", "got": "open"}]}
+```
+
+The tokens differ because the recovery does. `import refused` sent nothing to Things: fix the named items and re-run the whole payload. `import partially applied` already wrote: re-run with **only** the items listed, or the ones that landed get re-applied. `path` locates the item in the payload you sent (`[0]`, or `[2].attributes.items[0]` when nested in a project), `blocked` names the attributes Things will not accept on a repeating item, and `wanted`/`got` are the status asked for versus the one still there. `got` is absent when the row could not be read or no longer exists.
+
 Human output is styled with colors and aligned columns. Color auto-disables when piping or when `NO_COLOR` is set. Override with `--color=always|never` (default `auto`). JSON output is unaffected.
 
 ## Core commands


### PR DESCRIPTION
## What changed

`import` acts on many items at once, but both of its failures rendered as the generic `{"error": "error", "message": "..."}` with the per-item detail flattened into the message, so a consumer had to parse English to work out which items to fix. Both now carry an `items` array.

**Refusal** — `blocked` names the attributes Things will not accept on that repeating item:

```json
{
  "error": "import refused",
  "message": "1 of 1 update items change attributes Things does not allow on repeating items, ...",
  "items": [
    { "path": "[0]", "id": "rep-1", "title": "Water plants", "blocked": ["when", "deadline"] }
  ]
}
```

**Read-back failure** — `wanted` and `got` are the status the payload asked for and the one the item is still in:

```json
{
  "error": "import partially applied",
  "message": "1 of 1 requested status changes did not apply. ...",
  "items": [
    { "path": "[0]", "id": "one-1", "title": "Post letter", "wanted": "completed", "got": "open" }
  ]
}
```

Both blocks above are the real output, copied from the encoder rather than written by hand.

The two are separate tokens because the recovery differs, which is the distinction an agent actually needs: `import refused` sent nothing, so the payload can be fixed and re-run whole; `import partially applied` already wrote, so a blind re-run would re-apply what landed. `path` locates the item in the payload the caller sent (`[0]`, or `[2].attributes.items[0]` when nested in a project), and `got` is omitted when there was nothing to observe — the row could not be read, or no longer exists.

`prepareImport` and `verifyImportStatuses` return typed errors carrying the items, and `errorPayload` gains a case for each, so the wire format stays in the one place #157 put it. `verifyStatuses` now reports the status it observed alongside the error, which is where `got` comes from.

## Why

This is the follow-up #151 deliberately left open. Widening the error contract belonged to a separate change rather than being smuggled into a bug fix.

## Backward compatibility

Additive. `items` is `omitempty`, every existing field is untouched, and commands that fail on a single item carry no `items` at all. The 17 JSON-error tests from #157 pass with **no edits to `errors_test.go`** — that file is not in this diff, which is the evidence rather than the claim.

Plain-text output is byte-for-byte unchanged: the typed errors reproduce the previous strings exactly, which is why the pre-existing message assertions still pass untouched, and `TestImportFailuresPlainTextUnchanged` pins it directly.

## How tested

`make test` (`-race`, `-count=2`), `make lint` (0 issues), `go vet` — all clean. New tests drive both failures through #157's own `decodePayload` helper: `TestImportRefusalJSONItems` (token, per-item `blocked`, non-offending items excluded, summary retained), `TestImportVerifyJSONItems` (only the dropped item, `wanted`/`got`, no stray `blocked`), `TestImportVerifyJSONOmitsGotWhenUnobserved` (row deleted mid-import — asserts `got` is absent from the raw JSON, not merely empty), and `TestImportFailuresPlainTextUnchanged`.

`TestImportDoesNotLookUpUnresolvableTypes` was checked against the un-fixed code: it fails with "heading was looked up and warned about".

## Also fixed

`GetTaskByUUID` excludes headings (#149), so an `operation: update` item of type `heading` resolved to nothing and the pre-write pass warned that Things does not know an id it knows perfectly well. Headings cannot repeat or carry a status, so they join checklist items in the skip list. Found by `/code-review` on this branch.

Closes #161