### PR TITLE
ci(pages): let workflow_dispatch deploy again

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -67,7 +67,7 @@ jobs:
           path: "docs/public"
 
   deploy:
-    if: github.event_name == 'push'
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- Restore manual deploys: the deploy job's condition changes from `github.event_name == 'push'` to `github.event_name != 'pull_request'`, so both push-to-main and workflow_dispatch runs deploy, and only pull_request runs stop at build.

## Notes
- Follow-up to #186, where the previous condition unintentionally dropped workflow_dispatch as a deploy trigger.
- The build check is expected to stay red until the parallel docs/ Hugo content migration lands (docs/ is still Jekyll) — same known issue as #186, not something this PR touches.

## Test plan
- [ ] build job runs on this PR (expected build failure, docs/ still Jekyll)