### PR TITLE
fix(config): keep the config diagnostics working when the file is unusable

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,15 @@ ask, or take the flag.
 the command line.
 
 An unknown key, a value of the wrong type, or malformed TOML is an error
-that names the file and the key. Anything set here still loses to a flag,
-so `things --color never today` wins over `color = "always"`.
+that names the file and the key. It stops the commands that would have
+read the file, but not `things config path`, `things config show`,
+`things config init` or `--help` — those are how you find out which file
+is at fault, so they keep working. A `db` path that no longer exists is
+reported when a command opens the database, so it does not disable them
+either.
+
+Anything set here still loses to a flag, so `things --color never today`
+wins over `color = "always"`.
 
 Note for scripts and agents: `json = true` changes the output of every
 command. Pass `--json` (or `--json=false`) explicitly rather than relying

--- a/cmd/things/config.go
+++ b/cmd/things/config.go
@@ -104,6 +104,15 @@ func (*ConfigPathCmd) diagnosesConfig() {}
 
 func (c *ConfigPathCmd) Run(d *Deps) error {
 	cfg := d.config()
+	if cfg.Path == "" {
+		// No path was resolved at all, so there is no file to name. Printing
+		// " (not found)" here would claim we looked somewhere and came up
+		// empty, which is not what happened.
+		if cfg.Err != nil {
+			return cfg.Err
+		}
+		return fmt.Errorf("no config file path was resolved for this run")
+	}
 	if d.JSON {
 		problem := ""
 		if cfg.Err != nil {
@@ -137,7 +146,7 @@ func (c *ConfigShowCmd) Run(d *Deps) error {
 	// Under --json the error alone carries the path: a plain header on stdout
 	// would sit in front of the JSON object and break the consumer parsing it.
 	if cfg.Err != nil {
-		if !d.JSON {
+		if !d.JSON && cfg.Path != "" {
 			fmt.Fprintf(d.Stdout, "config: %s (%s)\n", cfg.Path, existence(cfg))
 		}
 		return cfg.Err

--- a/cmd/things/config.go
+++ b/cmd/things/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,17 +38,19 @@ func parserOptions(cfg *config.File) []kong.Option {
 // loadConfig resolves which config file applies to this invocation and reads
 // it. The file has to be found before kong parses, because it supplies the
 // defaults kong parses against, so --config is read straight off the argv.
+//
+// The returned File is never nil, even alongside an error: it names the file
+// that failed, which is what the `config` commands report. Returning nil here
+// would send them to (*Deps).config's fallback and have them describe — and,
+// for `config init`, write — the default path instead of the one asked for.
 func loadConfig(args []string) (*config.File, error) {
 	path, source, err := config.ResolvePath(configPathFromArgs(args))
 	if err != nil {
-		return nil, err
+		return &config.File{Source: config.SourceDefault, Err: err}, err
 	}
-	f, err := config.Load(path)
-	if err != nil {
-		return nil, err
-	}
+	f, loadErr := config.Load(path)
 	f.Source = source
-	return f, nil
+	return f, loadErr
 }
 
 // configPathFromArgs returns the value of a --config flag in args, or "".
@@ -70,6 +73,25 @@ func configPathFromArgs(args []string) string {
 	return ""
 }
 
+// diagnosesConfig reports whether the selected command is one that exists to
+// tell the user about the config file. Those have to run even when the file
+// could not be read — refusing would leave no way to find out why.
+func diagnosesConfig(ctx *kong.Context) bool {
+	if ctx == nil || ctx.Selected() == nil {
+		return false
+	}
+	target := ctx.Selected().Target
+	if !target.CanAddr() {
+		return false
+	}
+	_, ok := target.Addr().Interface().(configDiagnostic)
+	return ok
+}
+
+// configDiagnostic marks a command as one of those. It is a marker rather than
+// a name match so the set cannot drift from the commands that implement it.
+type configDiagnostic interface{ diagnosesConfig() }
+
 type ConfigCmd struct {
 	Path ConfigPathCmd `cmd:"" help:"Print the config file in use and whether it exists."`
 	Show ConfigShowCmd `cmd:"" help:"Print the defaults the config file establishes."`
@@ -78,27 +100,48 @@ type ConfigCmd struct {
 
 type ConfigPathCmd struct{}
 
+func (*ConfigPathCmd) diagnosesConfig() {}
+
 func (c *ConfigPathCmd) Run(d *Deps) error {
 	cfg := d.config()
 	if d.JSON {
+		problem := ""
+		if cfg.Err != nil {
+			problem = cfg.Err.Error()
+		}
 		return output.Print(d.Stdout, struct {
 			Path   string `json:"path"`
 			Exists bool   `json:"exists"`
 			Source string `json:"source"`
-		}{cfg.Path, cfg.Exists, cfg.Source}, true)
+			Error  string `json:"error,omitempty"`
+		}{cfg.Path, cfg.Exists, cfg.Source, problem}, true)
 	}
-	state := "not found"
-	if cfg.Exists {
-		state = "exists"
+	fmt.Fprintf(d.Stdout, "%s (%s)\n", cfg.Path, existence(cfg))
+	// Which file is in use is a fact about the path, so it is still worth
+	// printing when the contents are unusable — but say so, or the caller
+	// walks away thinking the file is fine.
+	if cfg.Err != nil {
+		fmt.Fprintf(d.errOut(), "warning: this file cannot be used: %v\n", cfg.Err)
 	}
-	fmt.Fprintf(d.Stdout, "%s (%s)\n", cfg.Path, state)
 	return nil
 }
 
 type ConfigShowCmd struct{}
 
+func (*ConfigShowCmd) diagnosesConfig() {}
+
 func (c *ConfigShowCmd) Run(d *Deps) error {
 	cfg := d.config()
+	// Nothing can be shown for a file that would not load, but naming it is
+	// the point of running this at all, so report which file failed and why.
+	// Under --json the error alone carries the path: a plain header on stdout
+	// would sit in front of the JSON object and break the consumer parsing it.
+	if cfg.Err != nil {
+		if !d.JSON {
+			fmt.Fprintf(d.Stdout, "config: %s (%s)\n", cfg.Path, existence(cfg))
+		}
+		return cfg.Err
+	}
 	settings := cfg.Settings()
 
 	if d.JSON {
@@ -110,11 +153,7 @@ func (c *ConfigShowCmd) Run(d *Deps) error {
 		}{cfg.Path, cfg.Exists, cfg.Source, settings}, true)
 	}
 
-	state := "not found"
-	if cfg.Exists {
-		state = "exists"
-	}
-	fmt.Fprintf(d.Stdout, "config: %s (%s)\n", cfg.Path, state)
+	fmt.Fprintf(d.Stdout, "config: %s (%s)\n", cfg.Path, existence(cfg))
 	fmt.Fprintf(d.Stdout, "These apply when no flag overrides them.\n\n")
 
 	keyW := 0
@@ -137,6 +176,14 @@ func (c *ConfigShowCmd) Run(d *Deps) error {
 	return nil
 }
 
+// existence is the parenthetical the config commands print after the path.
+func existence(cfg *config.File) string {
+	if cfg.Exists {
+		return "exists"
+	}
+	return "not found"
+}
+
 // showValue renders a setting for the plain listing. An empty string is a key
 // with nothing set, which reads better as a placeholder than as blank space.
 func showValue(v any) string {
@@ -149,14 +196,37 @@ func showValue(v any) string {
 	return fmt.Sprintf("%v", v)
 }
 
+// configCause strips the "config file <path>: " prefix from a config error,
+// for messages that already name the file.
+func configCause(err error) error {
+	var cfgErr *config.Error
+	if errors.As(err, &cfgErr) {
+		return cfgErr.Err
+	}
+	return err
+}
+
 type ConfigInitCmd struct {
 	Force bool `help:"Overwrite an existing config file." short:"f"`
 }
 
+func (*ConfigInitCmd) diagnosesConfig() {}
+
 func (c *ConfigInitCmd) Run(d *Deps) error {
 	cfg := d.config()
+	if cfg.Path == "" {
+		// Only reachable if the config was never resolved. Refuse rather than
+		// fall back to a path nobody asked for.
+		return fmt.Errorf("no config file path was resolved for this run")
+	}
 	if cfg.Exists && !c.Force {
-		return fmt.Errorf("config file already exists: %s — pass --force to overwrite", cfg.Path)
+		hint := ""
+		if cfg.Err != nil {
+			// The path is already in this sentence, so quote only the cause
+			// rather than the whole "config file <path>: ..." error.
+			hint = fmt.Sprintf(" (unusable as it stands: %v)", configCause(cfg.Err))
+		}
+		return fmt.Errorf("config file already exists: %s%s — pass --force to overwrite", cfg.Path, hint)
 	}
 	if dir := filepath.Dir(cfg.Path); dir != "" {
 		if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/cmd/things/config_test.go
+++ b/cmd/things/config_test.go
@@ -158,7 +158,8 @@ func TestConfigSeedsPerCommandFlag(t *testing.T) {
 }
 
 // A db path in the config that no longer exists must not stop a --db flag
-// from overriding it — the file always loses to the command line.
+// from overriding it — the file always loses to the command line — and it
+// must not be reported until something actually opens the database.
 func TestFlagBeatsStaleConfigDB(t *testing.T) {
 	isolateHome(t)
 	real := filepath.Join(t.TempDir(), "main.sqlite")
@@ -182,24 +183,59 @@ func TestFlagBeatsStaleConfigDB(t *testing.T) {
 	if cli.DB != real {
 		t.Errorf("db = %q, want %q (the flag should beat the config file)", cli.DB, real)
 	}
+	if _, err := (&Deps{DBPath: cli.DB, Config: cfg}).Database(); err != nil {
+		t.Errorf("opening the database named by --db: %v", err)
+	}
 
-	// Without the flag, the stale entry is reported and names the file.
+	// Without the flag, parsing still succeeds — the stale entry only bites
+	// when the database is opened, and then it names the file.
 	var bare CLI
 	parser, err = kong.New(&bare, parserOptions(cfg)...)
 	if err != nil {
 		t.Fatalf("kong.New: %v", err)
 	}
-	_, err = parser.Parse([]string{"--config", path, "today"})
-	if err == nil {
-		t.Fatal("parse with a stale config db: want error, got nil")
+	if _, err := parser.Parse([]string{"--config", path, "today"}); err != nil {
+		t.Fatalf("parse with a stale config db must not fail: %v", err)
 	}
-	if !strings.Contains(err.Error(), path) {
-		t.Errorf("error %q does not name the config file", err)
+	_, err = (&Deps{DBPath: bare.DB, Config: cfg}).Database()
+	if err == nil {
+		t.Fatal("opening a stale config db: want error, got nil")
+	}
+	var cfgErr *config.Error
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error %q (%T) does not unwrap to *config.Error", err, err)
+	}
+	if cfgErr.Path != path {
+		t.Errorf("cfgErr.Path = %q, want %q", cfgErr.Path, path)
+	}
+	for _, want := range []string{path, "db:", "/nonexistent/things.sqlite"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err, want)
+		}
 	}
 }
 
-// An empty db in the config means "unset"; handing "" to kong's existingfile
-// check would stat the working directory instead.
+// A path that no config file supplied is reported on its own terms — blaming
+// a file that never mentioned it would send the user to the wrong place.
+func TestMissingDBWithoutConfigAttribution(t *testing.T) {
+	isolateHome(t)
+	cfg, err := loadConfig(nil)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	_, err = (&Deps{DBPath: "/nonexistent/things.sqlite", Config: cfg}).Database()
+	if err == nil {
+		t.Fatal("opening a missing database: want error, got nil")
+	}
+	if strings.Contains(err.Error(), "config file") {
+		t.Errorf("error %q blames a config file that never set this path", err)
+	}
+	if !strings.Contains(err.Error(), "/nonexistent/things.sqlite") {
+		t.Errorf("error %q does not name the path", err)
+	}
+}
+
+// An empty db in the config means "unset", not a path of its own.
 func TestEmptyConfigDBIsUnset(t *testing.T) {
 	isolateHome(t)
 	path := writeConfig(t, "db = \"\"\n")
@@ -405,35 +441,6 @@ func TestConfigInitDefaultPathStaysUnderHome(t *testing.T) {
 	}
 }
 
-// TestConfigParseErrorIsRecognisable guards the branch in main that prints a
-// bad config value on its own instead of under a usage dump: the error kong
-// returns has to stay unwrappable to *config.Error.
-func TestConfigParseErrorIsRecognisable(t *testing.T) {
-	isolateHome(t)
-	path := writeConfig(t, `db = "/nonexistent/things.sqlite"`+"\n")
-
-	var cli CLI
-	cfg, err := loadConfig([]string{"--config", path})
-	if err != nil {
-		t.Fatalf("loadConfig: %v", err)
-	}
-	parser, err := kong.New(&cli, parserOptions(cfg)...)
-	if err != nil {
-		t.Fatalf("kong.New: %v", err)
-	}
-	_, err = parser.Parse([]string{"--config", path, "today"})
-	if err == nil {
-		t.Fatal("parse with a stale config db path: want error, got nil")
-	}
-	var cfgErr *config.Error
-	if !errors.As(err, &cfgErr) {
-		t.Fatalf("error %q (%T) does not unwrap to *config.Error", err, err)
-	}
-	if cfgErr.Path != path {
-		t.Errorf("cfgErr.Path = %q, want %q", cfgErr.Path, path)
-	}
-}
-
 // TestConfigTagPolicyExclusivity covers the interaction between the config
 // file and the --strict-tags / --create-tags exclusive pair. Kong counts a
 // resolved value as set, so a file that turns one on must not make the other
@@ -490,5 +497,163 @@ func TestConfigRejectsBothTagPolicies(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), path) || !strings.Contains(err.Error(), "cannot both be true") {
 		t.Errorf("error = %q, want it to name the file and the conflict", err)
+	}
+}
+
+// runDiag is runStreams for the diagnostic commands: no database, and the
+// returned error is whatever the command reported.
+func runDiag(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	return runStreams(t, nil, args...)
+}
+
+// The point of issue #179: a config file the CLI cannot use must not disable
+// the commands that exist to tell you so.
+func TestDiagnosticsSurviveABrokenConfig(t *testing.T) {
+	broken := map[string]struct {
+		body string
+		want string
+	}{
+		"stale db":       {`db = "/nonexistent/things.sqlite"` + "\n", "no such file"},
+		"unknown key":    {"verbose = true\n", `unknown key "verbose"`},
+		"malformed toml": {"color = \"always\n", "invalid TOML"},
+		"wrong type":     {`json = "yes"` + "\n", "must be a boolean"},
+		"both spellings": {"no_verify = true\nno-verify = false\n", "set twice"},
+	}
+
+	for name, tc := range broken {
+		t.Run(name, func(t *testing.T) {
+			isolateHome(t)
+			path := writeConfig(t, tc.body)
+
+			t.Run("config path", func(t *testing.T) {
+				stdout, stderr, err := runDiag(t, "--config", path, "config", "path")
+				if err != nil {
+					t.Fatalf("config path must still report the file: %v", err)
+				}
+				if !strings.Contains(stdout, path) {
+					t.Errorf("stdout %q does not name the file", stdout)
+				}
+				// A stale db is a usable file; the others are not, and say so.
+				if name != "stale db" && !strings.Contains(stderr, tc.want) {
+					t.Errorf("stderr %q does not explain the problem (%q)", stderr, tc.want)
+				}
+			})
+
+			t.Run("config show", func(t *testing.T) {
+				stdout, _, err := runDiag(t, "--config", path, "config", "show")
+				if !strings.Contains(stdout, path) {
+					t.Errorf("stdout %q does not name the file", stdout)
+				}
+				if name == "stale db" {
+					// The file is fine; only the path it points at is gone.
+					if err != nil {
+						t.Fatalf("config show with a stale db: %v", err)
+					}
+					if !strings.Contains(stdout, "/nonexistent/things.sqlite") {
+						t.Errorf("stdout %q does not show the configured db", stdout)
+					}
+					return
+				}
+				if err == nil {
+					t.Fatal("config show on an unreadable file: want an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.want) || !strings.Contains(err.Error(), path) {
+					t.Errorf("error %q should name the file and the problem (%q)", err, tc.want)
+				}
+			})
+
+			t.Run("config init refuses but explains", func(t *testing.T) {
+				_, _, err := runDiag(t, "--config", path, "config", "init")
+				if err == nil {
+					t.Fatal("config init over an existing file: want an error, got nil")
+				}
+				if !strings.Contains(err.Error(), path) || !strings.Contains(err.Error(), "--force") {
+					t.Errorf("error %q should name the file and the way out", err)
+				}
+				body, readErr := os.ReadFile(path)
+				if readErr != nil {
+					t.Fatalf("read config: %v", readErr)
+				}
+				if string(body) != tc.body {
+					t.Errorf("config init changed the file: %q", body)
+				}
+			})
+
+			t.Run("config init --force repairs", func(t *testing.T) {
+				if _, _, err := runDiag(t, "--config", path, "config", "init", "--force"); err != nil {
+					t.Fatalf("config init --force: %v", err)
+				}
+				cfg, err := loadConfig([]string{"--config", path})
+				if err != nil {
+					t.Fatalf("the repaired file still does not load: %v", err)
+				}
+				if cfg.Err != nil {
+					t.Errorf("repaired file carries an error: %v", cfg.Err)
+				}
+			})
+		})
+	}
+}
+
+// --help has to survive a broken file too: kong answers it during Parse, so
+// the gate that stops other commands must sit after parsing, not before.
+func TestBrokenConfigStillParses(t *testing.T) {
+	isolateHome(t)
+	path := writeConfig(t, "verbose = true\n")
+
+	cfg, cfgErr := loadConfig([]string{"--config", path})
+	if cfgErr == nil {
+		t.Fatal("loadConfig: want an error for an unknown key")
+	}
+	if cfg == nil || cfg.Path != path {
+		t.Fatalf("loadConfig dropped the file it failed on: %+v", cfg)
+	}
+
+	var cli CLI
+	parser, err := kong.New(&cli, parserOptions(cfg)...)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	ctx, err := parser.Parse([]string{"--config", path, "today"})
+	if err != nil {
+		t.Fatalf("parsing must not fail on a broken config: %v", err)
+	}
+	if cli.JSON || cli.Color != "auto" {
+		t.Error("a file that failed to load seeded a default anyway")
+	}
+	if diagnosesConfig(ctx) {
+		t.Error("`today` is not a config diagnostic")
+	}
+}
+
+func TestDiagnosesConfigMarksOnlyTheConfigCommands(t *testing.T) {
+	cases := []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"config", "path"}, true},
+		{[]string{"config", "show"}, true},
+		{[]string{"config", "init"}, true},
+		{[]string{"today"}, false},
+		{[]string{"projects"}, false},
+		{[]string{"skill", "list"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			isolateHome(t)
+			var cli CLI
+			parser, err := kong.New(&cli, parserOptions(nil)...)
+			if err != nil {
+				t.Fatalf("kong.New: %v", err)
+			}
+			ctx, err := parser.Parse(tc.args)
+			if err != nil {
+				t.Fatalf("parse %v: %v", tc.args, err)
+			}
+			if got := diagnosesConfig(ctx); got != tc.want {
+				t.Errorf("diagnosesConfig(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -134,7 +134,14 @@ func (d *Deps) Database() (*db.DB, error) {
 	// The check lives here rather than on the --db flag so that a stale path in
 	// the config file does not break the commands that never read the database
 	// — `config path` and `config show` are how you find out it is stale.
-	if _, err := os.Stat(path); err != nil {
+	info, err := os.Stat(path)
+	if err == nil && info.IsDir() {
+		// SQLite would take a directory too and fail much later with an opaque
+		// "unable to open database file"; kong's existingfile check used to
+		// catch this before the check moved here.
+		err = fmt.Errorf("%s is a directory, not a database file", path)
+	}
+	if err != nil {
 		if cfg := d.config(); cfg.SetsDB(path) {
 			return nil, &config.Error{Path: cfg.Path, Err: fmt.Errorf("db: %s", err)}
 		}
@@ -945,8 +952,10 @@ func main() {
 		renderError(os.Stdout, os.Stderr, cli.JSON, err)
 		var runCfgErr *config.Error
 		if errors.As(err, &runCfgErr) {
-			// A broken config file always exits 2, whether it was caught
-			// before, during, or after parsing.
+			// Bad content in the config file exits 2 wherever it was caught —
+			// here, or before the command ran. Failures around the file rather
+			// than in it (nowhere to look for one, a refusal to overwrite) are
+			// ordinary command errors and exit 1.
 			os.Exit(2)
 		}
 		os.Exit(1)

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -33,7 +33,7 @@ var (
 type CLI struct {
 	JSON    bool             `help:"Output as JSON." short:"j" default:"false"`
 	Color   string           `help:"Color mode (auto|always|never)." enum:"auto,always,never" default:"auto"`
-	DB      string           `help:"Override database path." type:"existingfile"`
+	DB      string           `help:"Override database path." type:"path"`
 	Config  string           `help:"Path to the TOML config file (default ~/.config/things-cli/config.toml)." placeholder:"PATH"`
 	Version kong.VersionFlag `help:"Print version and exit." short:"v"`
 
@@ -87,16 +87,14 @@ type Deps struct {
 	Config *config.File
 }
 
-// config returns the loaded config file, falling back to an unread file at the
-// default location so a Deps built without one (tests, direct construction)
-// still reports a sensible path.
+// config returns the loaded config file. main always supplies one, so a nil
+// Config means a Deps built by hand in a test. The fallback deliberately does
+// not resolve the real default path: a command that wrote to it would be
+// writing to the developer's own config file rather than the temp HOME the
+// test set up.
 func (d *Deps) config() *config.File {
 	if d.Config == nil {
-		path, source, err := config.ResolvePath("")
-		if err != nil {
-			source = config.SourceDefault
-		}
-		d.Config = &config.File{Path: path, Source: source}
+		d.Config = &config.File{Source: config.SourceDefault}
 	}
 	return d.Config
 }
@@ -130,6 +128,17 @@ func (d *Deps) Database() (*db.DB, error) {
 			return nil, err
 		}
 		path = p
+	}
+	// SQLite creates a missing file rather than refusing to open it, so a path
+	// that is not there would otherwise surface as "no such table" much later.
+	// The check lives here rather than on the --db flag so that a stale path in
+	// the config file does not break the commands that never read the database
+	// — `config path` and `config show` are how you find out it is stale.
+	if _, err := os.Stat(path); err != nil {
+		if cfg := d.config(); cfg.SetsDB(path) {
+			return nil, &config.Error{Path: cfg.Path, Err: fmt.Errorf("db: %s", err)}
+		}
+		return nil, fmt.Errorf("cannot open the Things database: %s", err)
 	}
 	database, err := db.Open(path)
 	if err != nil {
@@ -887,14 +896,12 @@ func main() {
 	var cli CLI
 
 	// The config file supplies the defaults kong parses against, so it has to
-	// be read before the parser is built.
-	cfg, err := loadConfig(os.Args[1:])
-	if err != nil {
-		// Nothing is parsed yet, so --json has to come off argv. The config
-		// file cannot supply the answer here: reading it is what just failed.
-		renderError(os.Stdout, os.Stderr, jsonRequested(false, os.Args[1:]), err)
-		os.Exit(2)
-	}
+	// be read before the parser is built. A file that could not be read does
+	// not stop us here: it supplies no defaults, parsing carries on with the
+	// built-in ones, and the failure is reported after we know which command
+	// was asked for — because `things config` is how you find out what is
+	// wrong with the file.
+	cfg, cfgErr := loadConfig(os.Args[1:])
 
 	parser := kong.Must(&cli, parserOptions(cfg)...)
 
@@ -907,14 +914,6 @@ func main() {
 	ctx, err := parser.Parse(os.Args[1:])
 	if err != nil {
 		asJSON := jsonRequested(cfg.JSON(), os.Args[1:])
-		// A bad value in the config file is not a usage mistake, so it is
-		// reported on its own rather than under a usage dump for a command
-		// that was typed correctly.
-		var cfgErr *config.Error
-		if errors.As(err, &cfgErr) {
-			renderError(os.Stdout, os.Stderr, asJSON, cfgErr)
-			os.Exit(2)
-		}
 		// kong's UsageOnError writes the usage block to stdout, which under
 		// --json would leave a consumer parsing help text instead of the JSON
 		// object it was promised. Render the failure as JSON instead — the
@@ -924,6 +923,14 @@ func main() {
 			os.Exit(parseExitCode(err))
 		}
 		parser.FatalIfErrorf(err)
+	}
+
+	// Every command but the ones that report on the config file needs the file
+	// to have loaded. --help and --version never get here: kong answers them
+	// during Parse.
+	if cfgErr != nil && !diagnosesConfig(ctx) {
+		renderError(os.Stdout, os.Stderr, cli.JSON, cfgErr)
+		os.Exit(2)
 	}
 
 	if err := output.SetColorMode(cli.Color); err != nil {
@@ -936,6 +943,12 @@ func main() {
 
 	if err := ctx.Run(deps); err != nil {
 		renderError(os.Stdout, os.Stderr, cli.JSON, err)
+		var runCfgErr *config.Error
+		if errors.As(err, &runCfgErr) {
+			// A broken config file always exits 2, whether it was caught
+			// before, during, or after parsing.
+			os.Exit(2)
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -175,10 +175,10 @@ func runStreams(t *testing.T, database *db.DB, args ...string) (string, string, 
 	isolateHome(t)
 
 	var cli CLI
-	cfg, err := loadConfig(args)
-	if err != nil {
-		t.Fatalf("load config %v: %v", args, err)
-	}
+	// A config file that failed to load is not fatal here, exactly as it is
+	// not in main: parsing carries on without it, and the failure is reported
+	// afterwards unless the command is one that exists to report on the file.
+	cfg, cfgErr := loadConfig(args)
 	parser, err := kong.New(&cli, parserOptions(cfg)...)
 	if err != nil {
 		t.Fatalf("kong.New: %v", err)
@@ -188,6 +188,9 @@ func runStreams(t *testing.T, database *db.DB, args ...string) (string, string, 
 		t.Fatalf("parse %v: %v", args, err)
 	}
 	var stdout, stderr bytes.Buffer
+	if cfgErr != nil && !diagnosesConfig(ctx) {
+		return "", "", cfgErr
+	}
 	deps := &Deps{DB: database, JSON: cli.JSON, Stdout: &stdout, Stderr: &stderr, NoVerify: cli.NoVerify, Hints: cli.Hints, Config: cfg}
 	var runErr error
 	withSilentStdout(t, func() {

--- a/docs/_tabs/commands.md
+++ b/docs/_tabs/commands.md
@@ -268,7 +268,8 @@ things config show     # the defaults it establishes
 
 See [Configuration]({{ site.baseurl }}/configuration/) for the full key
 table, an annotated example file, and what happens when the file is
-wrong.
+wrong. The three `config` subcommands keep working against a file the
+CLI cannot use — they are how you find out what is wrong with it.
 
 ## Caching
 

--- a/docs/_tabs/configuration.md
+++ b/docs/_tabs/configuration.md
@@ -78,9 +78,10 @@ Two constraints the CLI enforces:
 - `strict_tags` and `create_tags` are mutually exclusive. Setting both to
   `true` is an error, reported as soon as the file is read — they are two
   different answers to the same question.
-- `db` must point at a file that exists. The check runs while the flags
-  are being resolved, so a stale path is reported against the config file
-  rather than surfacing later as a puzzling flag error.
+- `db` must point at a file that exists. The check runs when a command
+  opens the database, so a stale path is reported against the config file
+  rather than as a puzzling flag error — and the commands that never read
+  the database keep working, which is how you find out the path is stale.
 
 `strict_tags` and `create_tags` also override each other from the command
 line: `--create-tags` on a run whose file says `strict_tags = true` is
@@ -263,26 +264,55 @@ $ things config path
 Error: config file /Users/me/.config/things-cli/config.toml: key "color" must be one of auto, always, never, got "pink"
 ```
 
-A `db` path that no longer exists is caught while the flags are resolved,
-which is before any command runs — including `config path` and `config
-show`, which never open the database. A `--db` on the command line still
-overrides a stale entry instead of tripping over it, because kong skips
-the resolver for a flag you passed:
+A `db` path that no longer exists is caught when a command opens the
+database, not before, so the commands that never read it still run — and
+a `--db` on the command line still overrides a stale entry rather than
+tripping over it:
 
 ```console
 $ things today
 Error: config file /Users/me/.config/things-cli/config.toml: db: stat /Users/me/old/main.sqlite: no such file or directory
 
-$ things config path
-Error: config file /Users/me/.config/things-cli/config.toml: db: stat /Users/me/old/main.sqlite: no such file or directory
+$ things config path                        # tells you which file to fix
+/Users/me/.config/things-cli/config.toml (exists)
 
 $ things --db ~/current/main.sqlite today   # works
 ```
 
-> Because the file supplies the defaults the parser needs, a file it
-> cannot read stops every command, `--help` included. Fix the file, or
-> delete it — the error names both the file and the problem.
-{: .prompt-warning }
+### The diagnostic commands always run
+
+A file the CLI cannot use stops every command that would have read it,
+but not the ones that exist to tell you about it. `things config path`,
+`things config show`, `things config init` and `--help` all work against
+a broken file:
+
+```console
+$ things config path
+/Users/me/.config/things-cli/config.toml (exists)
+warning: this file cannot be used: config file /Users/me/.config/things-cli/config.toml: invalid TOML: line 1, column 16: basic strings cannot have new lines
+```
+
+`config path` still exits `0` — which file is in use is a fact about the
+path, not its contents — and puts the warning on stderr. `config show`
+names the file and then reports the problem, because there are no values
+to show:
+
+```console
+$ things config show
+config: /Users/me/.config/things-cli/config.toml (exists)
+Error: config file /Users/me/.config/things-cli/config.toml: invalid TOML: line 1, column 16: basic strings cannot have new lines
+```
+
+`config init` refuses to overwrite as usual, but says why the file is
+unusable, and `--force` replaces it with a fresh template:
+
+```console
+$ things config init
+Error: config file already exists: /Users/me/.config/things-cli/config.toml (unusable as it stands: invalid TOML: line 1, column 16: basic strings cannot have new lines) — pass --force to overwrite
+
+$ things config init --force
+Wrote config template to /Users/me/.config/things-cli/config.toml
+```
 
 Under `--json` these come out as a JSON object on stdout like any other
 failure, so a script sees a structured error either way.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,6 +246,13 @@ func Load(path string) (*File, error) {
 		if os.IsNotExist(err) {
 			return f, nil
 		}
+		// Something is at the path, it just cannot be read — a directory, or
+		// a file the user has no read permission on. Say so: reporting it as
+		// "not found" would have `things config init` overwrite it without
+		// --force, and `things config path` deny it is there at all.
+		if _, statErr := os.Lstat(path); statErr == nil {
+			f.Exists = true
+		}
 		return fail(configErr(path, "cannot read: %w", err))
 	}
 	f.Exists = true
@@ -415,8 +422,8 @@ func (f *File) Resolver() kong.Resolver {
 				continue
 			}
 			// An empty db path is how a file says "leave it unset". Passing it
-			// on would make kong's existingfile check stat the empty string,
-			// which expands to the working directory.
+			// on would have kong's path mapper expand the empty string to the
+			// working directory and hand that over as the database.
 			if k.Name == dbKey && v == "" {
 				continue
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,6 +216,11 @@ type File struct {
 	Source string
 	Exists bool
 
+	// Err is why the file could not be used, when it could not be. The File is
+	// still returned so the diagnostic commands can report which file is at
+	// fault; it supplies no values in that state.
+	Err error
+
 	// values holds only the keys the file actually set, under their canonical
 	// names.
 	values map[string]any
@@ -223,43 +228,65 @@ type File struct {
 
 // Load reads and validates the config file at path. A file that is not there
 // yields an empty File rather than an error.
+//
+// The File is never nil, even when the error is not: a file that cannot be
+// read still has a path and an existence, which is what `things config path`
+// and `things config show` need in order to tell the user which file is
+// broken. Such a File supplies no values.
 func Load(path string) (*File, error) {
 	f := &File{Path: path, Source: SourceDefault, values: map[string]any{}}
+	fail := func(err error) (*File, error) {
+		f.Err = err
+		f.values = map[string]any{}
+		return f, err
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return f, nil
 		}
-		return nil, configErr(path, "cannot read: %w", err)
+		return fail(configErr(path, "cannot read: %w", err))
 	}
 	f.Exists = true
 
 	var raw map[string]any
 	if err := toml.Unmarshal(data, &raw); err != nil {
-		return nil, configErr(path, "invalid TOML: %s", tomlErrorText(err))
+		return fail(configErr(path, "invalid TOML: %s", tomlErrorText(err)))
 	}
 
 	for name, value := range raw {
 		key, ok := lookup(name)
 		if !ok {
-			return nil, configErr(path, "unknown key %q (valid keys: %s)",
-				name, strings.Join(KeyNames(), ", "))
+			return fail(configErr(path, "unknown key %q (valid keys: %s)",
+				name, strings.Join(KeyNames(), ", ")))
 		}
 		if _, dup := f.values[key.Name]; dup {
-			return nil, configErr(path, "key %q is set twice (%q and %q name the same setting)",
-				key.Name, key.Name, key.Flag)
+			return fail(configErr(path, "key %q is set twice (%q and %q name the same setting)",
+				key.Name, key.Name, key.Flag))
 		}
 		v, err := coerce(key, value)
 		if err != nil {
-			return nil, &Error{Path: path, Err: err}
+			return fail(&Error{Path: path, Err: err})
 		}
 		f.values[key.Name] = v
 	}
 
 	if err := f.checkExclusions(); err != nil {
-		return nil, err
+		return fail(err)
 	}
 	return f, nil
+}
+
+// SetsDB reports whether this file is what put path in play as the database,
+// so a failure to open it can be reported against the file rather than as a
+// bare path error with no clue where the path came from.
+func (f *File) SetsDB(path string) bool {
+	if f == nil || f.Err != nil {
+		return false
+	}
+	v, ok := f.values[dbKey].(string)
+	return ok && v != "" && kong.ExpandPath(v) == path
 }
 
 // checkExclusions rejects two mutually exclusive settings both turned on. Kong
@@ -381,9 +408,7 @@ func (f *File) Resolver() kong.Resolver {
 	values := map[string]any{}
 	excludes := map[string][]string{}
 	commands := map[string][]string{}
-	path := ""
-	if f != nil {
-		path = f.Path
+	if f != nil && f.Err == nil {
 		for _, k := range Keys {
 			v, ok := f.values[k.Name]
 			if !ok {
@@ -428,17 +453,6 @@ func (f *File) Resolver() kong.Resolver {
 			for _, other := range parent.Flags {
 				if other.Name == name && other.Set {
 					return nil, nil
-				}
-			}
-		}
-		// A db path that does not exist is reported here, naming the config
-		// file, rather than as a bare flag error. Kong skips resolvers for
-		// flags given on the command line, so --db still overrides a stale
-		// entry instead of tripping over it.
-		if flag.Name == dbKey {
-			if s, ok := v.(string); ok {
-				if _, err := os.Stat(kong.ExpandPath(s)); err != nil {
-					return nil, configErr(path, "db: %s", err)
 				}
 			}
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -121,6 +121,29 @@ func TestLoadMissingFileIsNotAnError(t *testing.T) {
 	}
 }
 
+func TestLoadMarksAnUnreadableFileAsExisting(t *testing.T) {
+	// A directory at the config path is the portable stand-in for a file that
+	// is there but cannot be read: os.ReadFile fails with something other than
+	// "not exist". Reporting Exists false would let `config init` overwrite it.
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	f, err := Load(path)
+	if err == nil {
+		t.Fatal("Load: want an error for a file that cannot be read")
+	}
+	if f == nil {
+		t.Fatal("Load returned a nil File alongside its error")
+	}
+	if !f.Exists {
+		t.Error("Exists = false for a file that is there but cannot be read")
+	}
+	if f.Err == nil {
+		t.Error("Err = nil on a File that failed to load")
+	}
+}
+
 func TestLoadReadsEveryKey(t *testing.T) {
 	path := write(t, `
 json = true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -204,30 +204,87 @@ func resolveFlag(t *testing.T, f *File, name string) (any, error) {
 	return f.Resolver().Resolve(nil, nil, &kong.Flag{Value: &kong.Value{Name: name}})
 }
 
-// A db path that has gone missing must not fail until kong actually asks for
-// it, so that a --db flag on the command line still overrides it.
-func TestResolverReportsMissingDB(t *testing.T) {
-	path := write(t, `db = "/nonexistent/things.sqlite"`+"\n")
-	f, err := Load(path)
+// A db path that has gone missing is not the resolver's problem: failing here
+// would take out every command, including the ones that exist to tell the user
+// the path is stale. The caller checks it when it opens the database.
+func TestResolverPassesMissingDBThrough(t *testing.T) {
+	stale := "/nonexistent/things.sqlite"
+	f, err := Load(write(t, `db = "`+stale+`"`+"\n"))
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if _, err := resolveFlag(t, f, "json"); err != nil {
-		t.Fatalf("resolving an unrelated flag: %v", err)
+	v, err := resolveFlag(t, f, "db")
+	if err != nil {
+		t.Fatalf("resolving db: %v", err)
 	}
-	_, err = resolveFlag(t, f, "db")
+	if v != stale {
+		t.Errorf("db = %v, want %q", v, stale)
+	}
+}
+
+// SetsDB is what lets the caller blame the file for a path the file supplied.
+func TestSetsDB(t *testing.T) {
+	stale := "/nonexistent/things.sqlite"
+	f, err := Load(write(t, `db = "`+stale+`"`+"\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !f.SetsDB(stale) {
+		t.Errorf("SetsDB(%q) = false, want true", stale)
+	}
+	if f.SetsDB("/somewhere/else.sqlite") {
+		t.Error("SetsDB reported a path the file never mentioned")
+	}
+
+	unset, err := Load(write(t, "json = true\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if unset.SetsDB(stale) {
+		t.Error("a file with no db key should not claim a path")
+	}
+	if (&File{}).SetsDB("") {
+		t.Error("an empty db should never be claimed")
+	}
+	var nilFile *File
+	if nilFile.SetsDB(stale) {
+		t.Error("a nil File should claim nothing")
+	}
+}
+
+// A file that would not load supplies nothing at all — otherwise a half-read
+// file would seed some defaults and not others.
+func TestBrokenFileResolvesNothingButKeepsItsPath(t *testing.T) {
+	path := write(t, "json = true\nnope = 1\n")
+	f, err := Load(path)
 	if err == nil {
-		t.Fatal("resolving db: want error, got nil")
+		t.Fatal("Load: want error, got nil")
 	}
-	for _, want := range []string{path, "db:", "/nonexistent/things.sqlite"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("error %q does not contain %q", err, want)
+	if f == nil {
+		t.Fatal("Load returned no File; the diagnostic commands need its path")
+	}
+	if f.Path != path || !f.Exists {
+		t.Errorf("File = {Path: %q, Exists: %v}, want {%q, true}", f.Path, f.Exists, path)
+	}
+	if f.Err == nil {
+		t.Error("File.Err is nil on a file that failed to load")
+	}
+	v, resolveErr := resolveFlag(t, f, "json")
+	if resolveErr != nil {
+		t.Fatalf("resolving json: %v", resolveErr)
+	}
+	if v != nil {
+		t.Errorf("json resolved to %v from a file that failed to load", v)
+	}
+	for _, s := range f.Settings() {
+		if s.Source != "default" {
+			t.Errorf("%s came from a file that failed to load", s.Key)
 		}
 	}
 }
 
-// An empty db is how a file says "unset". Handing "" to kong's existingfile
-// check would stat the working directory and fail.
+// An empty db is how a file says "unset", so it must not reach the flag as a
+// path of its own.
 func TestResolverSkipsEmptyDB(t *testing.T) {
 	f, err := Load(write(t, "db = \"\"\n"))
 	if err != nil {


### PR DESCRIPTION
## What changed

A config file the CLI cannot use no longer disables the commands that exist to tell you so. `things config path`, `things config show`, `things config init` and `--help` all work against a file with a stale `db` path, or one that will not parse at all.

## The stale `db` path

The `db` value was stat-checked in the config resolver, during flag resolution, so a path that had moved broke every command — including the two you would reach for to find the file.

The check moved to `(*Deps).Database`, at the point a command actually opens the database. The error text and the attribution to the config file are unchanged:

```
Error: config file ~/.config/things-cli/config.toml: db: stat /old/main.sqlite: no such file or directory
```

Getting there needed one more change than expected. Removing the check from the resolver did not fix it, because `--db` carried `type:"existingfile"` and kong's mapper stats resolver-supplied values too — the failure just moved from my error to kong's, with a usage dump and no mention of the config file. So `--db` is now `type:"path"` (still expanding `~`), and this check covers both sources.

That means a nonexistent `--db` on the command line is reported when the database is opened rather than at parse time, as `Error: cannot open the Things database: …` instead of a usage block. `existingfile` also rejected directories, so the replacement does that explicitly — sqlite accepts a directory and fails much later with an opaque pragma error.

`config.File.SetsDB` is what lets the error name the file: it reports whether the file is what put that path in play, so a path from `--db` or from auto-detection is reported on its own terms.

## The unreadable file

Previously `loadConfig` failing meant `main` exited before the parser existed, taking `--help` and the `config` commands with it.

Now a file that fails to load supplies no defaults but does not stop the run. Parsing continues on built-in defaults, and the failure is reported once the command is known — unless that command implements `configDiagnostic`, a marker interface on `ConfigPathCmd`, `ConfigShowCmd` and `ConfigInitCmd`. A marker rather than a name match, so the exempt set cannot drift from the commands that implement it. `--help` and `--version` never reach the gate; kong answers them during `Parse`.

Behaviour against a broken file:

- `config path` prints the path and `(exists)`, warns on stderr that the file cannot be used, and exits `0`. Which file is in use is a fact about the path, not its contents. `--json` carries the problem in an `error` field.
- `config show` prints `config: <path> (exists)` and then reports the problem, exit `2`. Under `--json` the header is suppressed so it cannot sit in front of the JSON object.
- `config init` refuses as usual but says why the file is unusable; `--force` replaces it with a fresh template, so the file can be repaired from the CLI.

## Two data-loss bugs found on the way

Both were mine, both are fixed and covered by tests.

`loadConfig` still returned `nil` alongside its error. The nil sent `(*Deps).config()` to a fallback that resolved the **real** default path, so `things --config <scratch> config init` ignored `--config` and wrote to `~/.config/things-cli/config.toml`. `loadConfig` now always returns the File it failed on, and the fallback no longer resolves a real path — a `Deps` built without a config yields an empty File, and `config init` refuses rather than inventing a destination.

`/code-review` then found that `Load` marked a file it could not **read** (permission denied, or a directory at the path) as not existing, so `config init` would silently overwrite it without `--force` and exit `0`. `Exists` is now set whenever something is at the path.

## How tested

`make test` (`go test -race ./...`) and `make lint` clean.

`TestDiagnosticsSurviveABrokenConfig` runs `config path`, `config show`, `config init` and `config init --force` against five kinds of broken file — stale `db`, unknown key, malformed TOML, wrong value type, one option under both spellings — asserting each command reports the file, that `init` leaves it byte-for-byte unchanged, and that `--force` produces a file that loads. Plus:

- `TestBrokenConfigStillParses` — parsing succeeds on a broken file and seeds no defaults from it.
- `TestDiagnosesConfigMarksOnlyTheConfigCommands` — the marker covers the three `config` commands and nothing else.
- `TestFlagBeatsStaleConfigDB` — parsing no longer fails on a stale entry; `--db` opens fine; without it the error unwraps to `*config.Error` naming the file.
- `TestMissingDBWithoutConfigAttribution` — a path no file supplied is not blamed on one.
- `TestLoadMarksAnUnreadableFileAsExisting`, `TestSetsDB`, `TestBrokenFileResolvesNothingButKeepsItsPath`, `TestResolverPassesMissingDBThrough`.

The test harness in `run_test.go` now mirrors `main` — it keeps the File on a load error and applies the same gate — so these paths are exercised the way the binary runs them rather than through a shortcut.

Manually verified: `config init` refuses on a mode-0222 file and leaves it untouched; `--db /tmp` reports a directory; `config path` with no `$HOME` or `$XDG_CONFIG_HOME` reports that rather than printing an empty path.

## Removed

The `*config.Error` branch in `main`'s parse-error handling. The resolver no longer returns errors, so no parse failure can be a config error, and the test covering that branch went with it. If a future key can fail at parse time the branch should come back with a test.

## Docs

`docs/_tabs/configuration.md` had documented the old behaviour in #178 — the "caught while the flags are resolved" paragraph and the warning that a broken file stops `--help`. Both replaced, with a new "The diagnostic commands always run" section showing the real output. README and `commands.md` updated to match.

Closes #179
