### PR TITLE
fix(views): list repeating project templates, hide them from things projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ project literally called `Inbox` would need `things -p Inbox`.
 | `upcoming` | Scheduled tasks and deadlines |
 | `anytime` | Anytime list |
 | `someday` | Someday list |
-| `repeating` | Repeating to-do templates |
+| `repeating` | Repeating to-do and project templates |
 | `logbook` | Completed tasks |
 | `trash` | Trashed tasks |
 | `deadlines` | Tasks with a deadline |
@@ -197,6 +197,18 @@ the template appears in `things repeating`; the generated to-dos are ordinary
 tasks and show up in `today`, `upcoming` and the rest as usual. Templates are
 kept out of every other view except `trash` and `logbook`, which report what
 the database holds.
+
+Projects repeat the same way, so `things repeating` lists project templates
+too — marked `(project)` in plain output, `"type": 1` in JSON — and
+`things projects` leaves them out. To-do templates come first, then project
+templates. `trash` and `logbook` are to-do lists, so a project template never
+shows there.
+
+`things search` is a lookup rather than a view: it searches the database as
+it stands and returns templates along with everything else, so a title you
+can see in the Things app is always findable. Search results carry
+`"repeating": true`, and `things show` prints a `Repeats:` line, so a
+template is identifiable when one comes back.
 
 A template and the to-do it generated share a title, so a title lookup —
 `things show`, `edit`, `complete`, `cancel` — resolves to the generated to-do,

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -19,10 +19,16 @@ things <view>          # shortcut: things inbox, things today, etc.
 Available views: `today`, `inbox`, `upcoming`, `anytime`, `someday`,
 `repeating`, `logbook`, `trash`, `deadlines`.
 
-`repeating` lists repeating to-do templates. The to-dos a template generates
-are ordinary tasks and appear in `today`, `upcoming` and the rest; the
-template itself appears only here, and in `trash` or `logbook` if it ends up
-there.
+`repeating` lists repeating to-do and project templates. The items a template
+generates are ordinary to-dos and projects and appear in `today`, `upcoming`,
+`things projects` and the rest; the template itself appears only here — plus
+`trash` or `logbook` for a to-do template that ends up there, since those two
+report what the database holds. Both are to-do lists, so a project template
+never shows in them. Project templates are marked `(project)` in plain output
+and carry `"type": 1` in JSON.
+
+`things search` is a lookup rather than a view, so it returns templates too.
+Results carry `"repeating": true`.
 
 Filter any list with `-p/--project`, `-a/--area`, or `-t/--tag`. On their
 own the filters cover every open task in the project, area, or tag; add a

--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -27,6 +27,13 @@ func (d *DB) ListProjects(areaFilter string, includeCompleted bool) ([]model.Pro
 	`
 	var args []any
 
+	// A repeating project is stored as a template plus the projects it
+	// generates. Things files the template under Repeating, not under
+	// Projects, so `things repeating` lists it and this does not (issue
+	// #165). On a schema with no recurrence column the reference degrades to
+	// NULL and the clause is a no-op.
+	query += " AND " + d.recurrenceCol() + " IS NULL"
+
 	if !includeCompleted {
 		query += " AND t.status = 0"
 	}

--- a/internal/db/projects_test.go
+++ b/internal/db/projects_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"testing"
 
+	"github.com/ryanlewis/things-cli/internal/db/dbtest"
 	"github.com/ryanlewis/things-cli/internal/model"
 )
 
@@ -106,5 +107,53 @@ func TestListProjectsCarriesTagsAndCounts(t *testing.T) {
 	}
 	if p.AreaTitle != "Work" {
 		t.Errorf("area title: got %q", p.AreaTitle)
+	}
+}
+
+// A repeating project is stored as a template plus the projects it generates.
+// Things files the template under Repeating, so `things projects` must not
+// list it — the same leak #147 fixed for to-dos (issue #165).
+func TestListProjectsExcludesRepeatingTemplates(t *testing.T) {
+	d := newTestDB(t)
+	seedProjects(t, d)
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, area, "index",
+		 untrashedLeafActionsCount, openUntrashedLeafActionsCount, rt1_recurrenceRule) VALUES
+		('p-tmpl', 'Weekly review', 1, 0, 0, 'area-work', 3, 0, 0, x'0102'),
+		('p-done', 'Old repeat',    1, 3, 0, 'area-work', 4, 0, 0, x'0102')`)
+
+	for _, includeCompleted := range []bool{false, true} {
+		projects, err := d.ListProjects("", includeCompleted)
+		if err != nil {
+			t.Fatalf("ListProjects(includeCompleted=%v): %v", includeCompleted, err)
+		}
+		for _, p := range projects {
+			if p.UUID == "p-tmpl" || p.UUID == "p-done" {
+				t.Errorf("includeCompleted=%v: template %s listed, want it excluded", includeCompleted, p.UUID)
+			}
+		}
+		// The ordinary projects are untouched.
+		if !includeCompleted && len(projects) != 3 {
+			t.Errorf("got %d open projects, want the same 3 as without templates: %+v", len(projects), projects)
+		}
+	}
+}
+
+// A schema carrying no recurrence column must still list projects rather than
+// failing the query outright.
+func TestListProjectsWithoutRecurrenceColumn(t *testing.T) {
+	sqlDB := dbtest.NewSQL(t)
+	if _, err := sqlDB.Exec(`ALTER TABLE TMTask DROP COLUMN rt1_recurrenceRule`); err != nil {
+		t.Fatalf("drop column: %v", err)
+	}
+	d := &DB{db: sqlDB}
+	seedProjects(t, d)
+
+	projects, err := d.ListProjects("", false)
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	if len(projects) != 3 {
+		t.Errorf("got %d, want 3: %+v", len(projects), projects)
 	}
 }

--- a/internal/db/repeating_test.go
+++ b/internal/db/repeating_test.go
@@ -1,9 +1,11 @@
 package db
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/ryanlewis/things-cli/internal/db/dbtest"
+	"github.com/ryanlewis/things-cli/internal/model"
 )
 
 func seedRepeatingPair(t *testing.T) *DB {
@@ -191,5 +193,57 @@ func TestTableColumnsUnknownTable(t *testing.T) {
 	}
 	if len(cols) != 0 {
 		t.Errorf("tableColumns(NoSuchTable) = %v, want empty", cols)
+	}
+}
+
+// A project can repeat too, and the app's Repeating list shows both kinds, so
+// the view is the one place that is not pinned to t.type = 0 (issue #165).
+// Ordering by type keeps to-dos and projects in contiguous blocks.
+func TestRepeatingViewIncludesProjectTemplates(t *testing.T) {
+	d := newTestDB(t)
+
+	// The project carries the lower "index", so index order alone would put it
+	// first: only the type-first ORDER BY yields the order asserted below.
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, "index", rt1_recurrenceRule) VALUES
+		('p-tmpl',   'Weekly review', 1, 0, 0, 2, 0, 1, x'0102'),
+		('t-tmpl',   'Water plants',  0, 0, 0, 2, 0, 2, x'0102')`)
+
+	// Neither an ordinary project nor an ordinary to-do belongs here.
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, "index") VALUES
+		('p-plain', 'Ship it',    1, 0, 0, 1, 0, 3),
+		('t-plain', 'Post letter', 0, 0, 0, 2, 0, 4)`)
+
+	got, err := d.ListTasks("repeating", TaskFilter{})
+	if err != nil {
+		t.Fatalf("ListTasks(repeating): %v", err)
+	}
+	if want := []string{"t-tmpl", "p-tmpl"}; !slices.Equal(uuidsOf(got), want) {
+		t.Fatalf("ListTasks(repeating) = %v, want %v (to-dos before projects)", uuidsOf(got), want)
+	}
+	if got[1].Type != model.TypeProject {
+		t.Errorf("project template Type = %d, want %d", got[1].Type, model.TypeProject)
+	}
+	if !got[0].Repeating || !got[1].Repeating {
+		t.Errorf("both rows should carry Repeating = true, got %v and %v", got[0].Repeating, got[1].Repeating)
+	}
+}
+
+// Headings carry no recurrence rule, but the view no longer pins t.type = 0,
+// so a heading must not be able to reach it.
+func TestRepeatingViewExcludesHeadings(t *testing.T) {
+	d := newTestDB(t)
+
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, "index", rt1_recurrenceRule) VALUES
+		('h-odd', 'A heading', 2, 0, 0, 1, 0, 1, x'0102')`)
+
+	got, err := d.ListTasks("repeating", TaskFilter{})
+	if err != nil {
+		t.Fatalf("ListTasks(repeating): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ListTasks(repeating) = %v, want no headings", uuidsOf(got))
 	}
 }

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -152,11 +152,15 @@ var viewFilters = map[string]string{
 	"logbook":   "t.status = 3 AND t.trashed = 0 AND t.type = 0",
 	"trash":     "t.trashed = 1 AND t.type = 0",
 	"deadlines": "t.deadline IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
-	// Things' Repeating list: the templates that generate to-dos, not the
-	// to-dos they generate. A template carries the recurrence rule; each
-	// generated instance is an ordinary row with no rule of its own, so
-	// "{{repeating}} IS NOT NULL" selects templates alone (issue #147).
-	"repeating": repeatingPlaceholder + " IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type = 0",
+	// Things' Repeating list: the templates that generate to-dos and
+	// projects, not the items they generate. A template carries the
+	// recurrence rule; each generated instance is an ordinary row with no
+	// rule of its own, so "{{repeating}} IS NOT NULL" selects templates
+	// alone (issue #147). Unlike every other view this one is not pinned to
+	// t.type = 0: a project can repeat too, and the app's Repeating list
+	// shows both kinds, so the view carries project templates as well and
+	// `things projects` leaves them out (issue #165).
+	"repeating": repeatingPlaceholder + " IS NOT NULL AND t.status = 0 AND t.trashed = 0 AND t.type IN (0, 1)",
 	// The catch-all open set: also the default view for a bare --project/
 	// --area/--tag filter.
 	"project": "t.status = 0 AND t.trashed = 0 AND t.type = 0",
@@ -172,6 +176,10 @@ var notHeading = fmt.Sprintf("COALESCE(t.type, 0) != %d", model.TypeHeading)
 var viewOrderBy = map[string]string{
 	"logbook":   "ORDER BY t.stopDate DESC",
 	"deadlines": "ORDER BY t.deadline ASC",
+	// Repeating holds both to-dos and projects. Ordering by type first keeps
+	// the two kinds in contiguous blocks instead of interleaving them by an
+	// index that is only meaningful within a kind.
+	"repeating": "ORDER BY t.type ASC, t.\"index\" ASC",
 	// Today view: top-level items (no project, no area) come first, then
 	// everything else sorted by area then project index. Project tasks and
 	// area-only tasks interleave by area.index — so projects in a low-index

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -82,6 +82,13 @@ func printTasks(w io.Writer, tasks []model.Task) error {
 		if t.Start == model.StartAnytime && t.StartBucket == 0 && t.StartDate != nil {
 			title = starStyle.Render("★") + " " + title
 		}
+		// A task list is normally to-dos only, but `things repeating` carries
+		// project templates too and `things search` can turn up a project, so
+		// say which rows are projects rather than letting them read as
+		// to-dos. Text, not just colour, so it survives --color never.
+		if t.Type == model.TypeProject {
+			title += " " + dimStyle.Render("(project)")
+		}
 
 		var date string
 		switch {
@@ -196,6 +203,13 @@ func printTaskDetail(w io.Writer, t *model.Task, items []model.ChecklistItem) er
 	fmt.Fprintf(w, "%s%s\n", label("Title:"), t.Title)
 	fmt.Fprintf(w, "%s%s\n", label("UUID:"), t.UUID)
 	fmt.Fprintf(w, "%s%s\n", label("Status:"), statusText(t.Status))
+	// A lookup resolves projects as well as to-dos, and `things repeating`
+	// hands out indexes for project templates, so say when the thing being
+	// shown is a project rather than leaving its detail block reading as a
+	// to-do's. To-do output is unchanged.
+	if t.Type == model.TypeProject {
+		fmt.Fprintf(w, "%s%s\n", label("Type:"), "project")
+	}
 	if t.ProjectTitle != "" {
 		fmt.Fprintf(w, "%s%s\n", label("Project:"), projectStyle.Render(t.ProjectTitle))
 	}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -358,3 +358,54 @@ func TestPrintTaskListJSONIgnoresViewLabel(t *testing.T) {
 		t.Errorf("got %+v, want one task u1", got)
 	}
 }
+
+// `things repeating` lists project templates alongside to-do templates, and
+// `things search` can turn up a project, so a project row has to say so in
+// plain output rather than reading as a to-do (issue #165). The marker is
+// text, not colour, so it survives --color never and a pipe.
+func TestPrintTasksMarksProjects(t *testing.T) {
+	tasks := []model.Task{
+		{UUID: "t1", Title: "Water plants", Type: model.TypeTask, Status: model.StatusOpen},
+		{UUID: "p1", Title: "Weekly review", Type: model.TypeProject, Status: model.StatusOpen},
+	}
+	var buf bytes.Buffer
+	if err := Print(&buf, tasks, false); err != nil {
+		t.Fatalf("Print: %v", err)
+	}
+	out := buf.String()
+
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.Contains(line, "Weekly review"):
+			if !strings.Contains(line, "(project)") {
+				t.Errorf("project row not marked:\n%s", line)
+			}
+		case strings.Contains(line, "Water plants"):
+			if strings.Contains(line, "(project)") {
+				t.Errorf("to-do row marked as a project:\n%s", line)
+			}
+		}
+	}
+}
+
+// `things show` on a project template must not print a block indistinguishable
+// from a to-do's (issue #165). To-do detail output stays as it was.
+func TestPrintTaskDetailMarksProjects(t *testing.T) {
+	var buf bytes.Buffer
+	project := &model.Task{UUID: "p1", Title: "Weekly review", Type: model.TypeProject, Status: model.StatusOpen}
+	if err := PrintTaskWithChecklist(&buf, project, nil, false); err != nil {
+		t.Fatalf("PrintTaskWithChecklist: %v", err)
+	}
+	if out := buf.String(); !strings.Contains(out, "project") {
+		t.Errorf("project detail does not say it is a project:\n%s", out)
+	}
+
+	buf.Reset()
+	todo := &model.Task{UUID: "t1", Title: "Water plants", Type: model.TypeTask, Status: model.StatusOpen}
+	if err := PrintTaskWithChecklist(&buf, todo, nil, false); err != nil {
+		t.Fatalf("PrintTaskWithChecklist: %v", err)
+	}
+	if out := buf.String(); strings.Contains(out, "Type:") {
+		t.Errorf("to-do detail gained a Type line:\n%s", out)
+	}
+}

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -49,6 +49,7 @@ This means the defaults you would otherwise assume may not hold — `json = true
 ```
 things list [view] [--project P] [--area A] [--tag T] [--on D | --from D --to D] [--include-completed]
     # views: today, inbox, upcoming, anytime, someday, repeating, logbook, trash, deadlines
+    # repeating holds to-do AND project templates; every other view is to-dos only
     # shortcut: `things today`, `things inbox`, etc.
     # No view: bare `things` is today, but --project/--area/--tag on their own
     # list every open task in that project/area/tag. Name a view to scope the
@@ -102,6 +103,10 @@ things config init [--force]    # write a commented template
 ### Repeating to-dos and projects
 
 A repeating to-do is stored as a template plus the to-dos it generates. `things repeating` lists the templates; they do not appear in `someday` or any other view except `trash` and `logbook`, which report what the database holds. The generated to-dos carry no recurrence rule of their own, so they list as ordinary tasks under `today`, `upcoming` and the rest.
+
+Projects repeat the same way. `things repeating` lists project templates too — marked `(project)` in plain output, `"type": 1` in JSON, to-dos first then projects — and `things projects` leaves them out. `trash` and `logbook` are to-do lists, so a project template never shows there. `things show` on a project prints a `Type: project` line. `trash` and `logbook` are to-do lists, so a project template never shows there.
+
+`things search` is a lookup, not a view: it searches the database as it stands and returns templates like anything else. Results carry `"repeating": true`, so check that field before trying to write to a search hit.
 
 A template and its generated to-do share a title, so a title lookup — `things show/edit/complete/cancel <title>` — resolves to the generated to-do, the one that can actually be completed. To reach the template, use its UUID or the numeric index from `things repeating`.
 


### PR DESCRIPTION
## What changed

A project repeats the same way a to-do does: a template row carrying the recurrence rule, plus the projects it generates. The `repeating` view added in #147 pinned `t.type = 0`, so a project template appeared nowhere at all, while `ListProjects` had no template exclusion and listed it in `things projects` as an ordinary project.

- `repeating` is now the one view not pinned to `t.type = 0` — it takes types 0 and 1, matching the app's Repeating list, which shows both kinds. Headings cannot reach it: they carry no recurrence rule, and type 2 is outside the set (there is a test for this, since dropping the type pin removes the guard that used to be implicit).
- `ListProjects` excludes rows carrying a recurrence rule, through the same probed column reference the views use, so a schema without that column degrades to a no-op.
- The view orders by type before index, keeping to-dos and projects in contiguous blocks rather than interleaving them by an index that is only meaningful within a kind.

### Marking projects in output

Plain output marks a project row `(project)`, and the detail view prints a `Type: project` line, so a project template is not left reading as a to-do. Both are text rather than colour, so they survive `--color never` and a pipe. JSON already carried `"type": 1`. This also covers `things search`, which could already return an unmarked project. To-do output is unchanged in both cases.

### Search

`things search` deliberately stays a raw lookup: it searches the database as it stands and returns templates like anything else, so a title visible in the Things app is always findable. Results carry `"repeating": true` and `things show` prints a `Repeats:` line, so a template is identifiable when one comes back. The docs said templates were kept out of every view but search; that wording is now fixed rather than the behaviour.

## How tested

- `make test` (race) and `make lint` — both green.
- New tests: project templates appear in `repeating` ordered after to-do templates and carry `Type`/`Repeating`; headings stay out; `ListProjects` excludes templates with and without `--completed` and leaves ordinary projects untouched; `ListProjects` still works on a schema with no recurrence column; and the two output markers, each asserting to-do output is unchanged.
- I confirmed each new test fails without its fix by reverting the three changes in turn.
- Checked against a read-only copy of the real Things database: it holds no repeating projects, so nothing shifts there — 12 projects and 2 to-do templates, both unchanged.

## Left out

The to-dos *inside* a template project have no guard: they carry no recurrence rule themselves, so they still list in `anytime`/`someday`/`upcoming` with a `projectTitle` pointing at a project `things projects` no longer reports. Same class as #147 and #155. I have not fixed it here because I cannot confirm the row layout — this machine's database has no repeating projects — and a wrong guard would hide real to-dos. It also needs an alias-parameterised recurrence helper, since the current one only emits the `t` alias. Worth its own issue, checked against a database that actually has a repeating project.

Closes #165