### PR TITLE
feat(site): add Umami analytics

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -14,6 +14,10 @@ disableKinds = ["taxonomy", "term", "RSS"]
   version = "0.7.0"
   repo = "ryanlewis/things-cli"
   author = "Ryan Lewis"
+  # Umami analytics. Emitted only in production builds, so `hugo server`
+  # does not record visits. Clear either value to turn it off.
+  umami_script = "https://arloo-stats.exe.xyz/script.js"
+  umami_website_id = "ca6a5ba0-17fd-4ec8-94a0-67a3c71e288f"
 
 [markup]
   [markup.goldmark.renderer]

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -31,3 +31,11 @@
 {{- else }}
   {{- errorf "assets/css/site.css is missing — the site would ship unstyled" }}
 {{- end }}
+
+{{- /* Umami analytics: production builds only, so a local `hugo server`
+       never records visits. Both params must be set for the tag to appear. */}}
+{{- $umamiScript := site.Params.umami_script }}
+{{- $umamiSite := site.Params.umami_website_id }}
+{{- if and hugo.IsProduction $umamiScript $umamiSite }}
+  <script defer src="{{ $umamiScript }}" data-website-id="{{ $umamiSite }}"></script>
+{{- end }}


### PR DESCRIPTION
Adds the Umami tag to every page of the site.

```html
<script defer src="https://arloo-stats.exe.xyz/script.js" data-website-id="ca6a5ba0-17fd-4ec8-94a0-67a3c71e288f"></script>
```

## How

It lives in the shared `head.html` partial, which `baseof.html` includes, so the landing page and the docs layout both get it from one edit.

The script URL and website id are params in `docs/hugo.toml` rather than literals in the layout, so either can change without touching templates. Both must be set for the tag to render — a half-configured site emits nothing rather than a script tag with an empty `data-website-id`.

The tag is emitted only when `hugo.IsProduction`. `hugo server` runs in the development environment, so local previews record no visits.

## Verification

| Check | Result |
| --- | --- |
| Production build (`hugo --minify --gc`) | tag on all 6 pages, exactly once each |
| Tag vs. the one requested | byte-for-byte identical |
| `hugo --environment development` | absent from `public/` entirely |
| Real `hugo server`, `/`, `/install/`, `/agents/` | 0 occurrences on each |
| Either param cleared | no tag at all, and no empty-attribute tag |

Collection itself was not verified from a headless browser — Umami ignores those.

## Note

Production is Hugo's default environment, so any plain `hugo` run reports to the live instance, not only CI. A `data-domains` allowlist would fix that, but the workflow builds with `--baseURL "${PAGES_ORIGIN}${BASE_PATH}/"`, and if that origin ever resolved to the github.io host rather than the custom domain the allowlist would silently drop all real traffic. Dropping real data is worse than the stray local hit, so it is left off deliberately.
