### PR TITLE
fix(project edit): refuse a to-do with the same structured error as edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ how a project completes under `--json`.
 
 A failing command prints a single JSON object to stdout and exits non-zero, so
 a consumer parsing stdout gets a structured failure either way. `error` is a
-stable token — `ambiguous task`, `not found`, `not a task`, `import refused`,
-`import partially applied`, or `error` for anything else — and `message`
-carries the same text plain-text mode prints.
+stable token — `ambiguous task`, `not found`, `not a task`, `not a project`,
+`import refused`, `import partially applied`, or `error` for anything else —
+and `message` carries the same text plain-text mode prints.
 
 ```console
 $ things show milk --json; echo "exit=$?"
@@ -93,7 +93,9 @@ the same route, so `--json` never leaves a usage block on stdout. Without
 on. Today that is a project handed to `edit`: the payload carries `kind` —
 what the reference turned out to be, not what was looked up — plus `query`,
 `uuid` and `title`, and nothing has been written. Retry with `things project
-edit`.
+edit`. `not a project` is the same mistake the other way round — a to-do
+handed to `project edit`, carrying the same fields, with `things edit` as the
+retry.
 
 #### Batch failures: `items`
 
@@ -436,7 +438,8 @@ stay untouched. An empty value clears the field (e.g. `--deadline ""`).
 
 `edit` is for to-dos only. A reference that resolves to a project is refused
 before anything is written — `things:///update` cannot address one — so use
-`things project edit` for those. See [Errors under `--json`](#errors-under---json).
+`things project edit` for those, and `project edit` refuses a to-do the same
+way. See [Errors under `--json`](#errors-under---json).
 
 > **Prerequisite:** `edit`, `project edit`, and `import` payloads with
 > `operation: update` require the Things auth token. Enable it once via

--- a/cmd/things/errors.go
+++ b/cmd/things/errors.go
@@ -16,8 +16,8 @@ import (
 // and can branch on the "error" token (issue #152). A successful write command
 // still prints nothing — only the read commands emit JSON on success.
 //
-// Error is a stable token: "ambiguous task", "not found", "not a task", or
-// "error" for a failure with no structure worth naming. Message is the same
+// Error is a stable token: "ambiguous task", "not found", "not a task",
+// "not a project", or "error" for a failure with no structure worth naming. Message is the same
 // text the plain-text path prints, for a human reading the JSON.
 type jsonErrorPayload struct {
 	Error   string           `json:"error"`
@@ -73,23 +73,28 @@ func (e *notFoundError) Error() string {
 	return fmt.Sprintf("%s not found: %s", e.Kind, e.Query)
 }
 
-// notATaskError is a reference that resolved to something the command cannot
-// act on — today only a project handed to `edit`, which would otherwise open
+// wrongKindError is a reference that resolved to the wrong sort of item for
+// the command: a project handed to `edit`, which would otherwise open
 // things:///update with a project id and leave Things showing a "does not
-// exist" dialog (issue #189). Kind names what the reference turned out to be,
-// so a caller can retry against the right command.
-type notATaskError struct {
+// exist" dialog (issue #189), or a to-do handed to `project edit` (issue
+// #191). Kind names what the reference turned out to be, so a caller can
+// retry against the right command.
+type wrongKindError struct {
+	// Token is the stable --json error token for this direction of the
+	// mistake — "not a task" or "not a project". It names what the command
+	// wanted, while Kind names what it got.
+	Token string
 	Kind  string
 	Query string
 	UUID  string
 	Title string
 	// Retry is the command that does handle this kind, spelled out rather
 	// than derived from Kind — "project" happens to read as a command name,
-	// but a second kind would silently name a command that does not exist.
+	// but "to-do" does not.
 	Retry string
 }
 
-func (e *notATaskError) Error() string {
+func (e *wrongKindError) Error() string {
 	return fmt.Sprintf("%q is a %s; use %s", e.Title, e.Kind, e.Retry)
 }
 
@@ -147,13 +152,13 @@ func errorPayload(err error) jsonErrorPayload {
 		return payload
 	}
 
-	var notATask *notATaskError
-	if errors.As(err, &notATask) {
-		payload.Error = "not a task"
-		payload.Kind = notATask.Kind
-		payload.Query = notATask.Query
-		payload.UUID = notATask.UUID
-		payload.Title = notATask.Title
+	var wrongKind *wrongKindError
+	if errors.As(err, &wrongKind) {
+		payload.Error = wrongKind.Token
+		payload.Kind = wrongKind.Kind
+		payload.Query = wrongKind.Query
+		payload.UUID = wrongKind.UUID
+		payload.Title = wrongKind.Title
 		return payload
 	}
 

--- a/cmd/things/errors.go
+++ b/cmd/things/errors.go
@@ -17,8 +17,9 @@ import (
 // still prints nothing — only the read commands emit JSON on success.
 //
 // Error is a stable token: "ambiguous task", "not found", "not a task",
-// "not a project", or "error" for a failure with no structure worth naming. Message is the same
-// text the plain-text path prints, for a human reading the JSON.
+// "not a project", or "error" for a failure with no structure worth naming.
+// Message is the same text the plain-text path prints, for a human reading
+// the JSON.
 type jsonErrorPayload struct {
 	Error   string           `json:"error"`
 	Message string           `json:"message"`
@@ -154,7 +155,12 @@ func errorPayload(err error) jsonErrorPayload {
 
 	var wrongKind *wrongKindError
 	if errors.As(err, &wrongKind) {
-		payload.Error = wrongKind.Token
+		// Token is what a caller branches on, so an unset one would ship
+		// `"error": ""` — a value no consumer can match. Fall back to the
+		// generic token instead.
+		if wrongKind.Token != "" {
+			payload.Error = wrongKind.Token
+		}
 		payload.Kind = wrongKind.Kind
 		payload.Query = wrongKind.Query
 		payload.UUID = wrongKind.UUID

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -462,8 +462,19 @@ func (c *ProjectEditCmd) Run(d *Deps) error {
 	if err != nil {
 		return err
 	}
+	// The mirror of the guard in EditCmd.Run: a to-do here would go to
+	// things:///update-project, which cannot address one (issue #191). Same
+	// structured error, so an agent can branch on the token in either
+	// direction rather than string-matching the message.
 	if project.Type != model.TypeProject {
-		return fmt.Errorf("not a project: %s", project.Title)
+		return &wrongKindError{
+			Token: "not a project",
+			Kind:  "to-do",
+			Query: c.Project,
+			UUID:  project.UUID,
+			Title: project.Title,
+			Retry: "things edit",
+		}
 	}
 	if err := checkRepeating(project, restrictedEdits(c.When, c.Deadline, c.Complete, c.Cancel, c.Duplicate)); err != nil {
 		return err
@@ -545,7 +556,14 @@ func (c *EditCmd) Run(d *Deps) error {
 	// rather than routing to update-project, which would silently drop the
 	// task-only flags (checklist, list, heading).
 	if task.Type == model.TypeProject {
-		return &notATaskError{Kind: "project", Query: c.Task, UUID: task.UUID, Title: task.Title, Retry: "things project edit"}
+		return &wrongKindError{
+			Token: "not a task",
+			Kind:  "project",
+			Query: c.Task,
+			UUID:  task.UUID,
+			Title: task.Title,
+			Retry: "things project edit",
+		}
 	}
 	if err := checkRepeating(task, restrictedEdits(c.When, c.Deadline, c.Complete, c.Cancel, c.Duplicate)); err != nil {
 		return err

--- a/cmd/things/run_test.go
+++ b/cmd/things/run_test.go
@@ -468,6 +468,42 @@ func TestRunEditRefusesProjectReference(t *testing.T) {
 	}
 }
 
+// The mirror of the above (issue #191): a to-do handed to `project edit` must
+// be refused the same way, so an agent branching on the token handles both
+// directions of the mistake rather than only one.
+func TestRunProjectEditRefusesTodoReference(t *testing.T) {
+	database, _ := seedWritable(t)
+	captured := stubExec(t)
+
+	err := runWith(t, database, "--json", "project", "edit", "Post letter", "--title", "Post the letter")
+	if err == nil {
+		t.Fatal("expected project edit to refuse a to-do reference")
+	}
+	if len(*captured) != 0 {
+		t.Errorf("no URL should be opened, got %v", *captured)
+	}
+	if want := `"Post letter" is a to-do; use things edit`; err.Error() != want {
+		t.Errorf("message = %q, want %q", err.Error(), want)
+	}
+
+	payload, raw := decodePayload(t, err)
+	if payload.Error != "not a project" {
+		t.Errorf("error = %q, want %q (%s)", payload.Error, "not a project", raw)
+	}
+	if payload.Kind != "to-do" {
+		t.Errorf("kind = %q, want %q", payload.Kind, "to-do")
+	}
+	if payload.Query != "Post letter" {
+		t.Errorf("query = %q, want %q", payload.Query, "Post letter")
+	}
+	if payload.UUID != "one-1" {
+		t.Errorf("uuid = %q, want %q", payload.UUID, "one-1")
+	}
+	if payload.Title != "Post letter" {
+		t.Errorf("title = %q, want %q", payload.Title, "Post letter")
+	}
+}
+
 func TestIsInteractiveStdinPipe(t *testing.T) {
 	// In `go test`, stdin is typically not a TTY. Just call it for coverage;
 	// don't assert on the result since test runners vary.

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -183,11 +183,13 @@ $ things show milk --json; echo "exit=$?"
 exit=1
 ```
 
-The tokens are `ambiguous task`, `not found`, `import refused`, `import
-partially applied`, and `error` for everything else. The two import
-failures carry an `items` array naming which payload items were blocked or
-did not land; the [Commands](/commands/) page has the
-detail.
+The tokens are `ambiguous task`, `not found`, `not a task`, `not a project`,
+`import refused`, `import partially applied`, and `error` for everything else.
+`not a task` is a project handed to `edit`, and `not a project` a to-do handed
+to `project edit`; both refuse before anything is written and name the command
+to retry with. The two import failures carry an `items` array naming which
+payload items were blocked or did not land; the [Commands](/commands/) page
+has the detail.
 
 Some patterns that fall out of this:
 

--- a/docs/content/commands.md
+++ b/docs/content/commands.md
@@ -114,7 +114,8 @@ things edit 3 --complete                 # also: --cancel, --duplicate, --reveal
 
 `edit` is for to-dos only. A reference that resolves to a project is refused
 before anything is written, because `things:///update` cannot address one —
-use `things project edit` instead.
+use `things project edit` instead. `project edit` refuses a to-do the same
+way, pointing back at `things edit`.
 
 `things project edit` takes most of the same flags (`--title`, `--notes`,
 `--prepend-notes`/`--append-notes`, `--when`, `--deadline`, `--tags`,

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -44,10 +44,12 @@ Most commands accept `--json` / `-j`. Prefer it when parsing. It also guarantees
 {"error": "not found", "message": "task not found: milk", "kind": "task", "query": "milk"}
 {"error": "not a task", "message": "\"Chores\" is a project; use things project edit",
  "kind": "project", "query": "Chores", "uuid": "...", "title": "Chores"}
+{"error": "not a project", "message": "\"Post letter\" is a to-do; use things edit",
+ "kind": "to-do", "query": "Post letter", "uuid": "...", "title": "Post letter"}
 {"error": "error", "message": "..."}
 ```
 
-On `ambiguous task`, retry with one of `matches[].uuid`. On `not a task` the reference resolved to a project, `edit` wrote nothing, and the retry is `things project edit <uuid>`. This covers argument and flag errors too — `things --json show` with no argument returns the object, not a usage block. Without `--json`, errors stay a plain `Error: ...` line on stderr.
+On `ambiguous task`, retry with one of `matches[].uuid`. On `not a task` the reference resolved to a project, `edit` wrote nothing, and the retry is `things project edit <uuid>`; `not a project` is the same mistake the other way round, and the retry is `things edit <uuid>`. This covers argument and flag errors too — `things --json show` with no argument returns the object, not a usage block. Without `--json`, errors stay a plain `Error: ...` line on stderr.
 
 `import` fails per item, so its two failures add an `items` array — act on that rather than parsing `message`:
 
@@ -166,6 +168,7 @@ things project add <title> [--notes --when --deadline --tags --area --todos --st
 things edit <task> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --checklist --prepend-checklist --append-checklist --list --list-id --heading --heading-id --complete --cancel --duplicate --reveal --strict-tags --create-tags]
     # to-dos only; a project reference is refused — edit projects with `things project edit`
 things project edit <project> [--title --notes --prepend-notes --append-notes --when --deadline --tags --add-tags --area --area-id --complete --cancel --duplicate --reveal --strict-tags --create-tags]
+    # projects only; a to-do reference is refused — edit to-dos with `things edit`
 things complete <task> [-y|--yes]   # task or project; a project asks first (rule 4)
 things cancel <task> [-y|--yes]
 things log                          # move Today → Logbook


### PR DESCRIPTION
#190 gave `things edit <project>` a stable `not a task` token under `--json`. The opposite mistake did not get the same treatment: `things project edit <to-do>` returned a bare `not a project: <title>`, which lands under `--json` as the generic `{"error": "error"}` with no `kind`, `uuid` or `title`. An agent branching on tokens handled one direction and had to string-match the other.

Both guards now return the same error type, carrying the token it renders as — `not a task` one way, `not a project` the other — with `kind`, `query`, `uuid` and `title` in each. The plain-text message mirrors its opposite:

```
Error: "Post letter" is a to-do; use things edit
```

The guard sits before `checkRepeating`, tag verification and any URL open, so nothing is written. A test mirrors the one from #190: a to-do reference through `project edit`, nothing opened, the whole payload asserted.

Docs: the new token in `internal/skill/SKILL.md`, the README error section and the site commands page, next to the `not a task` entries. The site's agents page listed tokens too and had never gained `not a task` — it now names both.

One thing found and left alone: title resolution has no type preference, so with both a project and a to-do called "Chores", `things project edit Chores` resolves the to-do and points at `things edit`, which is not the item the user meant. That is in `resolveTask`/`GetTask` and predates this change — worth its own issue.

Closes #191