### PR TITLE
build: stamp version, commit and date into local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,18 @@
 
 BINARY := things
 
+# Stamp the same variables goreleaser sets (see .goreleaser.yaml) so a local
+# build reports which commit it came from instead of "dev (commit none)".
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
+
 build:
-	go build -o $(BINARY) ./cmd/things
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/things
 
 install:
-	go install ./cmd/things
+	go install -ldflags "$(LDFLAGS)" ./cmd/things
 
 lint:
 	golangci-lint run ./...


### PR DESCRIPTION
`make build` and `make install` now pass the same `-X main.version/commit/date` ldflags goreleaser sets, so a local binary reports `things v0.7.0-3-gabc1234 (commit abc1234, built 2026-09-05T13:30:28Z)` instead of `things dev (commit none, built unknown)`. Version comes from `git describe --tags --always --dirty`, so an exact tag shows as `v0.7.0` and uncommitted tracked changes add `-dirty`. Each variable can be overridden (`make install VERSION=x`). Outside a git checkout the old `dev`/`none` values are used.

Tested: `make build && ./things version` and `make install && things version` from a worktree.