### PR TITLE
docs(config): describe the config file as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ wrong — is on the docs site under
 
 The file is read from `$XDG_CONFIG_HOME/things-cli/config.toml`, falling
 back to `~/.config/things-cli/config.toml`. Override the location with
-`--config PATH` or the `THINGS_CLI_CONFIG` environment variable. A missing
-file is not an error — `things` runs on its built-in defaults.
+`--config PATH` or the `THINGS_CLI_CONFIG` environment variable. The file is
+optional — without one, `things` runs on its built-in defaults.
 
 ```sh
 things config init     # write a commented template (refuses to overwrite; --force to replace)

--- a/docs/_tabs/configuration.md
+++ b/docs/_tabs/configuration.md
@@ -23,10 +23,9 @@ nothing you put here can take an option away from you.
 | 3 | `$XDG_CONFIG_HOME/things-cli/config.toml` | Only when `XDG_CONFIG_HOME` is set |
 | 4 | `~/.config/things-cli/config.toml` | The default |
 
-> **A missing file is not an error.** With no config file at all, `things`
-> runs on its built-in defaults. That is also true of a path you named
-> yourself — run `things config path` to see which file is in use and
-> whether it exists.
+> **The config file is optional.** Without one, `things` runs on its
+> built-in defaults. The same applies to a path you name yourself; run
+> `things config path` to see which file is in use and whether it exists.
 {: .prompt-info }
 
 `~` and relative paths are expanded, so `--config ./project.toml` works.
@@ -107,7 +106,8 @@ commented out. Uncomment a line to change that default.
 #
 # Read from $XDG_CONFIG_HOME/things-cli/config.toml, or
 # ~/.config/things-cli/config.toml. Override with --config PATH or
-# $THINGS_CLI_CONFIG. A missing file is not an error.
+# $THINGS_CLI_CONFIG. The file is optional; without it, things runs on
+# its built-in defaults.
 #
 # Uncomment a line to change the default.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,8 +209,8 @@ func ResolvePath(explicit string) (path, source string, err error) {
 	return p, SourceDefault, nil
 }
 
-// File is a loaded config file. A file that does not exist loads fine with
-// Exists false and no values; a missing config file is not an error.
+// File is a loaded config file. The file is optional: one that is not there
+// loads fine, with Exists false and no values.
 type File struct {
 	Path   string
 	Source string
@@ -226,8 +226,8 @@ type File struct {
 	values map[string]any
 }
 
-// Load reads and validates the config file at path. A file that is not there
-// yields an empty File rather than an error.
+// Load reads and validates the config file at path. The file is optional, so
+// one that is not there yields an empty File rather than an error.
 //
 // The File is never nil, even when the error is not: a file that cannot be
 // read still has a path and an existence, which is what `things config path`
@@ -492,7 +492,8 @@ func Template() string {
 	b.WriteString("#\n")
 	b.WriteString("# Read from $XDG_CONFIG_HOME/things-cli/config.toml, or\n")
 	b.WriteString("# ~/.config/things-cli/config.toml. Override with --config PATH or\n")
-	b.WriteString("# $" + EnvVar + ". A missing file is not an error.\n")
+	b.WriteString("# $" + EnvVar + ". The file is optional; without it, things runs on\n")
+	b.WriteString("# its built-in defaults.\n")
 	b.WriteString("#\n")
 	b.WriteString("# Uncomment a line to change the default.\n")
 	for _, k := range Keys {


### PR DESCRIPTION
## What changed

"A missing file is not an error" describes the config file by what does not go wrong. "The file is optional" says what it is. Replaced everywhere it appeared.

**User-facing text:**

- `docs/_tabs/configuration.md` — the callout under the lookup table:

  > **The config file is optional.** Without one, `things` runs on its built-in defaults. The same applies to a path you name yourself; run `things config path` to see which file is in use and whether it exists.

- `README.md` — "The file is optional — without one, `things` runs on its built-in defaults."

- `internal/config/config.go`, the `config init` template header:

  ```
  # Read from $XDG_CONFIG_HOME/things-cli/config.toml, or
  # ~/.config/things-cli/config.toml. Override with --config PATH or
  # $THINGS_CLI_CONFIG. The file is optional; without it, things runs on
  # its built-in defaults.
  ```

  Wrapped over two lines to stay inside the 72 columns the rest of the header uses; the suggested single line was 73.

**Doc comments**, so the code reads the same way as the docs: the comments on `config.File` and `config.Load` now say the file is optional rather than that its absence is not an error.

## The template and the page

The `toml` block on the configuration page has to stay byte-identical to `Template()` — `TestDocsPageQuotesTheTemplate` enforces it — so both changed together. The page block was regenerated by running `things config init` and pasting the result, not hand-edited, so the two cannot have drifted in the edit.

## Also checked

`docs/_tabs/commands.md` and `internal/skill/SKILL.md` do not carry the phrase. Neither describes the missing-file case at all: `commands.md` links to the configuration page for it, and SKILL.md says "the user **may** have a TOML file", which already reads as optional. Left both alone.

`grep -rn "not an error"` across `README.md`, `docs/`, `internal/` and `cmd/` now returns nothing.

## How tested

`make test` (`go test -race ./...`) and `make lint` clean, including the three docs-sync tests from #178 — the template check is what proves the page and the binary still agree.

Not verified by building the site, for the reasons in #178 and #181: no PR-time docs check, and no local Ruby new enough for `jekyll-theme-chirpy ~> 7.2`. The page edits are prose inside an existing callout and an existing fenced block, with no structural change.
