### PR TITLE
fix(views): hide the to-dos inside a repeating project template

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ too — marked `(project)` in plain output, `"type": 1` in JSON — and
 templates. `trash` and `logbook` are to-do lists, so a project template never
 shows there.
 
+The to-dos inside a project template are hidden along with it. They carry no
+recurrence rule of their own, so they are recognised by their project rather
+than by themselves — otherwise they would list as ordinary tasks against a
+project `things projects` does not report. `trash` and `logbook` still show
+them once they are trashed or logged.
+
 `things search` is a lookup rather than a view: it searches the database as
 it stands and returns templates along with everything else, so a title you
 can see in the Things app is always findable. Search results carry

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -27,6 +27,10 @@ report what the database holds. Both are to-do lists, so a project template
 never shows in them. Project templates are marked `(project)` in plain output
 and carry `"type": 1` in JSON.
 
+The to-dos inside a project template are hidden along with it, since they
+would otherwise list against a project `things projects` does not report.
+`trash` and `logbook` still show them once they are trashed or logged.
+
 `things search` is a lookup rather than a view, so it returns templates too.
 Results carry `"repeating": true`.
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -13,11 +13,12 @@ import (
 type DB struct {
 	db *sql.DB
 
-	// repeatSQL caches the probed recurrence-column reference and
-	// repeatQuery the task query built from it; see (*DB).probeRepeating.
-	repeatOnce  sync.Once
-	repeatSQL   string
-	repeatQuery string
+	// repeatColumn caches the probed recurrence-column name ("" when the
+	// schema carries none) and repeatQuery the task query built from it; see
+	// (*DB).probeRepeating.
+	repeatOnce   sync.Once
+	repeatColumn string
+	repeatQuery  string
 }
 
 // FindDBPath locates the Things3 SQLite database.

--- a/internal/db/repeating.go
+++ b/internal/db/repeating.go
@@ -23,17 +23,36 @@ var recurrenceColumns = []string{"rt1_recurrenceRule", "recurrenceRule"}
 // syntactically, so `t."rt1_recurrenceRule" IS NOT NULL` uses it while
 // `CASE WHEN ... END = 1` falls back to scanning every task.
 func (d *DB) recurrenceCol() string {
+	return d.recurrenceColFor("t")
+}
+
+// recurrenceColFor is recurrenceCol against an arbitrary TMTask alias. The
+// `p` alias — the row's resolved parent project — is what tells a to-do
+// inside a repeating project template apart from an ordinary one: the child
+// carries no rule of its own, only its project does (issue #171).
+func (d *DB) recurrenceColFor(alias string) string {
 	d.probeRepeating()
-	return d.repeatSQL
+	return recurrenceRef(alias, d.repeatColumn)
+}
+
+// recurrenceRef builds the reference without probing, so probeRepeating can
+// use it while holding its sync.Once — recurrenceColFor cannot, since
+// re-entering Once.Do deadlocks.
+func recurrenceRef(alias, column string) string {
+	if column == "" {
+		return "NULL"
+	}
+	return alias + `."` + column + `"`
 }
 
 // probeRepeating resolves the recurrence column reference and the assembled
 // task query once per DB.
 func (d *DB) probeRepeating() {
 	d.repeatOnce.Do(func() {
-		d.repeatSQL = "NULL"
+		// repeatColumn stays "" — the reference degrades to NULL — unless
+		// the probe finds a column below.
 		defer func() {
-			d.repeatQuery = strings.Replace(baseTaskQuery, repeatingPlaceholder, d.repeatSQL, 1)
+			d.repeatQuery = strings.Replace(baseTaskQuery, repeatingPlaceholder, recurrenceRef("t", d.repeatColumn), 1)
 		}()
 		cols, err := d.tableColumns("TMTask")
 		if err != nil {
@@ -41,7 +60,7 @@ func (d *DB) probeRepeating() {
 		}
 		for _, c := range recurrenceColumns {
 			if cols[c] {
-				d.repeatSQL = `t."` + c + `"`
+				d.repeatColumn = c
 				return
 			}
 		}

--- a/internal/db/repeating_test.go
+++ b/internal/db/repeating_test.go
@@ -1,8 +1,10 @@
 package db
 
 import (
+	"fmt"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/ryanlewis/things-cli/internal/db/dbtest"
 	"github.com/ryanlewis/things-cli/internal/model"
@@ -245,5 +247,130 @@ func TestRepeatingViewExcludesHeadings(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("ListTasks(repeating) = %v, want no headings", uuidsOf(got))
+	}
+}
+
+// A to-do inside a repeating project template must not list as an ordinary
+// task: `things projects` does not report its project, so it would show
+// against a project the user cannot see (issue #171). Each case seeds the row
+// shape its view selects on, once inside a repeating project template and
+// once inside an ordinary project — the sibling proves the guard discriminates
+// rather than just hiding everything.
+func TestTemplateProjectChildrenExcludedFromOpenViews(t *testing.T) {
+	today := int64(model.ThingsDateFromTime(time.Now()))
+	tomorrow := today + (1 << 7)
+
+	cases := []struct {
+		view    string
+		columns string
+		values  string
+	}{
+		{"inbox", "start, startBucket", "0, 0"},
+		{"today", "start, startBucket, startDate", fmt.Sprintf("1, 0, %d", today)},
+		{"upcoming", "start, startBucket, startDate", fmt.Sprintf("2, 0, %d", tomorrow)},
+		{"anytime", "start, startBucket", "1, 0"},
+		{"someday", "start, startBucket", "2, 0"},
+		{"deadlines", "start, startBucket, deadline", fmt.Sprintf("1, 0, %d", tomorrow)},
+		{"project", "start, startBucket", "1, 0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.view, func(t *testing.T) {
+			d := newTestDB(t)
+			// The child carries no recurrence rule — only its project does,
+			// which is why the template exclusion cannot see it.
+			mustExec(t, d, `INSERT INTO TMTask
+				(uuid, title, type, status, trashed, "index", rt1_recurrenceRule) VALUES
+				('p-tmpl', 'Weekly review', 1, 0, 0, 1, x'0102')`)
+			mustExec(t, d, `INSERT INTO TMTask
+				(uuid, title, type, status, trashed, "index") VALUES
+				('p-real', 'Ship it', 1, 0, 0, 2)`)
+			mustExec(t, d, `INSERT INTO TMTask
+				(uuid, title, type, status, trashed, project, "index", `+tc.columns+`) VALUES
+				('t-child', 'Inside the template', 0, 0, 0, 'p-tmpl', 1, `+tc.values+`),
+				('t-plain', 'Inside a real one',   0, 0, 0, 'p-real', 2, `+tc.values+`)`)
+
+			got, err := d.ListTasks(tc.view, TaskFilter{})
+			if err != nil {
+				t.Fatalf("ListTasks(%q): %v", tc.view, err)
+			}
+			if !sameSet(uuidsOf(got), []string{"t-plain"}) {
+				t.Errorf("view %q: got %v, want just t-plain — the template's child must not list", tc.view, uuidsOf(got))
+			}
+		})
+	}
+}
+
+// The guard resolves the project through COALESCE(t.project, h.project), so a
+// to-do nested under a heading in a template project is caught too (#139).
+func TestTemplateProjectChildrenExcludedThroughHeading(t *testing.T) {
+	d := newTestDB(t)
+
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, "index", rt1_recurrenceRule) VALUES
+		('p-tmpl', 'Weekly review', 1, 0, 0, 1, x'0102')`)
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, project, "index") VALUES
+		('head-1', 'A heading', 2, 0, 0, 'p-tmpl', 1)`)
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, heading, "index") VALUES
+		('t-child', 'Under the heading', 0, 0, 0, 1, 0, 'head-1', 1)`)
+
+	got, err := d.ListTasks("anytime", TaskFilter{})
+	if err != nil {
+		t.Fatalf("ListTasks(anytime): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ListTasks(anytime) = %v, want no heading-nested children of a template project", uuidsOf(got))
+	}
+}
+
+// trash and logbook report what the database holds, so a template's child
+// that has been trashed or completed still belongs in them. Without this the
+// guard would swallow rows those two views exist to show.
+func TestTrashAndLogbookKeepTemplateProjectChildren(t *testing.T) {
+	d := newTestDB(t)
+
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, "index", rt1_recurrenceRule) VALUES
+		('p-tmpl', 'Weekly review', 1, 0, 0, 1, x'0102')`)
+	mustExec(t, d, `INSERT INTO TMTask
+		(uuid, title, type, status, trashed, start, startBucket, project, "index") VALUES
+		('t-binned', 'Trashed child',   0, 0, 1, 1, 0, 'p-tmpl', 1),
+		('t-logged', 'Completed child', 0, 3, 0, 1, 0, 'p-tmpl', 2)`)
+
+	for _, tc := range []struct{ view, want string }{
+		{"trash", "t-binned"},
+		{"logbook", "t-logged"},
+	} {
+		got, err := d.ListTasks(tc.view, TaskFilter{})
+		if err != nil {
+			t.Fatalf("ListTasks(%q): %v", tc.view, err)
+		}
+		if !sameSet(uuidsOf(got), []string{tc.want}) {
+			t.Errorf("view %q: got %v, want [%s]", tc.view, uuidsOf(got), tc.want)
+		}
+	}
+}
+
+// The guard reads the parent through the `p` alias, so the helper has to
+// build a reference for an alias other than `t`, and still degrade to NULL on
+// a schema carrying no recurrence column.
+func TestRecurrenceColForAlias(t *testing.T) {
+	d := seedRepeatingPair(t)
+	if got, want := d.recurrenceColFor("p"), `p."rt1_recurrenceRule"`; got != want {
+		t.Errorf("recurrenceColFor(p) = %q, want %q", got, want)
+	}
+	if got, want := d.recurrenceColFor("t"), d.recurrenceCol(); got != want {
+		t.Errorf("recurrenceColFor(t) = %q, want recurrenceCol() = %q", got, want)
+	}
+
+	sqlDB := dbtest.NewSQL(t)
+	if _, err := sqlDB.Exec(`ALTER TABLE TMTask DROP COLUMN rt1_recurrenceRule`); err != nil {
+		t.Fatalf("drop column: %v", err)
+	}
+	bare := &DB{db: sqlDB}
+	if got := bare.recurrenceColFor("p"); got != "NULL" {
+		t.Errorf("recurrenceColFor(p) with no column = %q, want %q", got, "NULL")
 	}
 }

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -235,7 +235,16 @@ func (d *DB) ListTasks(view string, opts TaskFilter) ([]model.Task, error) {
 		where += " AND COALESCE(p.trashed, 0) = 0"
 	}
 	if !viewsIncludingTemplates[view] {
+		// The template row itself, which carries the recurrence rule.
 		where += " AND " + repeatingPlaceholder + " IS NULL"
+		// And the to-dos inside a repeating project template, which carry no
+		// rule of their own — only the project does — so the clause above
+		// cannot see them. Without this they list as ordinary tasks against
+		// a project `things projects` does not report (issue #171). Built
+		// here rather than through the placeholder because the placeholder
+		// exists for the static strings in viewFilters, and this one needs
+		// an alias those strings never mention.
+		where += " AND " + d.recurrenceColFor("p") + " IS NULL"
 	}
 
 	var args []any

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -118,7 +118,9 @@ things config init [--force]    # write a commented template
 
 A repeating to-do is stored as a template plus the to-dos it generates. `things repeating` lists the templates; they do not appear in `someday` or any other view except `trash` and `logbook`, which report what the database holds. The generated to-dos carry no recurrence rule of their own, so they list as ordinary tasks under `today`, `upcoming` and the rest.
 
-Projects repeat the same way. `things repeating` lists project templates too — marked `(project)` in plain output, `"type": 1` in JSON, to-dos first then projects — and `things projects` leaves them out. `trash` and `logbook` are to-do lists, so a project template never shows there. `things show` on a project prints a `Type: project` line. `trash` and `logbook` are to-do lists, so a project template never shows there.
+Projects repeat the same way. `things repeating` lists project templates too — marked `(project)` in plain output, `"type": 1` in JSON, to-dos first then projects — and `things projects` leaves them out. `trash` and `logbook` are to-do lists, so a project template never shows there. `things show` on a project prints a `Type: project` line.
+
+The to-dos inside a project template are hidden too. They carry no recurrence rule of their own, so they are recognised by their project rather than by themselves; without that they would list as ordinary tasks against a project `things projects` does not report. `trash` and `logbook` still show them once trashed or logged.
 
 `things search` is a lookup, not a view: it searches the database as it stands and returns templates like anything else. Results carry `"repeating": true`, so check that field before trying to write to a search hit.
 


### PR DESCRIPTION
## What changed

A repeating project is a template row carrying the recurrence rule plus the projects it generates. The template's own child to-dos carry no rule — only their project does — so the template exclusion added in #147 could not see them, and they listed as ordinary tasks against a project `things projects` no longer reports.

The guard tests the resolved parent through the existing `p` join. That needs a recurrence reference for an alias other than `t`, so `probeRepeating` now caches the bare column name and a small `recurrenceRef(alias, column)` builds the reference from it — `recurrenceColFor` can serve any alias, and `probeRepeating` can still build its own without re-entering the `sync.Once`. The `repeatSQL` field goes away; there is now one place that knows how the reference is spelled.

It runs for the same views that exclude templates, so `trash` and `logbook` keep reporting what the database holds. Because `p` resolves through `COALESCE(t.project, h.project)`, a to-do nested under a heading in a template project is covered too.

## Verification status — please read before merging

**This is not verified against a real repeating project.** This machine's Things database has none, so the tests assert the modelled row layout rather than an observed one.

What *is* observed, from the checkpointed daily backups of the real database: for repeating **to-dos**, Things keeps the rule-bearing row as a blueprint (2 rows with `rt1_recurrenceRule`, `rt1_repeatingTemplate` NULL, `start = 2`, `instanceCreationPaused = 1`) and generates **separate** instance rows (17 rows with `rt1_repeatingTemplate` set and no rule of their own). The blueprint is the row the app files under Repeating; the instances are what appear in Today. This guard assumes projects follow the same shape, which is the same `rt1_*` column family and the same mechanism.

The residual risk is that projects diverge from to-dos — that Things regenerates children in place under the row holding the rule. If that were so, this would hide every live to-do of every repeating project. I judge that unlikely given the above, but it is the thing to weigh, and it is why this says so here rather than in a comment.

## How tested

- `make test` (race) and `make lint` — both green.
- `TestTemplateProjectChildrenExcludedFromOpenViews` is table-driven across all seven views the guard applies to (`inbox`, `today`, `upcoming`, `anytime`, `someday`, `deadlines`, `project`). Each case seeds a child of a template project *and* a sibling in an ordinary project, so the assertion proves the guard discriminates rather than hiding everything.
- `TestTemplateProjectChildrenExcludedThroughHeading` covers the heading-nested path; `TestTrashAndLogbookKeepTemplateProjectChildren` pins the two opt-out views; `TestRecurrenceColForAlias` covers the helper for a non-`t` alias and the no-column fallback.
- I confirmed every exclusion case fails without the guard.
- Against a read-only copy of the real database, every view count is byte-identical to before the change — there are no repeating projects there, which is what a guard that cannot over-hide should do.

## Also here

`internal/skill/SKILL.md` had a sentence duplicated on main (my edit and a review fix collided in #170); removed.

Closes #171