### PR TITLE
docs: give configuration its own page on the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,10 @@ unchanged, and commands that fail on a single item carry no `items` at all.
 
 A TOML file supplies defaults for the flags below, so you can set them once
 instead of typing them every time. Precedence is flag > config file >
-built-in default.
+built-in default. The full reference — an annotated example file, the
+`config` subcommands with sample output, and what happens when the file is
+wrong — is on the docs site under
+[Configuration](https://things.rlew.io/configuration/).
 
 The file is read from `$XDG_CONFIG_HOME/things-cli/config.toml`, falling
 back to `~/.config/things-cli/config.toml`. Override the location with

--- a/docs/_tabs/about.md
+++ b/docs/_tabs/about.md
@@ -1,7 +1,7 @@
 ---
 title: About
 icon: fas fa-info-circle
-order: 3
+order: 4
 ---
 
 `things-cli` is a small Go CLI for [Things3](https://culturedcode.com/things/)

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -256,46 +256,19 @@ Prints the version, commit, and build date.
 
 ## Configuration
 
-A TOML file supplies defaults for global and per-command flags. Precedence
-is flag > config file > built-in default.
+A TOML file at `~/.config/things-cli/config.toml` supplies defaults for
+the flags above, so you can set them once instead of typing them every
+run. Precedence is flag > config file > built-in default.
 
 ```sh
-things config init     # write a commented template (--force to overwrite)
-things config path     # print the file in use and whether it exists
-things config show     # print the defaults the file establishes
-things config show -j  # the same, as JSON
+things config init     # write a commented template
+things config path     # the file in use, and whether it exists
+things config show     # the defaults it establishes
 ```
 
-The file is read from `$XDG_CONFIG_HOME/things-cli/config.toml`, falling
-back to `~/.config/things-cli/config.toml`. Override it with `--config
-PATH` or `THINGS_CLI_CONFIG`. A missing file is not an error.
-
-| Key | Flag it sets | Type | Default |
-| --- | --- | --- | --- |
-| `json` | `--json` | boolean | `false` |
-| `color` | `--color` | `"auto"`, `"always"`, `"never"` | `"auto"` |
-| `hints` | `--hints` / `--no-hints` | boolean | `true` |
-| `db` | `--db` | string path (must exist) | auto-detected |
-| `no_verify` | `--no-verify` | boolean | `false` |
-| `strict_tags` | `--strict-tags` | boolean | `false` |
-| `create_tags` | `--create-tags` | boolean | `false` |
-| `assume_yes` | `--yes` | boolean | `false` |
-
-```toml
-color = "always"
-strict_tags = true
-```
-
-`assume_yes` answers the confirmation asked before a project-wide
-`complete` or `cancel`. It does not reach the `--yes` on `skill install`
-or `skill uninstall`, which mean "overwrite" and "delete" — those still
-ask, or take the flag.
-
-`strict_tags` and `create_tags` are mutually exclusive; setting both to
-`true` is an error.
-
-Unknown keys, wrong types, and malformed TOML are errors that name the
-file and the key.
+See [Configuration]({{ site.baseurl }}/configuration/) for the full key
+table, an annotated example file, and what happens when the file is
+wrong.
 
 ## Caching
 

--- a/docs/_tabs/configuration.md
+++ b/docs/_tabs/configuration.md
@@ -1,0 +1,316 @@
+---
+title: Configuration
+icon: fas fa-cog
+order: 3
+---
+
+Every flag `things` accepts has a built-in default. A TOML config file lets
+you change those defaults once instead of typing the same flag on every
+run — colour always on, say, or a database somewhere other than where the
+CLI would look.
+
+The file only supplies defaults. A flag on the command line still wins, so
+nothing you put here can take an option away from you.
+
+## Where the file lives
+
+`things` uses the first of these it finds:
+
+| Order | Source | Notes |
+| --- | --- | --- |
+| 1 | `--config PATH` | Wins over everything else, for one run |
+| 2 | `$THINGS_CLI_CONFIG` | Same, for a whole shell session |
+| 3 | `$XDG_CONFIG_HOME/things-cli/config.toml` | Only when `XDG_CONFIG_HOME` is set |
+| 4 | `~/.config/things-cli/config.toml` | The default |
+
+> **A missing file is not an error.** With no config file at all, `things`
+> runs on its built-in defaults. That is also true of a path you named
+> yourself — run `things config path` to see which file is in use and
+> whether it exists.
+{: .prompt-info }
+
+`~` and relative paths are expanded, so `--config ./project.toml` works.
+
+## Precedence
+
+```text
+flag on the command line  >  config file  >  built-in default
+```
+
+There is no second code path: the file is a resolver the CLI hands to its
+argument parser, which consults it only for flags you did not pass. That
+is what makes the rule hold everywhere without exception.
+
+```sh
+# config file says color = "always"
+things today                  # colour on   — from the file
+things --color never today    # colour off  — the flag wins
+```
+
+For a boolean, spell the override out to turn it back off:
+
+```sh
+things --json=false today     # even with json = true in the file
+```
+
+## Keys
+
+Keys are named after the flag they set, in `snake_case`. The hyphenated
+spelling is accepted too, so `no-verify` works as well as `no_verify` —
+but pick one: setting the same option under both spellings in one file is
+an error rather than a coin toss.
+
+| Key | Also accepted | Type | Default | Applies to | What it does |
+| --- | --- | --- | --- | --- | --- |
+| `json` | — | boolean | `false` | every command | Print JSON instead of the plain text listing |
+| `color` | — | `"auto"` \| `"always"` \| `"never"` | `"auto"` | every command | When to colour output; `auto` means only on a terminal |
+| `hints` | — | boolean | `true` | every command | Print the hint line under a plain task listing |
+| `db` | — | path | auto-detected | every command | Where the Things3 SQLite database is; the file must exist |
+| `no_verify` | `no-verify` | boolean | `false` | `complete`, `cancel`, `edit`, `import` | Skip the read-back that confirms a status change landed |
+| `strict_tags` | `strict-tags` | boolean | `false` | `add`, `edit`, `project add`, `project edit`, `import` | Fail instead of writing when a tag does not exist |
+| `create_tags` | `create-tags` | boolean | `false` | `add`, `edit`, `project add`, `project edit`, `import` | Create missing tags before writing |
+| `assume_yes` | `yes` | boolean | `false` | `complete`, `cancel` | Answer the confirmation before a project-wide status change |
+
+Two constraints the CLI enforces when it reads the file:
+
+- `strict_tags` and `create_tags` are mutually exclusive. Setting both to
+  `true` is an error — they are two different answers to the same
+  question.
+- `db` must point at a file that exists. A stale path is reported against
+  the config file rather than surfacing later as a puzzling flag error.
+
+A short file setting two things:
+
+```toml
+color = "always"
+assume_yes = true
+```
+
+## An example file
+
+`things config init` writes this template, with every key present and
+commented out. Uncomment a line to change that default.
+
+```toml
+# things-cli configuration
+#
+# Defaults for the flags below. A flag passed on the command line always
+# wins: flag > this file > built-in default.
+#
+# Read from $XDG_CONFIG_HOME/things-cli/config.toml, or
+# ~/.config/things-cli/config.toml. Override with --config PATH or
+# $THINGS_CLI_CONFIG. A missing file is not an error.
+#
+# Uncomment a line to change the default.
+
+# Print JSON instead of the plain text listing. Same as --json / -j.
+# Turning this on changes the output of every command, including for
+# agents and scripts that expect plain text.
+# json = false
+
+# Color mode: "auto", "always" or "never". Same as --color.
+# "auto" colours only when stdout is a terminal.
+# color = "auto"
+
+# Print the hint line under a plain task listing. Same as --hints /
+# --no-hints. The hint only ever appears when stdout is a terminal and
+# the output is not JSON, so turning it off is for terminal use.
+# hints = true
+
+# Path to the Things3 SQLite database. Same as --db.
+# Leave unset to let things-cli find it. The file must exist.
+# db = "~/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/Things Database.thingsdatabase/main.sqlite"
+
+# Skip the read-back that confirms a complete/cancel actually landed.
+# Same as --no-verify. Faster, but a write Things silently drops is
+# then reported as a success.
+# no_verify = false
+
+# Fail instead of writing when a tag does not exist in Things.
+# Same as --strict-tags. Off by default, which warns and writes anyway.
+# Mutually exclusive with create_tags.
+# strict_tags = false
+
+# Create tags that do not exist in Things before writing.
+# Same as --create-tags. Mutually exclusive with strict_tags.
+# create_tags = false
+
+# Answer the confirmation asked before a project-wide complete or
+# cancel, instead of prompting. Same as --yes / -y on those two
+# commands; the --yes on `skill install` and `skill uninstall` is
+# deliberately not covered, so this cannot delete an installed skill.
+# Turning this on removes the last check before a project and every
+# task in it changes status.
+# assume_yes = false
+```
+
+> This block is checked against the real template by a test in the
+> repository, so it cannot drift from what `things config init` writes.
+{: .prompt-tip }
+
+## The `config` commands
+
+### `things config path`
+
+Prints the file in use and whether it is there.
+
+```console
+$ things config path
+/Users/me/.config/things-cli/config.toml (exists)
+```
+
+`--json` adds where the path came from — `flag`, `env`, or `default`:
+
+```console
+$ things --json config path
+{
+  "path": "/Users/me/.config/things-cli/config.toml",
+  "exists": true,
+  "source": "default"
+}
+```
+
+### `things config show`
+
+Prints the default each key resolves to and whether that came from the
+file or the CLI. These are the values that apply when you pass no flag —
+flags you pass to `config show` itself do not appear here.
+
+```console
+$ things config show
+config: /Users/me/.config/things-cli/config.toml (exists)
+These apply when no flag overrides them.
+
+  json         false    default
+  color        always   config
+  hints        true     default
+  db           (unset)  default
+  no_verify    false    default
+  strict_tags  false    default
+  create_tags  false    default
+  assume_yes   true     config
+```
+
+`--json` gives the same thing as a `settings` array:
+
+```console
+$ things --json config show
+{
+  "path": "/Users/me/.config/things-cli/config.toml",
+  "exists": true,
+  "source": "default",
+  "settings": [
+    {
+      "key": "json",
+      "value": false,
+      "source": "default"
+    },
+    {
+      "key": "color",
+      "value": "always",
+      "source": "config"
+    }
+  ]
+}
+```
+
+### `things config init`
+
+Writes the annotated template above, creating the directory if it is not
+there. It refuses to overwrite a file that already exists:
+
+```console
+$ things config init
+Wrote config template to /Users/me/.config/things-cli/config.toml
+
+$ things config init
+Error: config file already exists: /Users/me/.config/things-cli/config.toml — pass --force to overwrite
+```
+
+Pass `--force` to replace it, or `--config PATH` to write somewhere else.
+
+## When the file is wrong
+
+A problem with the file is reported on its own line, naming the file and
+what is wrong with it. It is not a usage mistake, so there is no usage
+dump. The command exits `2`.
+
+```console
+$ things config path
+Error: config file /Users/me/.config/things-cli/config.toml: unknown key "verbose" (valid keys: json, color, hints, db, no_verify, strict_tags, create_tags, assume_yes)
+```
+
+```console
+$ things config path
+Error: config file /Users/me/.config/things-cli/config.toml: key "no_verify" is set twice ("no_verify" and "no-verify" name the same setting)
+```
+
+```console
+$ things config path
+Error: config file /Users/me/.config/things-cli/config.toml: invalid TOML: line 1, column 16: basic strings cannot have new lines
+```
+
+```console
+$ things config path
+Error: config file /Users/me/.config/things-cli/config.toml: key "color" must be one of auto, always, never, got "pink"
+```
+
+A `db` path that no longer exists is caught when the CLI actually needs
+it, so a `--db` on the command line still overrides a stale entry instead
+of tripping over it:
+
+```console
+$ things today
+Error: config file /Users/me/.config/things-cli/config.toml: db: stat /Users/me/old/main.sqlite: no such file or directory
+
+$ things --db ~/current/main.sqlite today   # works
+```
+
+> Because the file supplies the defaults the parser needs, a file it
+> cannot read stops every command, `--help` included. Fix the file, or
+> delete it — the error names both the file and the problem.
+{: .prompt-warning }
+
+Under `--json` these come out as a JSON object on stdout like any other
+failure, so a script sees a structured error either way.
+
+## `assume_yes` and the skill commands
+
+Completing or cancelling a *project* also completes or cancels every task
+inside it, so `things complete` asks first. A run that cannot prompt —
+piped output, or `--json`, which never prompts — declines. `assume_yes`
+answers that question ahead of time, which is what lets a script or an
+agent complete a project.
+
+`--yes` also exists on `skill install` and `skill uninstall`, where it
+means "overwrite" and "delete". `assume_yes` deliberately does **not**
+reach those: a file written so a script can tick off a project should not
+also let `things skill uninstall` remove files without asking. Those two
+still prompt, or take the flag directly.
+
+```sh
+things skill uninstall claude --yes   # the flag works
+                                      # assume_yes = true does not do this for you
+```
+
+Keys can be scoped this way in general — `assume_yes` is the only one
+that currently is.
+
+## Notes for agents and scripts
+
+A config file can change defaults you would otherwise assume. `json =
+true` makes every command emit JSON; `no_verify = true` turns off the
+read-back that confirms a `complete` landed; `hints = false` drops the
+hint line.
+
+If you are writing something that has to behave the same on any machine,
+pass the flags you depend on rather than inheriting them:
+
+```sh
+things --json=false today     # plain text, whatever the file says
+things --json list today
+```
+
+`things config show` reports the file in use and everything it sets,
+which is the quickest way to find out why a command on one machine
+behaves differently from the same command on another.

--- a/docs/_tabs/configuration.md
+++ b/docs/_tabs/configuration.md
@@ -55,7 +55,9 @@ things --json=false today     # even with json = true in the file
 
 ## Keys
 
-Keys are named after the flag they set, in `snake_case`. The hyphenated
+Keys are named after the flag they set, in `snake_case` — except
+`assume_yes`, which is deliberately narrower than the `--yes` it seeds
+(see [below](#assume_yes-and-the-skill-commands)). The flag's own
 spelling is accepted too, so `no-verify` works as well as `no_verify` —
 but pick one: setting the same option under both spellings in one file is
 an error rather than a coin toss.
@@ -66,18 +68,23 @@ an error rather than a coin toss.
 | `color` | — | `"auto"` \| `"always"` \| `"never"` | `"auto"` | every command | When to colour output; `auto` means only on a terminal |
 | `hints` | — | boolean | `true` | every command | Print the hint line under a plain task listing |
 | `db` | — | path | auto-detected | every command | Where the Things3 SQLite database is; the file must exist |
-| `no_verify` | `no-verify` | boolean | `false` | `complete`, `cancel`, `edit`, `import` | Skip the read-back that confirms a status change landed |
+| `no_verify` | `no-verify` | boolean | `false` | `complete`, `cancel`, `edit`, `project edit`, `import`, `tag add` (and any write that creates tags) | Skip the read-back that confirms a status change or a tag creation landed |
 | `strict_tags` | `strict-tags` | boolean | `false` | `add`, `edit`, `project add`, `project edit`, `import` | Fail instead of writing when a tag does not exist |
 | `create_tags` | `create-tags` | boolean | `false` | `add`, `edit`, `project add`, `project edit`, `import` | Create missing tags before writing |
 | `assume_yes` | `yes` | boolean | `false` | `complete`, `cancel` | Answer the confirmation before a project-wide status change |
 
-Two constraints the CLI enforces when it reads the file:
+Two constraints the CLI enforces:
 
 - `strict_tags` and `create_tags` are mutually exclusive. Setting both to
-  `true` is an error — they are two different answers to the same
-  question.
-- `db` must point at a file that exists. A stale path is reported against
-  the config file rather than surfacing later as a puzzling flag error.
+  `true` is an error, reported as soon as the file is read — they are two
+  different answers to the same question.
+- `db` must point at a file that exists. The check runs while the flags
+  are being resolved, so a stale path is reported against the config file
+  rather than surfacing later as a puzzling flag error.
+
+`strict_tags` and `create_tags` also override each other from the command
+line: `--create-tags` on a run whose file says `strict_tags = true` is
+the override it looks like, not a "can't be used together" error.
 
 A short file setting two things:
 
@@ -191,7 +198,8 @@ These apply when no flag overrides them.
   assume_yes   true     config
 ```
 
-`--json` gives the same thing as a `settings` array:
+`--json` gives the same thing as a `settings` array — one entry per key,
+in the order above, abridged here:
 
 ```console
 $ things --json config show
@@ -255,12 +263,17 @@ $ things config path
 Error: config file /Users/me/.config/things-cli/config.toml: key "color" must be one of auto, always, never, got "pink"
 ```
 
-A `db` path that no longer exists is caught when the CLI actually needs
-it, so a `--db` on the command line still overrides a stale entry instead
-of tripping over it:
+A `db` path that no longer exists is caught while the flags are resolved,
+which is before any command runs — including `config path` and `config
+show`, which never open the database. A `--db` on the command line still
+overrides a stale entry instead of tripping over it, because kong skips
+the resolver for a flag you passed:
 
 ```console
 $ things today
+Error: config file /Users/me/.config/things-cli/config.toml: db: stat /Users/me/old/main.sqlite: no such file or directory
+
+$ things config path
 Error: config file /Users/me/.config/things-cli/config.toml: db: stat /Users/me/old/main.sqlite: no such file or directory
 
 $ things --db ~/current/main.sqlite today   # works
@@ -278,9 +291,13 @@ failure, so a script sees a structured error either way.
 
 Completing or cancelling a *project* also completes or cancels every task
 inside it, so `things complete` asks first. A run that cannot prompt —
-piped output, or `--json`, which never prompts — declines. `assume_yes`
-answers that question ahead of time, which is what lets a script or an
-agent complete a project.
+stdin is not a terminal (cron, a CI job, `< /dev/null`), or `--json`,
+which never prompts whatever stdin is — declines. `assume_yes` answers
+that question ahead of time, which is what lets a script or an agent
+complete a project.
+
+Piping *output* does not turn the prompt off: `things complete "Roof" |
+tee log` still asks on stderr and reads the answer from the terminal.
 
 `--yes` also exists on `skill install` and `skill uninstall`, where it
 means "overwrite" and "delete". `assume_yes` deliberately does **not**

--- a/internal/config/docs_test.go
+++ b/internal/config/docs_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// docsPage is the configuration page on the docs site. It reproduces the
+// `config init` template and the key table, both of which go stale silently
+// unless something checks them.
+const docsPage = "../../docs/_tabs/configuration.md"
+
+func readDocsPage(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.FromSlash(docsPage))
+	if err != nil {
+		t.Fatalf("read %s: %v", docsPage, err)
+	}
+	return string(body)
+}
+
+// The page prints the template verbatim and tells the reader it is what
+// `things config init` writes, so it has to actually be that.
+func TestDocsPageQuotesTheTemplate(t *testing.T) {
+	page := readDocsPage(t)
+	tpl := strings.TrimRight(Template(), "\n")
+	if !strings.Contains(page, tpl) {
+		t.Errorf("%s does not contain the current `config init` template verbatim — "+
+			"regenerate the ```toml block from `things config init`", docsPage)
+	}
+}
+
+// A key added to the registry without a row in the tables readers actually
+// consult is a key nobody can find out about.
+func TestDocsTablesDocumentEveryKey(t *testing.T) {
+	for _, path := range []string{docsPage, "../../README.md"} {
+		body, err := os.ReadFile(filepath.FromSlash(path))
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		for _, k := range Keys {
+			if !strings.Contains(string(body), "| `"+k.Name+"` |") {
+				t.Errorf("%s has no key-table row for %q", path, k.Name)
+			}
+		}
+	}
+}
+
+// The error example on the page lists the valid keys, which is the one place
+// the key set is spelled out in prose rather than a table.
+func TestDocsPageListsValidKeysInTheErrorExample(t *testing.T) {
+	page := readDocsPage(t)
+	want := "valid keys: " + strings.Join(KeyNames(), ", ")
+	if !strings.Contains(page, want) {
+		t.Errorf("%s does not show the current key list (%q) in its unknown-key example", docsPage, want)
+	}
+}


### PR DESCRIPTION
## What changed

Configuration gets its own page on the docs site: `docs/_tabs/configuration.md`, at `order: 3`. About moves to `order: 4`; Install (1) and Commands (2) are unchanged.

The config file previously had a section inside the Commands page and a longer one in the README, and neither had room for the annotated example, the subcommand output, or what the errors actually look like.

## The page

- **Where the file lives** — the four-step lookup (`--config`, `$THINGS_CLI_CONFIG`, `$XDG_CONFIG_HOME`, `~/.config`), and that a missing file is never an error, including a path you named yourself.
- **Precedence** — flag > file > built-in default, why it holds without exception (the file is a resolver the parser consults only for flags you did not pass), and how to spell a boolean override (`--json=false`).
- **Keys** — a table generated from `config.Keys`: name, the spelling also accepted, type, default, which commands it applies to, and a one-line meaning. Plus the two constraints the CLI enforces (`strict_tags`/`create_tags` exclusivity at load, `db` existence at resolve time) and the cross-flag override where `--create-tags` beats `strict_tags = true` from the command line.
- **An example file** — the `things config init` template verbatim.
- **The `config` commands** — `path`, `show`, `init`, each with real sample output in plain and `--json` form.
- **When the file is wrong** — unknown key, both spellings of one option, malformed TOML, bad enum value, and a stale `db`, with the actual error text and exit code.
- **`assume_yes` and the skill commands** — why the key is scoped to `complete`/`cancel` and does not reach `skill install` / `skill uninstall`.
- **Notes for agents and scripts** — that a config file can move defaults out from under you, and to pass the flags you depend on.

Every console sample is real output from a binary built at this commit, with the scratch paths rewritten to `/Users/me/...`.

## Keeping it in sync

Three tests in `internal/config/docs_test.go`:

- the quoted `toml` block must match `Template()` verbatim, so the example cannot drift from what `config init` writes;
- the key tables in both the page and the README must carry a row per `config.Keys` entry, so a new key cannot land undocumented;
- the unknown-key error example must list the current key set.

They read the markdown from disk, which is the only way to check a docs file from Go. A key added to the registry now fails `make test` until both tables and, if the template changed, the example block are updated.

## Trimming the duplicates

`docs/_tabs/commands.md` keeps a short Configuration section — what the file is, the three subcommands, the precedence line — and links to the new page. The README keeps its key table, since that is what people read on GitHub without the site, and gains a link to the page for the fuller treatment.

## Corrections found while writing it

`/code-review --fix` caught seven problems in the first draft, all now fixed and each verified against the code:

- The page said a run cannot prompt when **output** is piped. `isInteractive` reads **stdin** (`cmd/things/main.go:1041`), so `things complete "Roof" | tee log` from a terminal still prompts. Rewritten, with an explicit sentence that piping output does not turn the prompt off.
- It said a stale `db` path is caught when the CLI needs the database. The stat runs in the resolver, during flag resolution for every command, so `things config path` and `things config show` fail on it too even though neither opens the database. Now stated accurately, with `config path` in the sample so the blast radius is visible.
- `no_verify` also gates the tag-creation read-back (`cmd/things/tags.go:269`), so `tag add` and any `--create-tags` write are affected. The applies-to column said otherwise.
- "Keys are named after the flag they set" is contradicted by `assume_yes` → `--yes`; carved out with a pointer to the section that explains why.
- The `--strict-tags` / `--create-tags` command-line override was documented in the README but missing from the page.
- The abridged `--json config show` sample now says it is abridged.

## Build status

**The page is unbuilt.** There is no PR-time docs check — `pages.yml` runs only on push to `main` under `docs/**` — and a local `bundle exec jekyll build` is not possible here: system Ruby is 2.6.10 and `jekyll-theme-chirpy ~> 7.2` needs 3.1+, so building would mean installing a Ruby toolchain.

Verified instead by inspection: front matter parses as YAML, `order` values are 1-4 with no clash, all 34 code fences balance, every markdown table has a consistent column count, the three `{: .prompt-* }` annotations sit directly under their blockquotes, and the page contains no Liquid of its own. The one Liquid expression added is `{{ site.baseurl }}/configuration/` in `commands.md`, which resolves to `/configuration/` given `baseurl: ""` and `permalink: /:title/`.

## Possible follow-up, not done here

A stale `db` entry makes `things config path` and `things config show` fail — the two commands you would reach for to diagnose it. Same class as a malformed file stopping `--help`. Documented as-is rather than changed, since this task was the docs page; worth an issue if you want the diagnostic commands to survive a bad config.
