### PR TITLE
docs(release): add v0.7.0 release notes header

### DIFF
--- a/.github/releases/v0.7.0.md
+++ b/.github/releases/v0.7.0.md
@@ -1,0 +1,37 @@
+## `things-cli` v0.7.0 — a config file, tag creation, and output an agent can trust
+
+A TOML config file for persistent defaults, tag creation from the CLI, a `things show --agent` hand-off format, a `repeating` view, machine-readable `--json` errors, and fixes to what lookups and views return.
+
+### Settings live in a file now
+
+- **`~/.config/things-cli/config.toml`** supplies defaults for `json`, `color`, `db`, `no_verify`, `strict_tags`, `create_tags`, `assume_yes` and `hints`. Flags still win per run. `--config PATH` or `THINGS_CLI_CONFIG` point at another file, `$XDG_CONFIG_HOME` is honoured, and a missing file is not an error. **`things config path`**, **`config show`** and **`config init`** (writes a commented template) round it out. Unknown keys and malformed TOML fail with one line naming the file. Full reference at https://things.rlew.io/configuration/. (#159, #160)
+- `assume_yes` is scoped to `complete` and `cancel`; it cannot reach `skill uninstall`, whose `--yes` means delete. (#158, #169)
+
+### Tags can be created from the CLI
+
+- **`things tag add <name>...`** creates tags over AppleScript, skipping names that already exist (case-insensitive) and reading the tag list back to confirm. **`--create-tags`** on `add`, `edit`, `project add`, `project edit` and `import` creates the unknown tags before the write instead of warning. `--create-tags` with `--strict-tags` is rejected. Tag names are escaped for AppleScript. (#144, #150)
+
+### Handing a to-do to an agent
+
+- **`things show <ref> --agent`** prints a self-contained Markdown brief: the to-do, its notes and checklist, and the exact UUID-based commands to close it out, ready for `things show 3 --agent | claude -p "action this"`. Plain `list` and `search` output on a terminal ends with a one-line hint; `--no-hints` or `hints = false` turns it off. Notes are fenced and labelled as content so a to-do cannot forge the closing-out section. (#153, #172)
+- **`--json` is now non-interactive and its errors are JSON.** An ambiguous or missing ref no longer opens the picker or prints help text to stdout; you get one object with a stable `error` token (`ambiguous task`, `not found`, `import refused`, `import partially applied`, or `error`), the message, the query and the candidates or per-item details. Exit codes match the plain path. (#152, #157, #161, #166, #164, #168)
+- **`--yes` / `-y` on `complete` and `cancel`** skips the project confirmation, so `things --json complete <project> --yes` works from a script. (#158, #169)
+
+### Lookups and views return what they claim
+
+- **Project headings never come back as tasks** from `show`, `edit`, `complete`, `cancel`, `open`, `search` or the numeric index cache. A heading with the same title as a to-do no longer makes the lookup ambiguous. (#146, #149)
+- **Repeating templates have their own view.** `things repeating` lists to-do and project templates (projects marked `(project)`), and they are gone from `someday`, the catch-all project view and `things projects`. Generated instances were never affected and still list in today and upcoming. (#147, #154, #165, #170)
+- **A title shared by a template and its generated to-do resolves to the to-do**, so `things complete "Water plants"` no longer hits the repeating refusal while an actionable instance exists. The template is still reachable by UUID or from `things repeating`. (#156, #163)
+- **To-dos under a trashed project are hidden** in inbox, today, upcoming, anytime, someday and deadlines, not just the filtered views. `trash` and `logbook` still show them. (#155, #162)
+- **To-dos inside a repeating project template are hidden** from the same views, since the app only shows the generated copies. (#171, #173)
+- **`import` with `operation: update` goes through the repeating check and the read-back.** A payload that sets when, deadline, completed or canceled on a repeating item is refused whole, with the path of each offending item, before anything is sent. Status changes are read back after the write with one shared timeout. `completed: false` and `canceled: false` count as status changes, and `canceled` takes priority over `completed`, as the Things docs specify. (#145, #151)
+- The `things tag add` suggestion printed for unknown tags is now shell-quoted, and `--json=1`, `-jv` and other flag spellings render parse errors as JSON. (#164, #168)
+
+### Also
+
+- Import checks resolve every item in one query per round instead of one per item. (#167, #175)
+- The bundled agent skill was reorganised and audited against every `--help`; `open` is no longer described as a write, and the `skill`, `config` and `tag` commands are covered. Run `things skill install` again to pick it up. (#176)
+
+### Requirements
+
+macOS with Things3 installed. Binaries for Apple Silicon (`darwin_arm64`) and Intel (`darwin_amd64`).

--- a/.github/releases/v0.7.0.md
+++ b/.github/releases/v0.7.0.md
@@ -4,7 +4,7 @@ A TOML config file for persistent defaults, tag creation from the CLI, a `things
 
 ### Settings live in a file now
 
-- **`~/.config/things-cli/config.toml`** supplies defaults for `json`, `color`, `db`, `no_verify`, `strict_tags`, `create_tags`, `assume_yes` and `hints`. Flags still win per run. `--config PATH` or `THINGS_CLI_CONFIG` point at another file, `$XDG_CONFIG_HOME` is honoured, and a missing file is not an error. **`things config path`**, **`config show`** and **`config init`** (writes a commented template) round it out. Unknown keys and malformed TOML fail with one line naming the file. Full reference at https://things.rlew.io/configuration/. (#159, #160)
+- **`~/.config/things-cli/config.toml`** supplies defaults for `json`, `color`, `db`, `no_verify`, `strict_tags`, `create_tags`, `assume_yes` and `hints`. Flags still win per run. `--config PATH` or `THINGS_CLI_CONFIG` point at another file, `$XDG_CONFIG_HOME` is honoured, and the file is optional: without one, `things` runs on its built-in defaults. **`things config path`**, **`config show`** and **`config init`** (writes a commented template) round it out. Unknown keys and malformed TOML fail with one line naming the file. Full reference at https://things.rlew.io/configuration/. (#159, #160)
 - `assume_yes` is scoped to `complete` and `cancel`; it cannot reach `skill uninstall`, whose `--yes` means delete. (#158, #169)
 
 ### Tags can be created from the CLI


### PR DESCRIPTION
Release header for v0.7.0, read by goreleaser from `.github/releases/v0.7.0.md`. Each paragraph and bullet is one line so GitHub renders it without stray breaks.