### PR TITLE
fix(edit): refuse a project reference instead of opening things:///update

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,10 @@ the same route, so `--json` never leaves a usage block on stdout. Without
 `--json`, errors stay a plain `Error: ...` line on stderr, unchanged.
 
 `not a task` means the reference resolved to something the command cannot act
-on. Today that is a project handed to `edit`: the payload carries `kind`,
-`query`, `uuid` and `title`, and nothing has been written — retry with `things
-project edit`.
+on. Today that is a project handed to `edit`: the payload carries `kind` —
+what the reference turned out to be, not what was looked up — plus `query`,
+`uuid` and `title`, and nothing has been written. Retry with `things project
+edit`.
 
 #### Batch failures: `items`
 
@@ -432,6 +433,10 @@ things project add "Launch site" --area Work --deadline 2026-05-01
 `things project edit <project>` updates a project via
 `things:///update-project`. Only the flags you pass are sent — unset fields
 stay untouched. An empty value clears the field (e.g. `--deadline ""`).
+
+`edit` is for to-dos only. A reference that resolves to a project is refused
+before anything is written — `things:///update` cannot address one — so use
+`things project edit` for those. See [Errors under `--json`](#errors-under---json).
 
 > **Prerequisite:** `edit`, `project edit`, and `import` payloads with
 > `operation: update` require the Things auth token. Enable it once via

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ how a project completes under `--json`.
 
 A failing command prints a single JSON object to stdout and exits non-zero, so
 a consumer parsing stdout gets a structured failure either way. `error` is a
-stable token — `ambiguous task`, `not found`, `import refused`, `import
-partially applied`, or `error` for anything else — and `message` carries the
-same text plain-text mode prints.
+stable token — `ambiguous task`, `not found`, `not a task`, `import refused`,
+`import partially applied`, or `error` for anything else — and `message`
+carries the same text plain-text mode prints.
 
 ```console
 $ things show milk --json; echo "exit=$?"
@@ -88,6 +88,11 @@ exit=1
 Retry with one of the `matches[].uuid` values. Argument and flag errors take
 the same route, so `--json` never leaves a usage block on stdout. Without
 `--json`, errors stay a plain `Error: ...` line on stderr, unchanged.
+
+`not a task` means the reference resolved to something the command cannot act
+on. Today that is a project handed to `edit`: the payload carries `kind`,
+`query`, `uuid` and `title`, and nothing has been written — retry with `things
+project edit`.
 
 #### Batch failures: `items`
 

--- a/cmd/things/errors.go
+++ b/cmd/things/errors.go
@@ -83,10 +83,14 @@ type notATaskError struct {
 	Query string
 	UUID  string
 	Title string
+	// Retry is the command that does handle this kind, spelled out rather
+	// than derived from Kind — "project" happens to read as a command name,
+	// but a second kind would silently name a command that does not exist.
+	Retry string
 }
 
 func (e *notATaskError) Error() string {
-	return fmt.Sprintf("%q is a %s; use things %s edit", e.Title, e.Kind, e.Kind)
+	return fmt.Sprintf("%q is a %s; use %s", e.Title, e.Kind, e.Retry)
 }
 
 // ambiguousRefError carries a *db.AmbiguousTaskError alongside the multi-line

--- a/cmd/things/errors.go
+++ b/cmd/things/errors.go
@@ -16,14 +16,16 @@ import (
 // and can branch on the "error" token (issue #152). A successful write command
 // still prints nothing — only the read commands emit JSON on success.
 //
-// Error is a stable token: "ambiguous task", "not found", or "error" for a
-// failure with no structure worth naming. Message is the same text the
-// plain-text path prints, for a human reading the JSON.
+// Error is a stable token: "ambiguous task", "not found", "not a task", or
+// "error" for a failure with no structure worth naming. Message is the same
+// text the plain-text path prints, for a human reading the JSON.
 type jsonErrorPayload struct {
 	Error   string           `json:"error"`
 	Message string           `json:"message"`
 	Kind    string           `json:"kind,omitempty"`
 	Query   string           `json:"query,omitempty"`
+	UUID    string           `json:"uuid,omitempty"`
+	Title   string           `json:"title,omitempty"`
 	Matches []jsonErrorMatch `json:"matches,omitempty"`
 	Items   []jsonErrorItem  `json:"items,omitempty"`
 }
@@ -69,6 +71,22 @@ func (e *notFoundError) Error() string {
 		return e.msg
 	}
 	return fmt.Sprintf("%s not found: %s", e.Kind, e.Query)
+}
+
+// notATaskError is a reference that resolved to something the command cannot
+// act on — today only a project handed to `edit`, which would otherwise open
+// things:///update with a project id and leave Things showing a "does not
+// exist" dialog (issue #189). Kind names what the reference turned out to be,
+// so a caller can retry against the right command.
+type notATaskError struct {
+	Kind  string
+	Query string
+	UUID  string
+	Title string
+}
+
+func (e *notATaskError) Error() string {
+	return fmt.Sprintf("%q is a %s; use things %s edit", e.Title, e.Kind, e.Kind)
 }
 
 // ambiguousRefError carries a *db.AmbiguousTaskError alongside the multi-line
@@ -122,6 +140,16 @@ func errorPayload(err error) jsonErrorPayload {
 	if errors.As(err, &unapplied) {
 		payload.Error = "import partially applied"
 		payload.Items = unapplied.jsonItems()
+		return payload
+	}
+
+	var notATask *notATaskError
+	if errors.As(err, &notATask) {
+		payload.Error = "not a task"
+		payload.Kind = notATask.Kind
+		payload.Query = notATask.Query
+		payload.UUID = notATask.UUID
+		payload.Title = notATask.Title
 		return payload
 	}
 

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -539,6 +539,14 @@ func (c *EditCmd) Run(d *Deps) error {
 	if err != nil {
 		return err
 	}
+	// resolveTask returns projects too, and things:///update cannot address
+	// one: Things answers a project id with a modal "does not exist" dialog
+	// and changes nothing (issue #189). Refuse before anything is opened
+	// rather than routing to update-project, which would silently drop the
+	// task-only flags (checklist, list, heading).
+	if task.Type == model.TypeProject {
+		return &notATaskError{Kind: "project", Query: c.Task, UUID: task.UUID, Title: task.Title}
+	}
 	if err := checkRepeating(task, restrictedEdits(c.When, c.Deadline, c.Complete, c.Cancel, c.Duplicate)); err != nil {
 		return err
 	}

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -545,7 +545,7 @@ func (c *EditCmd) Run(d *Deps) error {
 	// rather than routing to update-project, which would silently drop the
 	// task-only flags (checklist, list, heading).
 	if task.Type == model.TypeProject {
-		return &notATaskError{Kind: "project", Query: c.Task, UUID: task.UUID, Title: task.Title}
+		return &notATaskError{Kind: "project", Query: c.Task, UUID: task.UUID, Title: task.Title, Retry: "things project edit"}
 	}
 	if err := checkRepeating(task, restrictedEdits(c.When, c.Deadline, c.Complete, c.Cancel, c.Duplicate)); err != nil {
 		return err

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -430,6 +430,44 @@ func TestRunCompleteProjectRequiresConfirmation(t *testing.T) {
 	}
 }
 
+// `edit` resolves projects as well as to-dos, but things:///update cannot
+// address a project — Things shows a "does not exist" dialog and writes
+// nothing (issue #189). The reference must be refused before `open` runs, and
+// under --json with the "not a task" token so an agent can retry against
+// `project edit`.
+func TestRunEditRefusesProjectReference(t *testing.T) {
+	database, _ := seedProject(t)
+	captured := stubExec(t)
+
+	err := runWith(t, database, "--json", "edit", "Chores", "--title", "Errands")
+	if err == nil {
+		t.Fatal("expected edit to refuse a project reference")
+	}
+	if len(*captured) != 0 {
+		t.Errorf("no URL should be opened, got %v", *captured)
+	}
+	if want := `"Chores" is a project; use things project edit`; err.Error() != want {
+		t.Errorf("message = %q, want %q", err.Error(), want)
+	}
+
+	payload, raw := decodePayload(t, err)
+	if payload.Error != "not a task" {
+		t.Errorf("error = %q, want %q (%s)", payload.Error, "not a task", raw)
+	}
+	if payload.Kind != "project" {
+		t.Errorf("kind = %q, want %q", payload.Kind, "project")
+	}
+	if payload.Query != "Chores" {
+		t.Errorf("query = %q, want %q", payload.Query, "Chores")
+	}
+	if payload.UUID != "proj-1" {
+		t.Errorf("uuid = %q, want %q", payload.UUID, "proj-1")
+	}
+	if payload.Title != "Chores" {
+		t.Errorf("title = %q, want %q", payload.Title, "Chores")
+	}
+}
+
 func TestIsInteractiveStdinPipe(t *testing.T) {
 	// In `go test`, stdin is typically not a TTY. Just call it for coverage;
 	// don't assert on the result since test runners vary.

--- a/docs/content/commands.md
+++ b/docs/content/commands.md
@@ -112,6 +112,10 @@ things edit 3 --append-checklist "Almond too"
 things edit 3 --complete                 # also: --cancel, --duplicate, --reveal
 ```
 
+`edit` is for to-dos only. A reference that resolves to a project is refused
+before anything is written, because `things:///update` cannot address one —
+use `things project edit` instead.
+
 `things project edit` takes most of the same flags (`--title`, `--notes`,
 `--prepend-notes`/`--append-notes`, `--when`, `--deadline`, `--tags`,
 `--add-tags`, `--complete`, `--cancel`, `--duplicate`, `--reveal`) plus

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -42,10 +42,12 @@ Most commands accept `--json` / `-j`. Prefer it when parsing. It also guarantees
 {"error": "ambiguous task", "message": "...", "kind": "task", "query": "milk",
  "matches": [{"uuid": "...", "title": "Buy milk", "project": "Chores"}]}
 {"error": "not found", "message": "task not found: milk", "kind": "task", "query": "milk"}
+{"error": "not a task", "message": "\"Chores\" is a project; use things project edit",
+ "kind": "project", "query": "Chores", "uuid": "...", "title": "Chores"}
 {"error": "error", "message": "..."}
 ```
 
-On `ambiguous task`, retry with one of `matches[].uuid`. This covers argument and flag errors too — `things --json show` with no argument returns the object, not a usage block. Without `--json`, errors stay a plain `Error: ...` line on stderr.
+On `ambiguous task`, retry with one of `matches[].uuid`. On `not a task` the reference resolved to a project, `edit` wrote nothing, and the retry is `things project edit <uuid>`. This covers argument and flag errors too — `things --json show` with no argument returns the object, not a usage block. Without `--json`, errors stay a plain `Error: ...` line on stderr.
 
 `import` fails per item, so its two failures add an `items` array — act on that rather than parsing `message`:
 
@@ -162,6 +164,7 @@ things tag add <name>...        # create tags; existing names are skipped
 things add <title> [--notes --when --deadline --tags --checklist --project --heading --list --strict-tags --create-tags]
 things project add <title> [--notes --when --deadline --tags --area --todos --strict-tags --create-tags]
 things edit <task> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --checklist --prepend-checklist --append-checklist --list --list-id --heading --heading-id --complete --cancel --duplicate --reveal --strict-tags --create-tags]
+    # to-dos only; a project reference is refused — edit projects with `things project edit`
 things project edit <project> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --area --area-id --complete --cancel --duplicate --reveal --strict-tags --create-tags]
 things complete <task> [-y|--yes]   # task or project; a project asks first (rule 4)
 things cancel <task> [-y|--yes]


### PR DESCRIPTION
`things edit <project>` resolved the reference fine — `resolveTask` returns projects as well as to-dos — and then opened `things:///update?id=<project uuid>`. Things answers a project id there with a modal "Cannot update to-do with ID … because it does not exist", steals focus, and changes nothing.

`edit` now refuses a project before any URL is opened. Plain text on stderr:

```
Error: "Chores" is a project; use things project edit
```

Under `--json` it is a new stable token, `not a task`, carrying `kind`, `query`, `uuid` and `title`, so an agent can branch on it and retry against the right command.

I refused rather than routing to `update-project`. Routing would silently drop the task-only flags — `--checklist`, `--list`, `--heading` — so a caller could get a partial edit reported as a success.

Also here: a test that sends a project reference through `edit` and asserts nothing is opened and the token is right; the new token in `internal/skill/SKILL.md` and the README error list; and a line in the README and site command pages saying `edit` is for to-dos only, where someone reads about editing rather than only in the error section.

One thing left alone deliberately: the mirror case, `things project edit <to-do>`, still returns an unstructured `not a project: …`, so under `--json` it lands as the generic `error` token. Fixing that needs its own token and doc entries, so it belongs in its own change.

Closes #189