### PR TITLE
docs(site): add configuration tab to locale

### DIFF
--- a/docs/_data/locales/en.yml
+++ b/docs/_data/locales/en.yml
@@ -17,6 +17,7 @@ tabs:
   about: About
   install: Install
   commands: Commands
+  configuration: Configuration
 
 # the text displayed in the search bar & search results
 search:

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -60,7 +60,7 @@
       {%- capture title -%}
         {%- if page.collection == 'tabs' -%}
           {%- assign tab_key = page.title | downcase -%}
-          {{- site.data.locales[include.lang].tabs[tab_key] -}}
+          {{- site.data.locales[include.lang].tabs[tab_key] | default: page.title -}}
         {%- else -%}
           {{- page.title -}}
         {%- endif -%}


### PR DESCRIPTION
## What changed

Two commits, separable.

**`docs(site): add configuration tab to locale`** — the fix. Chirpy takes a tab page's browser title from the `tabs:` map in `docs/_data/locales/en.yml`, keyed by the lowercased page title. The map listed `install` and `commands` but not `configuration`, so the tab added in #178 rendered with an empty `<title>`. One line: `configuration: Configuration`.

**`docs(site): fall back to the page title when a tab has no locale entry`** — optional, drop it if you would rather not touch the override. `docs/_includes/head.html:63` reads the locale map with no `default:` filter, which is why a missing key produced an empty title rather than an imperfect one. The theme's own equivalents both carry the fallback, so the override looks like it diverged by accident:

| Where | Code | Fallback |
| --- | --- | --- |
| `docs/_includes/head.html` (this repo) | `site.data.locales[include.lang].tabs[tab_key]` | none — **the bug** |
| theme `_includes/sidebar.html` | `... tabs.[tab_name] \| default: tab.title \| upcase` | yes |
| theme `_layouts/page.html` | `... tabs[tab_key] \| default: page.title` | yes |

Adding `| default: page.title` matches upstream and makes the next tab self-healing.

## What else depends on the locale

Nothing else on the page was broken. The sidebar label and the `<h1>` both go through the theme, and both already fall back to the front-matter title, so they rendered "CONFIGURATION" and "Configuration" correctly all along — the empty `<title>` was the only symptom. `jekyll-seo-tag` uses `page.title` directly and is unaffected.

Checked every tab against the map: `about`, `commands`, `configuration` and `install` all now have a key matching their lowercased title.

## How verified

Not by building the site — there is no PR-time docs check (`pages.yml` runs only on push to `main`), and a local `bundle exec jekyll build` is not possible here: system Ruby is 2.6.10 and `jekyll-theme-chirpy ~> 7.2` needs 3.1+.

Instead: `en.yml` parses as YAML with the expected `tabs` map, every `docs/_tabs/*.md` front-matter title lowercases to a key present in it, and the two theme templates were read at the `v7.2.4` tag to confirm where the fallbacks are and that `head.html` is the only place without one.

`make test` and `make lint` are clean, though neither touches the site.

## Possible follow-up

A tab whose locale key is missing is now cosmetic rather than broken, so nothing further is needed. If you would rather it were caught outright, a check that every `docs/_tabs/*.md` title has a key in `en.yml` would do it — it is the same shape as the docs-sync tests from #178, though it would need a home, since nothing under `docs/` is Go.
