### PR TITLE
perf(db): batch the per-item uuid lookups in the import checks

### DIFF
--- a/cmd/things/importcheck.go
+++ b/cmd/things/importcheck.go
@@ -231,21 +231,30 @@ func (e *importVerifyError) Error() string {
 func prepareImport(d *Deps, database *db.DB, data []byte) (*importPlan, error) {
 	plan := &importPlan{updates: importUpdates(data), tasks: map[string]*model.Task{}}
 
+	// One query for the whole payload rather than one per item (issue #167).
+	var ids []string
+	for _, u := range plan.updates {
+		if u.resolvable() {
+			ids = append(ids, u.id)
+		}
+	}
+	found, err := database.GetTasksByUUIDs(ids)
+	if err != nil {
+		return nil, fmt.Errorf("checking the payload against the Things database: %w", err)
+	}
+	// An id with no row maps to a nil task, which is what the loop below and
+	// the read-back afterwards both read as "not in the database".
+	for _, id := range ids {
+		plan.tasks[id] = found[id]
+	}
+
 	var refusals []importRefusalItem
 	var missing []string
 	for _, u := range plan.updates {
 		if !u.resolvable() {
 			continue
 		}
-		task, ok := plan.tasks[u.id]
-		if !ok {
-			var err error
-			task, err = database.GetTaskByUUID(u.id)
-			if err != nil {
-				return nil, fmt.Errorf("checking %s (id %s) against the Things database: %w", u.path, u.id, err)
-			}
-			plan.tasks[u.id] = task
-		}
+		task := plan.tasks[u.id]
 		if task == nil {
 			missing = append(missing, fmt.Sprintf("%s (id %s)", u.path, u.id))
 			continue

--- a/cmd/things/importcheck_test.go
+++ b/cmd/things/importcheck_test.go
@@ -660,3 +660,83 @@ func TestImportFailuresPlainTextUnchanged(t *testing.T) {
 		t.Errorf("stderr lost the per-item line: %q", stderr.String())
 	}
 }
+
+// The batched lookup (#167) has to leave the checks behaving exactly as the
+// per-item one did, including when a payload mixes a repeating target, a
+// duplicate id, an unknown id and a heading in a single pass.
+func TestImportBatchedLookupKeepsCheckBehaviour(t *testing.T) {
+	database, sqlDB := seedWritable(t)
+	if _, err := sqlDB.Exec(`INSERT INTO TMTask (uuid, title, type, status, trashed) VALUES ('head-1', 'Phase 2', 2, 0, 0)`); err != nil {
+		t.Fatalf("seed heading: %v", err)
+	}
+	calls := stubExecDropping(t)
+
+	payload := `[
+	  {"type":"to-do","operation":"update","id":"one-1","attributes":{"title":"a"}},
+	  {"type":"to-do","operation":"update","id":"rep-1","attributes":{"when":"today"}},
+	  {"type":"to-do","operation":"update","id":"rep-1","attributes":{"deadline":"2026-05-01"}},
+	  {"type":"to-do","operation":"update","id":"nope-1","attributes":{"title":"b"}},
+	  {"type":"heading","operation":"update","id":"head-1","attributes":{"title":"c"}}
+	]`
+	err := runWith(t, database, "import", "--file", importPayload(t, payload))
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	// The same repeating item named twice is refused twice, once per payload
+	// position, even though it was only looked up once.
+	for _, want := range []string{
+		"2 of 5 update items",
+		`[1] (id rep-1): "Water plants" is a repeating to-do — when`,
+		`[2] (id rep-1): "Water plants" is a repeating to-do — deadline`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q:\n%v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "head-1") || strings.Contains(err.Error(), "nope-1") {
+		t.Errorf("a heading or unknown id was treated as an offender:\n%v", err)
+	}
+	if *calls != 0 {
+		t.Errorf("payload was sent to Things anyway (%d calls)", *calls)
+	}
+}
+
+// A read-back over several items resolves each one from the shared round
+// query, so the per-item verdicts stay independent.
+func TestImportBatchedReadBackKeepsPerItemVerdicts(t *testing.T) {
+	fastVerify(t)
+	database, sqlDB := seedWritable(t)
+	for _, seed := range []string{
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, start) VALUES ('one-2', 'File taxes', 0, 0, 0, 2)`,
+		`INSERT INTO TMTask (uuid, title, type, status, trashed, start) VALUES ('one-3', 'Call bank', 0, 0, 0, 2)`,
+	} {
+		if _, err := sqlDB.Exec(seed); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	// Things applies the first and third, drops the middle one.
+	stubExecApplyingAll(t, sqlDB, map[string]int{
+		"one-1": int(model.StatusCompleted),
+		"one-3": int(model.StatusCancelled),
+	})
+
+	payload := `[
+	  {"type":"to-do","operation":"update","id":"one-1","attributes":{"completed":true}},
+	  {"type":"to-do","operation":"update","id":"one-2","attributes":{"canceled":true}},
+	  {"type":"to-do","operation":"update","id":"one-3","attributes":{"canceled":true}}
+	]`
+	err := runWith(t, database, "--json", "import", "--file", importPayload(t, payload))
+	if err == nil {
+		t.Fatal("expected a read-back failure for the dropped item")
+	}
+	p, raw := decodePayload(t, err)
+	if len(p.Items) != 1 {
+		t.Fatalf("got %d items, want only the dropped one (%s)", len(p.Items), raw)
+	}
+	if p.Items[0].ID != "one-2" || p.Items[0].Wanted != "cancelled" || p.Items[0].Got != "open" {
+		t.Errorf("item = %+v, want one-2 cancelled/open", p.Items[0])
+	}
+	if !strings.Contains(p.Message, "1 of 3 requested status changes") {
+		t.Errorf("summary lost the batch counts: %s", p.Message)
+	}
+}

--- a/cmd/things/verify.go
+++ b/cmd/things/verify.go
@@ -105,10 +105,19 @@ func verifyStatuses(database *db.DB, wants []statusWant, budget time.Duration) [
 		// Read the clock once per round so every item in it is judged against
 		// the same deadline.
 		expired := !time.Now().Before(deadline)
+
+		// One query per round for every item still pending, rather than one
+		// per item per round (issue #167).
+		uuids := make([]string, len(pending))
+		for n, i := range pending {
+			uuids[n] = wants[i].uuid
+		}
+		found, err := database.GetTasksByUUIDs(uuids)
+
 		var next []int
 		for _, i := range pending {
 			w := wants[i]
-			current, err := database.GetTaskByUUID(w.uuid)
+			current := found[w.uuid]
 			switch {
 			case err != nil:
 				if expired {

--- a/internal/db/tasks.go
+++ b/internal/db/tasks.go
@@ -301,6 +301,66 @@ func (d *DB) GetTaskByUUID(uuid string) (*model.Task, error) {
 	return &t, nil
 }
 
+// uuidChunkSize caps how many uuids go into one IN (...) clause, so a caller
+// passing an arbitrarily long list can never trip SQLITE_MAX_VARIABLE_NUMBER —
+// the bound parameter limit is a property of the SQLite build, not something
+// this package can rely on, and hitting it would surface as an opaque query
+// error. 500 sits well under every plausible limit — the modernc.org/sqlite
+// build this module pins accepts 32766 (the modern SQLITE_MAX_VARIABLE_NUMBER)
+// and refuses 40000 with "too many SQL variables" — and the per-chunk cost is
+// flat, so nothing is lost by staying conservative. Import payloads are
+// bounded by the macOS URL length limit anyway, so in practice one chunk
+// covers them and the loop never runs twice.
+const uuidChunkSize = 500
+
+// GetTasksByUUIDs looks up many tasks in one query instead of one query per
+// uuid, and returns them keyed by uuid. An id that matches nothing is simply
+// absent from the map — the caller decides whether that is an error, the same
+// way GetTaskByUUID returns a nil task rather than failing.
+//
+// It shares taskQuery and the notHeading filter with GetTaskByUUID so the two
+// agree on what a lookup can see: headings stay excluded (issue #146) and the
+// repeating column is resolved the same way. Duplicate and empty ids are
+// dropped before querying, so callers can pass a raw list.
+func (d *DB) GetTasksByUUIDs(uuids []string) (map[string]*model.Task, error) {
+	found := make(map[string]*model.Task, len(uuids))
+
+	unique := make([]string, 0, len(uuids))
+	seen := make(map[string]struct{}, len(uuids))
+	for _, u := range uuids {
+		if u == "" {
+			continue
+		}
+		if _, dup := seen[u]; dup {
+			continue
+		}
+		seen[u] = struct{}{}
+		unique = append(unique, u)
+	}
+
+	for start := 0; start < len(unique); start += uuidChunkSize {
+		end := min(start+uuidChunkSize, len(unique))
+		chunk := unique[start:end]
+
+		args := make([]any, len(chunk))
+		for i, u := range chunk {
+			args[i] = u
+		}
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(chunk)), ",")
+		query := d.taskQuery() + " WHERE t.uuid IN (" + placeholders + ") AND " + notHeading + " GROUP BY t.uuid"
+
+		tasks, err := d.collectTasks(query, args...)
+		if err != nil {
+			return nil, err
+		}
+		for i := range tasks {
+			task := tasks[i]
+			found[task.UUID] = &task
+		}
+	}
+	return found, nil
+}
+
 func (d *DB) GetTask(uuidOrTitle string) (*model.Task, error) {
 	t, err := d.GetTaskByUUID(uuidOrTitle)
 	if err != nil {

--- a/internal/db/tasks_test.go
+++ b/internal/db/tasks_test.go
@@ -3,6 +3,8 @@ package db
 import (
 	"errors"
 	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -1104,4 +1106,128 @@ func TestTitleLookupsWithoutRecurrenceColumn(t *testing.T) {
 	if !sameSet(uuidsOf(matches), []string{"a", "b"}) {
 		t.Errorf("got %v", uuidsOf(matches))
 	}
+}
+
+// --- batched uuid lookups (issue #167) ---
+
+func TestGetTasksByUUIDs(t *testing.T) {
+	d := newTestDB(t)
+	seedTasks(t, d)
+	seedLookupHeadings(t, d)
+
+	// A duplicate, an empty string, an unknown id and a heading all go in
+	// alongside the real ones: callers pass a raw list built from a payload.
+	got, err := d.GetTasksByUUIDs([]string{
+		"t-today", "proj-1", "t-today", "", "nope", "head-phase",
+	})
+	if err != nil {
+		t.Fatalf("GetTasksByUUIDs: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want 2 (to-do + project): %v", len(got), keysOf(got))
+	}
+	if task := got["t-today"]; task == nil || task.Title != "Today task" {
+		t.Errorf("t-today = %+v", task)
+	}
+	if task := got["proj-1"]; task == nil {
+		t.Error("a project should resolve, as it does through GetTaskByUUID")
+	}
+	// Absent, not a nil entry: the caller distinguishes the two.
+	if _, present := got["nope"]; present {
+		t.Error("an unknown id should be absent from the map")
+	}
+	if _, present := got["head-phase"]; present {
+		t.Error("a heading should be excluded, as it is from GetTaskByUUID (#146)")
+	}
+	if _, present := got[""]; present {
+		t.Error("an empty id should never be queried")
+	}
+}
+
+// The batch must agree with the single lookup field for field, or the import
+// checks would see different tasks depending on which path ran.
+func TestGetTasksByUUIDsMatchesGetTaskByUUID(t *testing.T) {
+	d := newTestDB(t)
+	seedTasks(t, d)
+	seedLookupHeadings(t, d)
+
+	ids := []string{"t-today", "t-inbox", "proj-1", "head-phase", "nope"}
+	batch, err := d.GetTasksByUUIDs(ids)
+	if err != nil {
+		t.Fatalf("GetTasksByUUIDs: %v", err)
+	}
+	for _, id := range ids {
+		single, err := d.GetTaskByUUID(id)
+		if err != nil {
+			t.Fatalf("GetTaskByUUID(%s): %v", id, err)
+		}
+		one, ok := batch[id]
+		if single == nil {
+			if ok {
+				t.Errorf("%s: batch returned %+v where the single lookup found nothing", id, one)
+			}
+			continue
+		}
+		if !ok {
+			t.Errorf("%s: batch found nothing where the single lookup found %+v", id, single)
+			continue
+		}
+		if !reflect.DeepEqual(*one, *single) {
+			t.Errorf("%s: batch = %+v, single = %+v", id, *one, *single)
+		}
+	}
+}
+
+// More ids than fit in one chunk, and not a whole multiple of one either, so
+// the loop has to reassemble three chunks — two full and a short tail —
+// without dropping a row at a boundary or double-counting one.
+func TestGetTasksByUUIDsChunksLargeInput(t *testing.T) {
+	d := newTestDB(t)
+
+	const n = uuidChunkSize*2 + 7
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		uuid := fmt.Sprintf("bulk-%04d", i)
+		ids = append(ids, uuid)
+		mustExec(t, d, `INSERT INTO TMTask (uuid, title, type, status, trashed) VALUES (?, ?, 0, 0, 0)`,
+			uuid, fmt.Sprintf("Bulk %d", i))
+	}
+
+	got, err := d.GetTasksByUUIDs(ids)
+	if err != nil {
+		t.Fatalf("GetTasksByUUIDs across %d ids: %v", n, err)
+	}
+	if len(got) != n {
+		t.Fatalf("got %d rows, want %d — a chunk went missing", len(got), n)
+	}
+	for _, id := range ids {
+		if got[id] == nil {
+			t.Fatalf("%s missing from the batch result", id)
+		}
+	}
+}
+
+func TestGetTasksByUUIDsEmptyInput(t *testing.T) {
+	d := newTestDB(t)
+	seedTasks(t, d)
+
+	for _, ids := range [][]string{nil, {}, {"", ""}} {
+		got, err := d.GetTasksByUUIDs(ids)
+		if err != nil {
+			t.Fatalf("GetTasksByUUIDs(%v): %v", ids, err)
+		}
+		if len(got) != 0 {
+			t.Errorf("GetTasksByUUIDs(%v) = %v, want empty", ids, keysOf(got))
+		}
+	}
+}
+
+func keysOf(m map[string]*model.Task) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }


### PR DESCRIPTION
## What changed

`prepareImport` called `GetTaskByUUID` once per update item, and `verifyStatuses` called it once per pending item *per polling round* — so a 200-item import whose status changes never landed ran roughly 20,000 single-row queries (each a five-join `GROUP BY`) against the database Things is concurrently writing to.

New `db.GetTasksByUUIDs(uuids []string) (map[string]*model.Task, error)` resolves the whole set in one query, keyed by uuid, with an unmatched id simply absent from the map — the batch equivalent of `GetTaskByUUID` returning `(nil, nil)` rather than an error.

It is built on the same `taskQuery()` and `notHeading` filter as `GetTaskByUUID`, so the heading exclusion from #146 and the repeating column stay in step between the two by construction rather than by duplication. Empty and duplicate ids are dropped before querying, so a caller can pass a raw list built straight from a payload. Long lists are chunked to stay clear of `SQLITE_MAX_VARIABLE_NUMBER`.

Both call sites keep their previous behaviour exactly — same refusal text, same per-item verdicts, same warnings — and `GetTaskByUUID` is untouched.

## How tested

`make test` (`-race`), `make lint` (0 issues), `go vet` — all clean.

New `internal/db` tests: `TestGetTasksByUUIDs` (a duplicate, an empty string, an unknown id and a heading all in one call), `TestGetTasksByUUIDsMatchesGetTaskByUUID` (field-for-field `reflect.DeepEqual` against the single lookup for every seeded id, so the two cannot drift), `TestGetTasksByUUIDsChunksLargeInput` (three chunks — two full plus a short tail — reassemble without dropping or double-counting at a boundary), and `TestGetTasksByUUIDsEmptyInput`.

New `cmd/things` tests: `TestImportBatchedLookupKeepsCheckBehaviour` (a payload mixing a repeating target named twice, an unknown id and a heading — the duplicate is refused at both payload positions though looked up once) and `TestImportBatchedReadBackKeepsPerItemVerdicts` (three items, middle one dropped, verdicts stay independent).

The existing import and verify tests pass unchanged, and the diff to `internal/db/tasks_test.go` is purely additive (no deletions), which is the evidence that behaviour is preserved rather than re-baselined.

## A correction worth recording

An earlier revision of this branch carried a code comment claiming that this SQLite build *hangs* on a 1000-parameter `IN` clause while 999 returns instantly. `/code-review` could not reproduce it and pushed back. It was right: my measurement was wrong, not SQLite. The probe never closed its `*sql.Rows`, and because `dbtest` sets `SetMaxOpenConns(1)` the *second* query in the loop blocked forever waiting for the only connection. The hang was a leaked connection in the probe.

Re-measured properly, on a 1200-row table with the real query shape: 999 params 2.5ms, 1000 params 2.8ms, 1007 params 2.9ms, 5000 params 13ms, 32766 params 310ms, and 40000 params fails cleanly with `too many SQL variables`. So the limit is the modern `SQLITE_MAX_VARIABLE_NUMBER` of 32766 and it errors rather than hanging. The comment now states that.

Chunking is still worth keeping — the parameter ceiling is a property of the SQLite build rather than something this package should depend on — but the rationale in the code is now something that is actually true.

Closes #167