### PR TITLE
ci(site): derive the site version from tags and rebuild on release

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # `git describe` below needs both the tags and the commits
+          # connecting HEAD to them. The default shallow checkout has neither:
+          # actions/checkout passes --no-tags at depth 1, and adding
+          # fetch-tags: true brings the tag refs but not the history describe
+          # has to walk to reach them. Depth 0 fetches both, so describe
+          # resolves instead of silently falling back on every build.
+          fetch-depth: 0
           persist-credentials: false
+
+      # The landing page shows the current version. Take it from the newest v*
+      # tag reachable from this ref so a release updates the badge on its own;
+      # docs/hugo.toml keeps the value used for local builds.
+      - name: Resolve the released version
+        run: |
+          set -euo pipefail
+          if tag=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null); then
+            echo "HUGO_PARAMS_VERSION=${tag#v}" >> "$GITHUB_ENV"
+            echo "Building the site as version ${tag#v} (from tag ${tag})."
+          else
+            echo "No v* tag reachable from HEAD — keeping the version set in docs/hugo.toml."
+          fi
 
       - name: Install Hugo
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,3 +100,28 @@ jobs:
           subject-path: |
             dist/*.tar.gz
             dist/checksums.txt
+
+  # The site's version badge is derived from the newest v* tag, so the release
+  # has to exist before the site is rebuilt. goreleaser creates it with this
+  # workflow's own token, and a release made that way does not trigger other
+  # workflows — so ask for the rebuild explicitly. Dispatch on main rather than
+  # the tag: that is the ref Pages deploys from.
+  #
+  # A separate job on purpose: `actions: write` is scoped to a job, not a step,
+  # so granting it alongside the signing keys and the tap token would hand it
+  # to goreleaser and everything goreleaser downloads. Splitting it also keeps
+  # a failed dispatch from failing the release job itself — the artifacts are
+  # already published by then, and re-running that job would re-run goreleaser
+  # against a release that already exists.
+  rebuild-site:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Rebuild the site for the new version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No checkout in this job, so gh cannot infer the repo from a remote.
+          GH_REPO: ${{ github.repository }}
+        run: gh workflow run pages.yml --ref main

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -7,9 +7,10 @@ disableKinds = ["taxonomy", "term", "RSS"]
 [params]
   tagline = "A small, AI-friendly CLI for Things3 on macOS"
   description = "List, add, edit and complete your Things 3 tasks from the shell. Every read command speaks JSON, and a bundled agent skill teaches Claude Code, Codex and Pi to drive it."
-  # Shown in the landing page hero badge. Hand-maintained: bump it when a
-  # release goes out. Hugo cannot read git tags, so nothing checks this.
-  # Overridable at build time with HUGO_PARAMS_VERSION.
+  # Shown in the landing page hero badge. This value is the local-dev
+  # fallback only: the Pages workflow derives the real one from the newest
+  # v* tag and passes it in as HUGO_PARAMS_VERSION, so a release updates the
+  # badge without anyone editing this file.
   version = "0.7.0"
   repo = "ryanlewis/things-cli"
   author = "Ryan Lewis"


### PR DESCRIPTION
The landing page hero badge was a hand-set value in `docs/hugo.toml` that nothing checked, so it went stale the moment a release went out. This makes it track the tags, and makes a release rebuild the site.

## Deriving the version

The Pages build resolves the newest `v*` tag reachable from the ref being built and hands it to Hugo as `HUGO_PARAMS_VERSION`:

```sh
if tag=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null); then
  echo "HUGO_PARAMS_VERSION=${tag#v}" >> "$GITHUB_ENV"
fi
```

The value in `hugo.toml` stays, now documented as the local-dev fallback: a build with no tag in reach keeps using it rather than failing.

**This needs `fetch-depth: 0`, not `fetch-tags`.** `actions/checkout` passes `--no-tags` at depth 1, and `fetch-tags: true` brings the tag refs without the history `git describe` has to walk to reach them. I checked both against a real shallow clone — with tags fetched but the history shallow, describe still fails:

```
fatal: No tags can describe '3000b466...'.
```

Either shallow option would have left the badge silently falling back on every build, with nothing failing to say so.

## Rebuilding on release

goreleaser creates the release with the workflow's own token, and a release made that way does not trigger other workflows. So `release.yml` dispatches `pages.yml` once the release is published.

That runs as **its own job** rather than a final step on `goreleaser`. `actions: write` is granted per job, not per step, so putting it on the release job would hand it to goreleaser and everything goreleaser downloads — the one job holding the signing keys and the tap token, and the one wrapped in a harden-runner block policy for exactly that reason. Splitting it also stops a failed dispatch from failing a release that has already shipped, where re-running the job would re-run goreleaser against a release that now exists.

The new job carries no secrets and no checkout, so it gets `GH_REPO` to name the repo that `gh` would otherwise infer from a git remote. No harden-runner on it: per the repo's own convention, egress hardening is earned by holding something worth stealing, and this job holds nothing. `api.github.com:443` was already on the release job's allow-list, so that is unchanged.

## Verification

`actionlint` is clean across all workflows. Every action pin is untouched. The derivation was run locally against the real tags — `v0.7.0` resolves to `0.7.0`, and the badge in a build with that value reads `v0.7.0 · macOS · single binary`; `HUGO_PARAMS_VERSION` demonstrably overrides the config value. The no-tag path falls back and still exits 0. Every past release tag is an ancestor of `main`, so dispatching on `--ref main` will resolve the newest one.

This PR touches `pages.yml`, so the PR build itself exercises the new step — its log is the real proof that `fetch-depth: 0` resolves the tag on a runner.

## Note, not addressed here

`--match 'v*'` also matches pre-release tags, and `release.yml` triggers on `v*` too. Cutting a `v0.8.0-rc.1` would therefore put `0.8.0-rc.1` on the public landing page. No rc tags exist today and whether an rc should move the badge is a product decision, so the matcher is left alone.
