### PR TITLE
fix(cli): correct --json parse-failure handling and the tag hint's quoting

### DIFF
--- a/cmd/things/errors.go
+++ b/cmd/things/errors.go
@@ -12,8 +12,9 @@ import (
 
 // jsonErrorPayload is the machine-readable form of a command failure. Under
 // --json a failing command prints one of these to stdout and exits non-zero,
-// so a consumer reading stdout always gets JSON — success or failure — and can
-// branch on the "error" token instead of parsing English (issue #152).
+// so a consumer reading stdout sees a JSON failure rather than English prose,
+// and can branch on the "error" token (issue #152). A successful write command
+// still prints nothing — only the read commands emit JSON on success.
 //
 // Error is a stable token: "ambiguous task", "not found", or "error" for a
 // failure with no structure worth naming. Message is the same text the
@@ -116,6 +117,11 @@ func renderError(stdout, stderr io.Writer, asJSON bool, err error) {
 	}
 	enc := json.NewEncoder(stdout)
 	enc.SetIndent("", "  ")
+	// Message is meant to read as the plain-text error does. The default
+	// encoder escapes the three HTML-significant characters into \u00xx
+	// sequences, which turns a message like `expected "<task>"` into line
+	// noise for anyone reading the JSON.
+	enc.SetEscapeHTML(false)
 	if encErr := enc.Encode(errorPayload(err)); encErr != nil {
 		// Encoding a struct of strings can't realistically fail, but a broken
 		// stdout can — fall back to the plain line so the failure isn't silent.

--- a/cmd/things/errors_test.go
+++ b/cmd/things/errors_test.go
@@ -10,8 +10,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alecthomas/kong"
+
 	"github.com/ryanlewis/things-cli/internal/db"
 	"github.com/ryanlewis/things-cli/internal/db/dbtest"
+	"github.com/ryanlewis/things-cli/internal/skill"
+	"github.com/ryanlewis/things-cli/internal/things"
 )
 
 // stubTTY makes isInteractive report that stdin is a terminal for the duration
@@ -237,6 +241,17 @@ func TestRenderErrorGeneric(t *testing.T) {
 	}
 }
 
+// The message is meant to read as the plain-text line does, so the encoder
+// must not turn <, > and & into escape sequences.
+func TestRenderErrorDoesNotEscapeHTML(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	renderError(&stdout, &stderr, true, fmt.Errorf(`expected "<task>" & more`))
+
+	if !strings.Contains(stdout.String(), `expected \"<task>\" & more`) {
+		t.Errorf("message was escaped: %s", stdout.String())
+	}
+}
+
 // Plain-text mode is untouched: the line still goes to stderr, and stdout stays
 // empty so a `things ... > file` redirect is unaffected.
 func TestRenderErrorPlainTextUnchanged(t *testing.T) {
@@ -329,10 +344,127 @@ func TestJSONRequested(t *testing.T) {
 		{[]string{"--json=false", "show"}, false},
 		{[]string{"--json", "--json=false", "show"}, false},
 		{[]string{"add", "--", "--json"}, false},
+		// kong's bool mapper takes true/1/yes and false/0/no, case
+		// insensitively, so these are the same flag spelled differently.
+		{[]string{"--json=1", "show"}, true},
+		{[]string{"--json=yes", "show"}, true},
+		{[]string{"--json=YES", "show"}, true},
+		{[]string{"--json", "--json=0", "show"}, false},
+		{[]string{"--json", "--json=no", "show"}, false},
+		{[]string{"--json", "--json=No", "show"}, false},
+		// Values kong rejects: it will fail the parse, so the mode is left
+		// alone rather than guessed at. "T" is one of these — strconv.ParseBool
+		// would take it, kong does not.
+		{[]string{"--json=T", "show"}, false},
+		{[]string{"--json=maybe", "show"}, false},
+		// kong clusters boolean shorts, so -j can arrive inside one. Scanning
+		// stops at the first short that takes a value, because that one takes
+		// the rest of the cluster as its value.
+		{[]string{"-jv"}, true},
+		{[]string{"-vj", "show"}, true},
+		{[]string{"list", "-pj"}, false},
+		{[]string{"import", "-fj"}, false},
+		{[]string{"-j=false", "show"}, false},
+		{[]string{"-vj=false", "show"}, false},
+		{[]string{"-jv=false", "show"}, true},
+		{[]string{"-", "show"}, false},
+		{[]string{"--jsonish", "show"}, false},
 	}
 	for _, tc := range cases {
 		if got := jsonRequested(false, tc.args); got != tc.want {
-			t.Errorf("jsonRequested(%v) = %v, want %v", tc.args, got, tc.want)
+			t.Errorf("jsonRequested(false, %v) = %v, want %v", tc.args, got, tc.want)
+		}
+	}
+
+	// The config file supplies the starting value, so argv has to be able to
+	// turn it off — and a value kong will reject leaves it alone rather than
+	// silently flipping the mode.
+	if !jsonRequested(true, []string{"show"}) {
+		t.Error("config default should carry through")
+	}
+	if jsonRequested(true, []string{"--json=false", "show"}) {
+		t.Error("argv should be able to turn the config default off")
+	}
+	if jsonRequested(true, []string{"--json=no", "show"}) {
+		t.Error("argv should be able to turn the config default off with =no")
+	}
+	if !jsonRequested(true, []string{"--json=maybe", "show"}) {
+		t.Error("a value kong would reject should leave the mode alone")
+	}
+}
+
+// kongBool has to agree with kong's own bool mapper: the pre-parse read of
+// --json decides how a parse failure is rendered, so a value kong accepts must
+// not be ignored here, and one it rejects must not flip the mode.
+func TestKongBoolMatchesKong(t *testing.T) {
+	for _, v := range []string{"true", "1", "yes", "TRUE", "Yes", "false", "0", "no", "No", "t", "T", "f", "maybe", ""} {
+		var cli CLI
+		parser, err := kong.New(&cli, kong.Name("things"),
+			kong.Vars{
+				"builtin_lists": strings.Join(things.BuiltinLists, ", "),
+				"skill_agents":  skill.AgentNames(),
+			},
+		)
+		if err != nil {
+			t.Fatalf("kong.New: %v", err)
+		}
+		_, parseErr := parser.Parse([]string{"--json=" + v, "projects"})
+
+		got, ok := kongBool(v)
+		if ok != (parseErr == nil) {
+			t.Errorf("kongBool(%q) accepted = %v, but kong parse error = %v", v, ok, parseErr)
+			continue
+		}
+		if ok && got != cli.JSON {
+			t.Errorf("kongBool(%q) = %v, kong parsed %v", v, got, cli.JSON)
+		}
+	}
+}
+
+// boolShorts is hand-maintained, so check it still describes the real grammar:
+// every letter in it must be boolean on every command that uses it, and no
+// value-taking flag may share a letter with it.
+func TestBoolShortsMatchesGrammar(t *testing.T) {
+	var cli CLI
+	parser, err := kong.New(&cli, kong.Name("things"),
+		kong.Vars{
+			"builtin_lists": strings.Join(things.BuiltinLists, ", "),
+			"skill_agents":  skill.AgentNames(),
+		},
+	)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+
+	// letter -> whether every flag spelled with it takes no value.
+	allBool := map[byte]bool{}
+	var walk func(n *kong.Node)
+	walk = func(n *kong.Node) {
+		for _, f := range n.Flags {
+			if f.Short == 0 {
+				continue
+			}
+			c := byte(f.Short)
+			isBool := f.IsBool()
+			if prev, seen := allBool[c]; seen {
+				isBool = isBool && prev
+			}
+			allBool[c] = isBool
+		}
+		for _, child := range n.Children {
+			walk(child)
+		}
+	}
+	walk(parser.Model.Node)
+
+	for c := range boolShorts {
+		if !allBool[c] {
+			t.Errorf("boolShorts has %q, but the grammar has a value-taking flag spelled -%c", c, c)
+		}
+	}
+	for c, isBool := range allBool {
+		if isBool && !boolShorts[c] && c != 'h' {
+			t.Errorf("-%c is a boolean short the grammar knows and boolShorts does not — a cluster like -%cj would be missed", c, c)
 		}
 	}
 }

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -893,7 +893,7 @@ func main() {
 		// flag has to come from argv because parsing is what just failed.
 		if asJSON {
 			renderError(os.Stdout, os.Stderr, true, err)
-			os.Exit(1)
+			os.Exit(parseExitCode(err))
 		}
 		parser.FatalIfErrorf(err)
 	}
@@ -912,6 +912,28 @@ func main() {
 	}
 }
 
+// parseExitCode is the status kong would have exited with for a parse
+// failure: 80 for a usage error, 1 for one of the errors it raises without a
+// code of its own (a resolver or a hook). The --json branch above reports the
+// same failure kong would, so it has to exit the same way.
+func parseExitCode(err error) int {
+	var coder kong.ExitCoder
+	if errors.As(err, &coder) {
+		return coder.ExitCode()
+	}
+	return 1
+}
+
+// boolShorts are the single-letter flags that take no value. Only these can be
+// followed by more flags in a cluster: kong lets the first short that takes a
+// value swallow the rest of the cluster as that value. "f" is deliberately
+// absent — it is boolean on `config init` but a value flag on `import`, and
+// treating an ambiguous letter as value-taking only costs a fallback to kong's
+// plain-text usage, while the reverse would misread a filename.
+//
+// TestBoolShortsMatchesGrammar keeps this in step with the CLI struct.
+var boolShorts = map[byte]bool{'j': true, 'v': true, 'y': true}
+
 // jsonRequested reports whether argv asks for --json, starting from def — the
 // default the config file establishes. main needs the answer before kong has
 // parsed anything, because a parse error still has to be rendered in the mode
@@ -922,14 +944,67 @@ func jsonRequested(def bool, args []string) bool {
 		if a == "--" {
 			break
 		}
-		switch a {
-		case "-j", "--json", "--json=true":
-			asJSON = true
-		case "--json=false":
-			asJSON = false
+		flag, value, hasValue := strings.Cut(a, "=")
+		asks, takesValue := flagAsksJSON(flag)
+		if !asks {
+			continue
 		}
+		// --json=1 and --json=yes mean the same as --json. A value kong
+		// would not accept is kong's to complain about — leave the mode as
+		// it was rather than guess at what was meant.
+		on := true
+		if hasValue && takesValue {
+			b, ok := kongBool(value)
+			if !ok {
+				continue
+			}
+			on = b
+		}
+		asJSON = on
 	}
 	return asJSON
+}
+
+// kongBool parses an explicit flag value the way kong's bool mapper does:
+// true/1/yes and false/0/no, case-insensitively. strconv.ParseBool is a
+// different set — it takes "t" and "T" and rejects "yes" — so using it here
+// would disagree with the parser about what the caller asked for.
+func kongBool(v string) (value, ok bool) {
+	switch strings.ToLower(v) {
+	case "true", "1", "yes":
+		return true, true
+	case "false", "0", "no":
+		return false, true
+	}
+	return false, false
+}
+
+// flagAsksJSON reports whether one argv token names --json, and whether an
+// "=value" on it would belong to --json rather than to another flag in the
+// same cluster. Only a long flag really carries a value that way — kong does
+// not split a short on "=" at all, so `-j=false` is a parse error either way
+// — but answering for the cluster keeps a token like -vj=false from being
+// read as plain -j.
+//
+// kong clusters boolean shorts, so -vj is two flags and asks for JSON just as
+// -j does. Scanning stops at the first short that is not boolean, because that
+// one takes the rest of the cluster as its value: -pj is --project=j.
+func flagAsksJSON(flag string) (asks, takesValue bool) {
+	if flag == "--json" {
+		return true, true
+	}
+	if len(flag) < 2 || flag[0] != '-' || flag[1] == '-' {
+		return false, false
+	}
+	for i := 1; i < len(flag); i++ {
+		if flag[i] == 'j' {
+			return true, i == len(flag)-1
+		}
+		if !boolShorts[flag[i]] {
+			return false, false
+		}
+	}
+	return false, false
 }
 
 // isInteractive reports whether stdin is a terminal. It is a var so tests can

--- a/cmd/things/tags.go
+++ b/cmd/things/tags.go
@@ -3,9 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/ryanlewis/things-cli/internal/db"
 	"github.com/ryanlewis/things-cli/internal/output"
@@ -75,14 +75,45 @@ func verifyTags(d *Deps, flags TagFlags, names []string) error {
 // commas, so joining with ", " would suggest a command that creates a tag
 // literally named "foo," — hence a space-separated, quoted list.
 func tagAddHint(names []string) string {
-	parts := make([]string, 0, len(names))
+	parts := make([]string, 0, len(names)+1)
 	for _, n := range names {
-		if strings.ContainsAny(n, " \t\"'\\`$") {
-			n = strconv.Quote(n)
+		// A name that starts with a dash would be read as a flag, not a
+		// positional — quoting stops the shell eating it but not the CLI, so
+		// the hint has to end flag parsing first.
+		if strings.HasPrefix(n, "-") {
+			parts = append(parts, "--")
+			break
 		}
-		parts = append(parts, n)
+	}
+	for _, n := range names {
+		parts = append(parts, shellQuote(n))
 	}
 	return "things tag add " + strings.Join(parts, " ")
+}
+
+// shellQuote makes name safe to paste into a POSIX shell. A tag name is
+// arbitrary user text, so the hint has to survive `R&D` (which bash would
+// split into two commands) and `$HOME` (which double quotes would expand) —
+// single quotes are the only form that suppresses every expansion, with the
+// usual '\” dance for an embedded quote.
+func shellQuote(s string) string {
+	if s != "" && !strings.ContainsFunc(s, needsShellQuoting) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// needsShellQuoting reports whether r has any meaning to a shell. It is an
+// allow-list: anything outside it gets quoted, so a character the list forgot
+// is merely quoted unnecessarily rather than left live.
+func needsShellQuoting(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		return false
+	case r > unicode.MaxASCII:
+		return false
+	}
+	return !strings.ContainsRune("-_./:@+,%", r)
 }
 
 // createTags makes each missing tag in Things over AppleScript. It runs before

--- a/cmd/things/tags_test.go
+++ b/cmd/things/tags_test.go
@@ -300,8 +300,18 @@ func TestTagAddHint(t *testing.T) {
 	}{
 		{"one", []string{"focus"}, "things tag add focus"},
 		{"many", []string{"focus", "cifas-auto-reject"}, "things tag add focus cifas-auto-reject"},
-		{"spaces", []string{"deep work", "focus"}, `things tag add "deep work" focus`},
-		{"quote", []string{`ev"il`}, `things tag add "ev\"il"`},
+		{"spaces", []string{"deep work", "focus"}, `things tag add 'deep work' focus`},
+		{"quote", []string{`ev"il`}, `things tag add 'ev"il'`},
+		// Metacharacters bash would act on: & splits the command, $ and `
+		// expand inside double quotes. Single quotes suppress all of it.
+		{"ampersand", []string{"R&D"}, `things tag add 'R&D'`},
+		{"dollar", []string{"a$HOME"}, `things tag add 'a$HOME'`},
+		{"apostrophe", []string{"Ryan's"}, `things tag add 'Ryan'\''s'`},
+		{"empty", []string{""}, `things tag add ''`},
+		// Quoting stops the shell splitting a leading-dash name, but the CLI
+		// would still read it as a flag, so the hint has to end flag parsing.
+		{"leading dash", []string{"-p"}, "things tag add -- -p"},
+		{"dash later", []string{"focus", "--json"}, "things tag add -- focus --json"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -318,7 +328,7 @@ func TestStrictTagsErrorSuggestsAUsableCommand(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error under --strict-tags")
 	}
-	if !strings.Contains(err.Error(), "`things tag add cifas-auto-reject \"deep work\"`") {
+	if !strings.Contains(err.Error(), "`things tag add cifas-auto-reject 'deep work'`") {
 		t.Errorf("error does not suggest a usable command: %v", err)
 	}
 }

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -21,7 +21,7 @@ In JSON, `status` is a string enum — `"open"`, `"cancelled"`, or `"completed"`
 
 `--json` also means "never prompt": a reference that matches several tasks returns an error listing the candidates instead of dropping into the interactive picker, and a project `complete`/`cancel` declines rather than asking for confirmation.
 
-Under `--json`, a failure prints a single JSON object to **stdout** and exits non-zero, so parse stdout whether the command succeeded or not. The `error` field is a stable token; `message` is the human text.
+Under `--json`, a failure prints a single JSON object to **stdout** and exits non-zero, so branch on the exit status and read the failure off stdout rather than parsing stderr. (On success the read commands print their JSON result there; the write commands — `add`, `edit`, `complete`, `cancel`, `log`, `open` — print nothing.) The `error` field is a stable token; `message` is the human text.
 
 ```json
 {"error": "ambiguous task", "message": "...", "kind": "task", "query": "milk",


### PR DESCRIPTION
## What changed

Six small fixes to code already on main, all found by review passes on #162 and #163.

**`--json` parse failures (#157).**

- `renderError` used a default `json.Encoder`, which escapes `<`, `>` and `&` into `\u00xx`. Every kong parse error carries them, so the most common `--json` failure came out as `expected \"<task>\"` — line noise, in the field whose doc says it reads as the plain-text error does. `SetEscapeHTML(false)`.
- `jsonRequested` recognised only bare `--json` and `--json=true|false`, so `things --json=1 …` and `things --json=yes …` fell through to kong's usage block on stdout: exactly what the function exists to prevent. Values now go through `kongBool`, which mirrors kong's bool mapper — `true/1/yes`, `false/0/no`, case-insensitive. `strconv.ParseBool` was the wrong set in both directions: it accepts `T`, which kong rejects, and rejects `yes`, which kong accepts.
- It also missed clustered shorts, so `things -jv --bogus` did the same thing. It now walks a cluster and stops at the first short that takes a value, because that one swallows the rest of the cluster as its value — `-pj` is `--project=j`, not `--json`.
- The JSON branch exited 1 where kong's plain-text path exits 80, so the same failure returned a different code depending on the flag. `parseExitCode` now reads kong's own `ExitCoder`, which also gets the cases right where kong raises a parse error with no code of its own and exits 1 rather than 80 — this CLI installs a config resolver, so that path is reachable.
- `SKILL.md` and the `jsonErrorPayload` doc both told agents to parse stdout whether or not the command succeeded. The write commands (`add`, `edit`, `complete`, `cancel`, `log`, `open`) print nothing on success, so an agent following that tried to parse an empty string.

**Tag hint quoting (#150).**

`tagAddHint` builds a copy-pastable `things tag add …` suggestion, but quoted a handful of characters with `strconv.Quote`, which is Go syntax rather than shell. `things tag add R&D` backgrounds a command and runs `D`; `a;b` leaves an unquoted `;`; `"a$HOME"` expands. It now uses POSIX single-quoting driven by a character allow-list, so a character the list forgot is merely quoted unnecessarily rather than left live. A name starting with `-` also gets a `--` separator: quoting stops the shell splitting it but not kong reading it as a flag.

## Why the two hand-maintained lists have tests that derive them

`boolShorts` and `kongBool` both restate something kong owns, which is exactly the kind of thing that rots silently.

- `TestBoolShortsMatchesGrammar` walks the real kong model and fails if a boolean short exists that `boolShorts` does not list, or if a letter in `boolShorts` is value-taking anywhere. (`-f` is deliberately absent: boolean on `config init`, a value flag on `import`. Treating an ambiguous letter as value-taking only costs a fallback to kong's plain-text usage; the reverse would misread a filename.)
- `TestKongBoolMatchesKong` runs each candidate value through an actual `parser.Parse` and asserts `kongBool` agrees on both acceptance and result.

## How tested

`make test` (race) and `make lint` clean.

New and extended tests: the `jsonRequested` table gains cluster cases (`-jv`, `-vj`, `-pj`, `-fj`), `yes`/`no` casing, config-default interaction, and values kong rejects; `TestRenderErrorDoesNotEscapeHTML`; the two derivation tests above; and `tags_test.go` cases for `&`, `$`, `'`, empty, and a leading dash.

Checked against the built binary: `things --json show` → `{"error":"error","message":"expected \"<task>\""}` on stdout, exit 80, empty stderr. `things -jv --bogus` and `things --json=1 --bogus` likewise. `things -pj --bogus` correctly keeps kong's usage block, since `-pj` is not a JSON request. `things --json=T lst` also keeps the plain path, matching kong's rejection of `T`.

Closes #164