### PR TITLE
feat(complete): add --yes to complete and cancel so projects work non-interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ color = "always"
 strict_tags = true
 ```
 
-`assume_yes` answers every confirmation prompt: the project-wide
-`complete`/`cancel` question, and overwriting an installed agent skill.
+`assume_yes` answers the confirmation asked before a project-wide
+`complete` or `cancel`. It does not reach the `--yes` on `skill install`
+or `skill uninstall`, which mean "overwrite" and "delete" — those still
+ask, or take the flag.
 
 `strict_tags` and `create_tags` are mutually exclusive; setting both to
 `true` is an error. Either one is still overridden by the other's flag on
@@ -439,8 +441,10 @@ landed; `--no-verify` skips that. `--json` reports the two lists as
 | --- | --- |
 | `things complete <task>` | Mark a task or project as completed (project completion is confirmed interactively) |
 | `things cancel <task>` | Cancel a task or project (project cancellation is confirmed interactively) |
-| `-y, --yes` | On `complete`/`cancel`: answer the project confirmation up front |
 | `things log` | Move today's done/cancelled items to the Logbook (Items → Log Completed) |
+
+`complete` and `cancel` also take `-y` / `--yes`, which answers the project
+confirmation up front.
 
 `log` is the housekeeping action; `logbook` (above) is the *view* of
 already-archived tasks.
@@ -455,10 +459,16 @@ Completing or cancelling a *project* also completes or cancels every task in
 it, so it asks first. A run that cannot prompt — piped stdin, or `--json` —
 declines rather than guessing:
 
-```text
-$ things --json complete "Launch v2"
-Error: cancelled: complete project "Launch v2" needs confirmation, and this run cannot prompt — pass --yes, or re-run without --json
+```console
+$ things --json complete "Launch v2"; echo "exit=$?"
+{
+  "error": "error",
+  "message": "cancelled: complete project \"Launch v2\" needs confirmation, and this run cannot prompt — pass --yes, or re-run without --json"
+}
+exit=1
 ```
+
+Without `--json` the same refusal is a plain `Error: ...` line on stderr.
 
 `--yes` (`-y`) answers that confirmation, which is what makes project
 completion work from a script or an agent:
@@ -469,8 +479,10 @@ things --json complete "Launch v2" --yes
 
 Set `assume_yes = true` in the [config file](#configuration) to answer it every
 time. `--yes` still decides each run, so `--yes=false` restores the prompt for
-one invocation. It removes the last check before a project and all its tasks
-change status, so prefer passing the flag where you need it.
+one invocation. Turning `assume_yes` on removes the last check before a project
+and all its tasks change status, so prefer passing the flag where you need it.
+It covers `complete` and `cancel` only — the `--yes` on `skill install` and
+`skill uninstall` is not affected.
 
 After a `complete` or `cancel` the CLI reads the item back from the database
 and exits non-zero if the status did not change. Things has no callback for

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ in follow-up commands like `show`, `edit`, `complete`, and `cancel`.
 `--json` also implies non-interactive: the CLI never prompts, so a reference
 matching several tasks returns an error listing the candidates instead of
 opening the picker, and `complete`/`cancel` on a project declines instead of
-asking to confirm.
+asking to confirm. Pass `--yes` to answer the confirmation up front, which is
+how a project completes under `--json`.
 
 ### Errors under `--json`
 
@@ -124,11 +125,15 @@ snake_case form.
 | `no_verify` | `--no-verify` | boolean | `false` |
 | `strict_tags` | `--strict-tags` | boolean | `false` |
 | `create_tags` | `--create-tags` | boolean | `false` |
+| `assume_yes` | `--yes` | boolean | `false` |
 
 ```toml
 color = "always"
 strict_tags = true
 ```
+
+`assume_yes` answers every confirmation prompt: the project-wide
+`complete`/`cancel` question, and overwriting an installed agent skill.
 
 `strict_tags` and `create_tags` are mutually exclusive; setting both to
 `true` is an error. Either one is still overridden by the other's flag on
@@ -434,6 +439,7 @@ landed; `--no-verify` skips that. `--json` reports the two lists as
 | --- | --- |
 | `things complete <task>` | Mark a task or project as completed (project completion is confirmed interactively) |
 | `things cancel <task>` | Cancel a task or project (project cancellation is confirmed interactively) |
+| `-y, --yes` | On `complete`/`cancel`: answer the project confirmation up front |
 | `things log` | Move today's done/cancelled items to the Logbook (Items → Log Completed) |
 
 `log` is the housekeeping action; `logbook` (above) is the *view* of
@@ -444,6 +450,27 @@ things complete 3
 things cancel "Old idea"
 things log
 ```
+
+Completing or cancelling a *project* also completes or cancels every task in
+it, so it asks first. A run that cannot prompt — piped stdin, or `--json` —
+declines rather than guessing:
+
+```text
+$ things --json complete "Launch v2"
+Error: cancelled: complete project "Launch v2" needs confirmation, and this run cannot prompt — pass --yes, or re-run without --json
+```
+
+`--yes` (`-y`) answers that confirmation, which is what makes project
+completion work from a script or an agent:
+
+```sh
+things --json complete "Launch v2" --yes
+```
+
+Set `assume_yes = true` in the [config file](#configuration) to answer it every
+time. `--yes` still decides each run, so `--yes=false` restores the prompt for
+one invocation. It removes the last check before a project and all its tasks
+change status, so prefer passing the flag where you need it.
 
 After a `complete` or `cancel` the CLI reads the item back from the database
 and exits non-zero if the status did not change. Things has no callback for

--- a/cmd/things/confirm.go
+++ b/cmd/things/confirm.go
@@ -1,0 +1,9 @@
+package main
+
+// ConfirmFlags is embedded in the commands that ask before a project-wide
+// write. Kong resolves --yes from the config file's `assume_yes` key as well,
+// so the prompt can be turned off once for machine use with the flag still
+// deciding each run.
+type ConfirmFlags struct {
+	Yes bool `help:"Skip the confirmation prompt and proceed." short:"y" name:"yes"`
+}

--- a/cmd/things/confirm_test.go
+++ b/cmd/things/confirm_test.go
@@ -158,28 +158,66 @@ func TestConfigAssumeYesSeedsTheFlag(t *testing.T) {
 	}
 }
 
-// assume_yes seeds every --yes on the CLI, not just complete/cancel — the
-// skill commands share the flag name, and the docs say so.
-func TestConfigAssumeYesReachesSkillOverwrite(t *testing.T) {
-	isolateHome(t)
-	path := writeConfig(t, "assume_yes = true\n")
-	args := []string{"--config", path, "skill", "install", "claude", "--path", filepath.Join(t.TempDir(), "skills")}
+// The skill commands have a --yes of their own that means "overwrite" and
+// "delete". assume_yes is about the project confirmation and must not reach
+// them, or a config file written to automate `complete` would also make
+// `skill uninstall` delete without asking.
+func TestConfigAssumeYesDoesNotReachSkillCommands(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		got  func(*CLI) bool
+	}{
+		{"install", []string{"skill", "install", "claude"}, func(c *CLI) bool { return c.Skill.Install.Yes }},
+		{"uninstall", []string{"skill", "uninstall", "claude"}, func(c *CLI) bool { return c.Skill.Uninstall.Yes }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			path := writeConfig(t, "assume_yes = true\n")
+			args := append([]string{"--config", path}, tc.args...)
+			args = append(args, "--path", filepath.Join(t.TempDir(), "skills"))
 
-	var cli CLI
-	cfg, err := loadConfig(args)
-	if err != nil {
-		t.Fatalf("loadConfig: %v", err)
+			var cli CLI
+			cfg, err := loadConfig(args)
+			if err != nil {
+				t.Fatalf("loadConfig: %v", err)
+			}
+			parser, err := kong.New(&cli, parserOptions(cfg)...)
+			if err != nil {
+				t.Fatalf("kong.New: %v", err)
+			}
+			if _, err := parser.Parse(args); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if tc.got(&cli) {
+				t.Errorf("assume_yes = true reached skill %s --yes", tc.name)
+			}
+		})
 	}
-	parser, err := kong.New(&cli, parserOptions(cfg)...)
-	if err != nil {
-		t.Fatalf("kong.New: %v", err)
-	}
-	if _, err := parser.Parse(args); err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	if !cli.Skill.Install.Yes {
-		t.Error("assume_yes = true did not reach skill install --yes")
-	}
+
+	// The flag itself still works there, which is what makes the config key's
+	// silence the deliberate part.
+	t.Run("flag still works", func(t *testing.T) {
+		isolateHome(t)
+		path := writeConfig(t, "")
+		args := []string{"--config", path, "skill", "uninstall", "claude", "--yes"}
+		var cli CLI
+		cfg, err := loadConfig(args)
+		if err != nil {
+			t.Fatalf("loadConfig: %v", err)
+		}
+		parser, err := kong.New(&cli, parserOptions(cfg)...)
+		if err != nil {
+			t.Fatalf("kong.New: %v", err)
+		}
+		if _, err := parser.Parse(args); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if !cli.Skill.Uninstall.Yes {
+			t.Error("--yes on skill uninstall should still work")
+		}
+	})
 }
 
 // The template has to keep loading cleanly now that it carries assume_yes.

--- a/cmd/things/confirm_test.go
+++ b/cmd/things/confirm_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/ryanlewis/things-cli/internal/db"
+	"github.com/ryanlewis/things-cli/internal/db/dbtest"
+)
+
+// seedProject returns a writable in-memory DB holding one open project, plus
+// the raw handle so the exec stub can apply the status change to it.
+func seedProject(t *testing.T) (*db.DB, *sql.DB) {
+	t.Helper()
+	sqlDB := dbtest.NewSQL(t)
+	stmts := []string{
+		`INSERT INTO TMSettings (uuid, uriSchemeAuthenticationToken) VALUES ('s1', 'tok')`,
+		`INSERT INTO TMTask (uuid, title, type, status, trashed)
+		 VALUES ('proj-1', 'Chores', 1, 0, 0)`,
+	}
+	for _, s := range stmts {
+		if _, err := sqlDB.Exec(s); err != nil {
+			t.Fatalf("seed %q: %v", s, err)
+		}
+	}
+	return db.NewFromSQL(sqlDB), sqlDB
+}
+
+// The point of issue #158: --json makes the run non-interactive, so a project
+// complete could never succeed for a machine caller. --yes is the way through.
+func TestProjectStatusChangeUnderJSONNeedsYes(t *testing.T) {
+	cases := []struct {
+		name   string
+		verb   string
+		status int
+	}{
+		{"complete", "complete", 3},
+		{"cancel", "cancel", 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("declines without --yes", func(t *testing.T) {
+				fastVerify(t)
+				database, sqlDB := seedProject(t)
+				stubExecApplying(t, sqlDB, "proj-1", tc.status)
+
+				err := runWith(t, database, "--json", tc.verb, "Chores")
+				if err == nil {
+					t.Fatal("want a cancelled error, got nil")
+				}
+				if !strings.Contains(err.Error(), "--yes") {
+					t.Errorf("error %q should point at --yes", err)
+				}
+			})
+
+			t.Run("proceeds with --yes", func(t *testing.T) {
+				fastVerify(t)
+				database, sqlDB := seedProject(t)
+				stubExecApplying(t, sqlDB, "proj-1", tc.status)
+
+				if err := runWith(t, database, "--json", tc.verb, "Chores", "--yes"); err != nil {
+					t.Fatalf("%s --yes under --json: %v", tc.verb, err)
+				}
+				var got int
+				if err := sqlDB.QueryRow(`SELECT status FROM TMTask WHERE uuid = 'proj-1'`).Scan(&got); err != nil {
+					t.Fatalf("read back status: %v", err)
+				}
+				if got != tc.status {
+					t.Errorf("status = %d, want %d", got, tc.status)
+				}
+			})
+		})
+	}
+}
+
+// A terminal run with --yes must not prompt either; stubTTY(true) with no
+// stdin to read would otherwise decline.
+func TestProjectStatusChangeYesSkipsPromptOnTerminal(t *testing.T) {
+	stubTTY(t, true)
+	fastVerify(t)
+	database, sqlDB := seedProject(t)
+	stubExecApplying(t, sqlDB, "proj-1", 3)
+
+	if err := runWith(t, database, "complete", "Chores", "--yes"); err != nil {
+		t.Fatalf("complete --yes: %v", err)
+	}
+}
+
+func TestConfirmProjectStatusChangeAssumeYes(t *testing.T) {
+	stubTTY(t, false)
+	if err := confirmProjectStatusChange(&Deps{JSON: true}, true, "Complete", "Chores"); err != nil {
+		t.Errorf("assumeYes under --json: %v", err)
+	}
+	if err := confirmProjectStatusChange(&Deps{}, true, "Cancel", "Chores"); err != nil {
+		t.Errorf("assumeYes on a pipe: %v", err)
+	}
+}
+
+// A to-do is not a project, so it never reaches the confirmation at all —
+// --yes must be accepted there and change nothing.
+func TestYesOnAPlainTaskIsHarmless(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	stubExecApplying(t, sqlDB, "one-1", 3)
+
+	if err := runWith(t, database, "complete", "one-1", "--yes"); err != nil {
+		t.Fatalf("complete a to-do with --yes: %v", err)
+	}
+}
+
+func TestConfigAssumeYesSeedsTheFlag(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		args []string
+		want bool
+	}{
+		{"config on", "assume_yes = true\n", nil, true},
+		{"config off", "assume_yes = false\n", nil, false},
+		{"unset", "", nil, false},
+		{"flag beats config off", "assume_yes = false\n", []string{"--yes"}, true},
+		{"flag beats config on", "assume_yes = true\n", []string{"--yes=false"}, false},
+		{"yes spelling accepted", "yes = true\n", nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+			path := writeConfig(t, tc.body)
+
+			for _, verb := range []string{"complete", "cancel"} {
+				args := append([]string{"--config", path, verb, "Chores"}, tc.args...)
+				var cli CLI
+				cfg, err := loadConfig(args)
+				if err != nil {
+					t.Fatalf("loadConfig: %v", err)
+				}
+				parser, err := kong.New(&cli, parserOptions(cfg)...)
+				if err != nil {
+					t.Fatalf("kong.New: %v", err)
+				}
+				if _, err := parser.Parse(args); err != nil {
+					t.Fatalf("parse %v: %v", args, err)
+				}
+				got := cli.Complete.Yes
+				if verb == "cancel" {
+					got = cli.Cancel.Yes
+				}
+				if got != tc.want {
+					t.Errorf("%s --yes = %v, want %v", verb, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// assume_yes seeds every --yes on the CLI, not just complete/cancel — the
+// skill commands share the flag name, and the docs say so.
+func TestConfigAssumeYesReachesSkillOverwrite(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "assume_yes = true\n")
+	args := []string{"--config", path, "skill", "install", "claude", "--path", filepath.Join(t.TempDir(), "skills")}
+
+	var cli CLI
+	cfg, err := loadConfig(args)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	parser, err := kong.New(&cli, parserOptions(cfg)...)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cli.Skill.Install.Yes {
+		t.Error("assume_yes = true did not reach skill install --yes")
+	}
+}
+
+// The template has to keep loading cleanly now that it carries assume_yes.
+func TestConfigInitTemplateStillLoads(t *testing.T) {
+	isolateHome(t)
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if _, err := runOut(t, nil, "--config", path, "config", "init"); err != nil {
+		t.Fatalf("config init: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("template not written: %v", err)
+	}
+	if _, err := loadConfig([]string{"--config", path}); err != nil {
+		t.Fatalf("loadConfig(template): %v", err)
+	}
+}

--- a/cmd/things/errors_test.go
+++ b/cmd/things/errors_test.go
@@ -342,7 +342,7 @@ func TestJSONRequested(t *testing.T) {
 func TestConfirmProjectStatusChangeNonInteractiveExplains(t *testing.T) {
 	stubTTY(t, true)
 
-	err := confirmProjectStatusChange(&Deps{JSON: true}, "Complete", "Chores")
+	err := confirmProjectStatusChange(&Deps{JSON: true}, false, "Complete", "Chores")
 	if err == nil {
 		t.Fatal("--json must decline")
 	}
@@ -359,7 +359,7 @@ func TestConfirmProjectStatusChangeNonInteractiveExplains(t *testing.T) {
 	// Piped stdin without --json hits the same branch; the advice there is to
 	// use a terminal, not to drop a flag that was never passed.
 	stubTTY(t, false)
-	err = confirmProjectStatusChange(&Deps{}, "Cancel", "Chores")
+	err = confirmProjectStatusChange(&Deps{}, false, "Cancel", "Chores")
 	if err == nil {
 		t.Fatal("a non-terminal run must decline")
 	}

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -542,6 +542,7 @@ func (c *EditCmd) Run(d *Deps) error {
 
 type CompleteCmd struct {
 	Task string `arg:"" required:"" help:"Task title, UUID, or numeric index from last list."`
+	ConfirmFlags
 }
 
 func (c *CompleteCmd) Run(d *Deps) error {
@@ -558,7 +559,7 @@ func (c *CompleteCmd) Run(d *Deps) error {
 	}
 	write := func() error { return things.CompleteTask(task.UUID) }
 	if task.Type == model.TypeProject {
-		if err := confirmProjectStatusChange(d, "Complete", task.Title); err != nil {
+		if err := confirmProjectStatusChange(d, c.Yes, "Complete", task.Title); err != nil {
 			return err
 		}
 		write = func() error { return things.CompleteProject(task.UUID) }
@@ -568,6 +569,7 @@ func (c *CompleteCmd) Run(d *Deps) error {
 
 type CancelCmd struct {
 	Task string `arg:"" required:"" help:"Task title, UUID, or numeric index from last list."`
+	ConfirmFlags
 }
 
 func (c *CancelCmd) Run(d *Deps) error {
@@ -584,7 +586,7 @@ func (c *CancelCmd) Run(d *Deps) error {
 	}
 	write := func() error { return things.CancelTask(task.UUID) }
 	if task.Type == model.TypeProject {
-		if err := confirmProjectStatusChange(d, "Cancel", task.Title); err != nil {
+		if err := confirmProjectStatusChange(d, c.Yes, "Cancel", task.Title); err != nil {
 			return err
 		}
 		write = func() error { return things.CancelProject(task.UUID) }
@@ -1022,13 +1024,18 @@ func resolveTask(d *Deps, ref string, database *db.DB) (*model.Task, error) {
 // confirmProjectStatusChange gates a project-wide complete/cancel behind a
 // confirmation. When the run cannot prompt — piped stdin, or --json, which
 // never prompts — say so instead of returning a bare "cancelled" the caller
-// has no way to interpret.
-func confirmProjectStatusChange(d *Deps, verb, title string) error {
+// has no way to interpret. assumeYes is the caller's --yes: it answers the
+// question up front, which is the only way a machine caller can get through
+// this at all.
+func confirmProjectStatusChange(d *Deps, assumeYes bool, verb, title string) error {
+	if assumeYes {
+		return nil
+	}
 	action := strings.ToLower(verb)
 	if !d.interactive() {
-		reason := "re-run in a terminal"
+		reason := "pass --yes, or re-run in a terminal"
 		if d.JSON {
-			reason = "re-run without --json"
+			reason = "pass --yes, or re-run without --json"
 		}
 		return fmt.Errorf("cancelled: %s project %q needs confirmation, and this run cannot prompt — %s", action, title, reason)
 	}

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -132,7 +132,15 @@ afterwards to confirm it landed, which `--no-verify` skips.
 ```sh
 things complete 3
 things cancel 3
+things complete "Launch v2" --yes    # skip the project confirmation
 ```
+
+Completing or cancelling a project also completes or cancels every task
+in it, so it asks first. A run that cannot prompt — piped stdin, or
+`--json` — declines instead of guessing; `--yes` (`-y`) answers the
+question up front, which is how project completion works from a script.
+`assume_yes = true` in the config file sets it every time, and `--yes`
+still decides each run.
 
 Both go through AppleScript so Things3 records the change in its
 activity log. Task creation (`add`) and edits go through the
@@ -227,11 +235,15 @@ PATH` or `THINGS_CLI_CONFIG`. A missing file is not an error.
 | `no_verify` | `--no-verify` | boolean | `false` |
 | `strict_tags` | `--strict-tags` | boolean | `false` |
 | `create_tags` | `--create-tags` | boolean | `false` |
+| `assume_yes` | `--yes` | boolean | `false` |
 
 ```toml
 color = "always"
 strict_tags = true
 ```
+
+`assume_yes` answers every confirmation prompt: the project-wide
+`complete`/`cancel` question, and overwriting an installed agent skill.
 
 `strict_tags` and `create_tags` are mutually exclusive; setting both to
 `true` is an error.

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -242,8 +242,10 @@ color = "always"
 strict_tags = true
 ```
 
-`assume_yes` answers every confirmation prompt: the project-wide
-`complete`/`cancel` question, and overwriting an installed agent skill.
+`assume_yes` answers the confirmation asked before a project-wide
+`complete` or `cancel`. It does not reach the `--yes` on `skill install`
+or `skill uninstall`, which mean "overwrite" and "delete" — those still
+ask, or take the flag.
 
 `strict_tags` and `create_tags` are mutually exclusive; setting both to
 `true` is an error.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/alecthomas/kong"
@@ -56,6 +57,7 @@ type Key struct {
 	Default  any      // built-in default; bool or string
 	Enum     []string // permitted values, for keys with a fixed set
 	Excludes []string // keys this one cannot be combined with
+	Commands []string // commands whose flags this key may seed; empty means all
 	Comment  []string // template comment, one line per entry
 	Example  string   // template assignment, written commented out
 }
@@ -130,15 +132,17 @@ var Keys = []Key{
 		Example: "create_tags = false",
 	},
 	{
-		Name:    "assume_yes",
-		Flag:    "yes",
-		Default: false,
+		Name:     "assume_yes",
+		Flag:     "yes",
+		Default:  false,
+		Commands: []string{"complete", "cancel"},
 		Comment: []string{
-			"Answer yes to confirmation prompts instead of asking. Same as",
-			"--yes / -y. Covers the project-wide complete and cancel prompts,",
-			"and overwriting an installed agent skill.",
+			"Answer the confirmation asked before a project-wide complete or",
+			"cancel, instead of prompting. Same as --yes / -y on those two",
+			"commands; the --yes on `skill install` and `skill uninstall` is",
+			"deliberately not covered, so this cannot delete an installed skill.",
 			"Turning this on removes the last check before a project and every",
-			"task in it is completed or cancelled.",
+			"task in it changes status.",
 		},
 		Example: "assume_yes = false",
 	},
@@ -365,6 +369,7 @@ func (f *File) JSON() bool {
 func (f *File) Resolver() kong.Resolver {
 	values := map[string]any{}
 	excludes := map[string][]string{}
+	commands := map[string][]string{}
 	path := ""
 	if f != nil {
 		path = f.Path
@@ -388,11 +393,18 @@ func (f *File) Resolver() kong.Resolver {
 			}
 			values[k.Flag] = v
 			excludes[k.Flag] = excludingFlags(k)
+			commands[k.Flag] = k.Commands
 		}
 	}
 	return kong.ResolverFunc(func(_ *kong.Context, parent *kong.Path, flag *kong.Flag) (any, error) {
 		v, ok := values[flag.Name]
 		if !ok {
+			return nil, nil
+		}
+		// A key restricted to certain commands must not seed a same-named flag
+		// elsewhere: `--yes` also means "overwrite" and "delete" on the skill
+		// commands, and assume_yes is not asking for either.
+		if cmds := commands[flag.Name]; len(cmds) > 0 && !slices.Contains(cmds, parent.Node().Path()) {
 			return nil, nil
 		}
 		// A flag on the command line beats the file, and so does the flag it

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,6 +129,19 @@ var Keys = []Key{
 		},
 		Example: "create_tags = false",
 	},
+	{
+		Name:    "assume_yes",
+		Flag:    "yes",
+		Default: false,
+		Comment: []string{
+			"Answer yes to confirmation prompts instead of asking. Same as",
+			"--yes / -y. Covers the project-wide complete and cancel prompts,",
+			"and overwriting an installed agent skill.",
+			"Turning this on removes the last check before a project and every",
+			"task in it is completed or cancelled.",
+		},
+		Example: "assume_yes = false",
+	},
 }
 
 // KeyNames lists the canonical key names in declaration order.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -135,8 +135,8 @@ strict_tags = true
 	if !f.Exists {
 		t.Error("Exists = false for a file that is there")
 	}
-	want := map[string]any{"json": true, "color": "never", "no_verify": true, "strict_tags": true, "db": "", "create_tags": false}
-	source := map[string]string{"json": "config", "color": "config", "no_verify": "config", "strict_tags": "config", "db": "default", "create_tags": "default"}
+	want := map[string]any{"json": true, "color": "never", "no_verify": true, "strict_tags": true, "db": "", "create_tags": false, "assume_yes": false}
+	source := map[string]string{"json": "config", "color": "config", "no_verify": "config", "strict_tags": "config", "db": "default", "create_tags": "default", "assume_yes": "default"}
 	for _, s := range f.Settings() {
 		if s.Value != want[s.Key] {
 			t.Errorf("%s = %v, want %v", s.Key, s.Value, want[s.Key])
@@ -168,7 +168,7 @@ func TestLoadRejectsBadFiles(t *testing.T) {
 		body string
 		want []string
 	}{
-		{"unknown key", "nope = 1\n", []string{"unknown key", `"nope"`, "json, color, db, no_verify, strict_tags, create_tags"}},
+		{"unknown key", "nope = 1\n", []string{"unknown key", `"nope"`, "json, color, db, no_verify, strict_tags, create_tags, assume_yes"}},
 		{"malformed", "json = \n", []string{"invalid TOML", "line 1"}},
 		{"wrong type", `json = "yes"` + "\n", []string{`key "json" must be a boolean`, "got string"}},
 		{"table value", "[json]\na = 1\n", []string{`key "json" must be a boolean`, "got table"}},

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -39,7 +39,7 @@ Human output is styled with colors and aligned columns. Color auto-disables when
 
 The user may have a TOML config file (`~/.config/things-cli/config.toml`, or `$XDG_CONFIG_HOME/things-cli/config.toml`) that changes what the flags default to. Precedence is flag > config file > built-in default. Keys: `json`, `color`, `db`, `no_verify`, `strict_tags`, `create_tags`, `assume_yes`.
 
-This means the defaults you would otherwise assume may not hold — `json = true` makes every command emit JSON, `no_verify = true` turns off the read-back that confirms a `complete`/`cancel` landed, and `assume_yes = true` removes the confirmation before a project and all its tasks change status.
+This means the defaults you would otherwise assume may not hold — `json = true` makes every command emit JSON, `no_verify = true` turns off the read-back that confirms a `complete`/`cancel` landed, and `assume_yes = true` removes the confirmation before a project and all its tasks change status (it covers `complete` and `cancel` only).
 
 - Pass the flags you depend on explicitly. Use `--json` when you want JSON and `--json=false` when you want the plain listing; do not infer the format from a bare invocation.
 - `things config show` prints the file in use and the defaults it establishes (`--json` for machine-readable). `things config path` prints just the path and whether it exists.

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -7,6 +7,7 @@ today, upcoming, projects, or areas on macOS.
 
 - Reads (`list`, `show`, `projects`, `areas`, `tags`, `search`) are safe — use freely.
 - Writes (`add`, `project add`, `edit`, `tag add`, `complete`, `cancel`, `log`, `open`) modify the user's real data. Confirm before destructive ones (`complete`, `cancel`, bulk `edit`).
+- `complete`/`cancel` on a *project* also changes every task in it, so the CLI asks first and `--yes` is what skips that. Ask the user before passing it — the flag is there so a non-interactive run can proceed, not so the check can be dropped.
 - `edit`, `project edit`, and `import` payloads with `operation: update` require *Things → Settings → General → Enable Things URLs*. The error to recognise: `update: auth token is required — enable Things URLs in Things → Settings → General …`.
 - `--complete` and `--cancel` are mutually exclusive on `edit` and `project edit`.
 - `complete` and `cancel` (and `edit --complete` / `--cancel`) read the item back afterwards and exit non-zero if the status did not change. Treat a non-zero exit as "the task is still open" — do not report it as done.
@@ -19,7 +20,7 @@ Tasks and projects carry `"repeating": true` in JSON when Things treats them as 
 
 In JSON, `status` is a string enum — `"open"`, `"cancelled"`, or `"completed"` (not the raw Things integer) — on tasks, projects, and checklist items. Filter with e.g. `jq 'select(.status=="open")'`.
 
-`--json` also means "never prompt": a reference that matches several tasks returns an error listing the candidates instead of dropping into the interactive picker, and a project `complete`/`cancel` declines rather than asking for confirmation.
+`--json` also means "never prompt": a reference that matches several tasks returns an error listing the candidates instead of dropping into the interactive picker, and a project `complete`/`cancel` declines rather than asking for confirmation. Pass `--yes` to answer that confirmation up front — under `--json` it is the only way a project completes at all.
 
 Under `--json`, a failure prints a single JSON object to **stdout** and exits non-zero, so parse stdout whether the command succeeded or not. The `error` field is a stable token; `message` is the human text.
 
@@ -36,9 +37,9 @@ Human output is styled with colors and aligned columns. Color auto-disables when
 
 ## Config file changes the defaults
 
-The user may have a TOML config file (`~/.config/things-cli/config.toml`, or `$XDG_CONFIG_HOME/things-cli/config.toml`) that changes what the flags default to. Precedence is flag > config file > built-in default. Keys: `json`, `color`, `db`, `no_verify`, `strict_tags`, `create_tags`.
+The user may have a TOML config file (`~/.config/things-cli/config.toml`, or `$XDG_CONFIG_HOME/things-cli/config.toml`) that changes what the flags default to. Precedence is flag > config file > built-in default. Keys: `json`, `color`, `db`, `no_verify`, `strict_tags`, `create_tags`, `assume_yes`.
 
-This means the defaults you would otherwise assume may not hold — `json = true` makes every command emit JSON, and `no_verify = true` turns off the read-back that confirms a `complete`/`cancel` landed.
+This means the defaults you would otherwise assume may not hold — `json = true` makes every command emit JSON, `no_verify = true` turns off the read-back that confirms a `complete`/`cancel` landed, and `assume_yes = true` removes the confirmation before a project and all its tasks change status.
 
 - Pass the flags you depend on explicitly. Use `--json` when you want JSON and `--json=false` when you want the plain listing; do not infer the format from a bare invocation.
 - `things config show` prints the file in use and the defaults it establishes (`--json` for machine-readable). `things config path` prints just the path and whether it exists.
@@ -77,8 +78,10 @@ things add <title> [--notes --when --deadline --tags --checklist --project --hea
 things project add <title> [--notes --when --deadline --tags --area --todos --strict-tags --create-tags]
 things project edit <project> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --area --area-id --complete --cancel --duplicate --reveal --strict-tags --create-tags]
 things edit <task> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --checklist --prepend-checklist --append-checklist --list --list-id --heading --heading-id --complete --cancel --duplicate --reveal --strict-tags --create-tags]
-things complete <task>          # task or project; project completion asks to confirm
-things cancel <task>            # task or project; project cancellation asks to confirm
+things complete <task> [-y|--yes]  # task or project; project completion asks to confirm
+things cancel <task> [-y|--yes]   # task or project; project cancellation asks to confirm
+    # --yes answers the project confirmation; required under --json, which
+    # never prompts. It has no effect on a plain to-do, which is not confirmed.
 things log                      # move Today → Logbook
 things --no-verify complete <task>   # skip the read-back (rarely needed; also applies to import)
 things open [<ref>] [-p P | -a A | -t T | -q Q] [--filter T1,T2] [--background]
@@ -223,3 +226,4 @@ things --json list today | jq '.[] | .title'
 - After a `list`/`search`, numeric indices stay valid until the next one.
 - Use `things open` when the user wants to *see* something in the app rather than read data back.
 - Check `things config show` before assuming a default. Pass `--json` explicitly rather than relying on the config file.
+- Completing or cancelling a project also completes or cancels every task in it. Confirm with the user first, then pass `--yes` — under `--json` the command declines without it.


### PR DESCRIPTION
## What changed

`complete` and `cancel` gain `--yes` / `-y`, which answers the confirmation asked before a project-wide status change.

Completing or cancelling a project also completes or cancels every task in it, so the CLI asks first. A run that cannot prompt — piped stdin, or `--json`, which never prompts — declined with no way through, so project completion was impossible for a script or an agent. `--yes` answers the question up front.

The message shown when a run cannot prompt now names the flag:

```
cancelled: complete project "Launch v2" needs confirmation, and this run cannot prompt — pass --yes, or re-run without --json
```

`--yes` has no effect on a plain to-do, which is never confirmed.

## Config key

`assume_yes` (built on the registry from #159) sets it once, with the flag still deciding each run — `--yes=false` restores the prompt for one invocation.

I picked `assume_yes` over `yes`. In a file, `yes = true` reads as an assertion with no object — it does not say what is being answered. `assume_yes = true` reads as the policy it is, and it matches the phrasing used by other tools (`apt -y` is "assume yes"). `yes` is still accepted as an alias, the same way every key accepts its flag spelling.

## Why

Closes #158. Flagged by the #152 worker in PR #157.

## A note on scope

`assume_yes` seeds `--yes` on `complete` and `cancel` only.

The first cut resolved on flag name alone, which meant it also satisfied the `--yes` on `skill install` and `skill uninstall`, where the same flag means "overwrite" and "delete". `/code-review` confirmed it end to end: with `assume_yes = true`, `things skill uninstall claude` deleted the installed file with no prompt. A config file written so a script can complete a project should not do that.

So `config.Key` gained a `Commands` field: a key may name the commands whose flags it seeds, and an empty list keeps the previous behaviour of matching every flag with that name. `assume_yes` names `complete` and `cancel`. The `--yes` flag on the skill commands still works when passed directly.

## How tested

`make test` (`go test -race ./...`) and `make lint` both clean.

New tests in `cmd/things/confirm_test.go`:

- `complete` and `cancel` on a project under `--json`: declines without `--yes` with a message naming the flag, and with `--yes` writes the status through and reads it back from the DB.
- `--yes` on a terminal skips the prompt rather than reading stdin.
- `--yes` on a plain to-do is a no-op.
- `confirmProjectStatusChange` with `assumeYes` returns nil on both non-interactive paths.
- The config key seeding both commands' flags, six cases: config on, config off, unset, `--yes` beating `assume_yes = false`, `--yes=false` beating `assume_yes = true`, and the `yes` alias spelling.
- `assume_yes = true` NOT reaching `skill install --yes` or `skill uninstall --yes`, plus the flag still working there when passed.
- The `config init` template still round-trips now that it carries the new key.

Manually confirmed against a scratch config that `things --config … skill uninstall claude --path DIR` still refuses and leaves the file in place with `assume_yes = true` set.

## Files

`cmd/things/confirm.go` (new, the `ConfirmFlags` embed), `cmd/things/confirm_test.go` (new), `cmd/things/main.go` (the two command structs, the confirmation call, and the reason string), `internal/config/config.go` (`Commands` on `Key`, the `assume_yes` entry, the resolver check), `internal/config/config_test.go`, `cmd/things/errors_test.go` (call-site arity), `README.md`, `docs/_tabs/commands.md`, `internal/skill/SKILL.md`.

`main.go` hunks are confined to `CompleteCmd`, `CancelCmd`, and `confirmProjectStatusChange`, clear of the `renderError` / `jsonRequested` area being changed for #164.

SKILL.md tells agents to pass `--yes` when completing a project under `--json`, and to ask the user first — the flag exists so a non-interactive run can proceed, not so the check can be dropped.

Closes #158
