### PR TITLE
ci(site): ignore pre-release tags for the site version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,7 +52,9 @@ jobs:
       - name: Resolve the released version
         run: |
           set -euo pipefail
-          if tag=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null); then
+          # --exclude skips pre-releases (v0.8.0-rc.1): release.yml fires on
+          # v* too, so without it an rc would put itself on the public badge.
+          if tag=$(git describe --tags --abbrev=0 --match 'v*' --exclude 'v*-*' 2>/dev/null); then
             echo "HUGO_PARAMS_VERSION=${tag#v}" >> "$GITHUB_ENV"
             echo "Building the site as version ${tag#v} (from tag ${tag})."
           else


### PR DESCRIPTION
Pre-releases should not move the public version badge.

`release.yml` triggers on `v*` with no pre-release filter, and its `rebuild-site` job dispatches `pages.yml` after any tag. So cutting a `v0.8.0-rc.1` would publish the release and then rebuild the site with `HUGO_PARAMS_VERSION=0.8.0-rc.1`, putting an rc on the landing page.

Adding `--exclude 'v*-*'` to the `git describe` skips any tag carrying a hyphen, so the badge stays on the last stable tag.

```sh
git describe --tags --abbrev=0 --match 'v*' --exclude 'v*-*'
```

## Verification

Tested against a throwaway `v9.9.9-rc.1` tag created locally and deleted afterwards (never pushed — `git ls-remote` confirms):

| Tags present | `--match 'v*'` | `+ --exclude 'v*-*'` |
| --- | --- | --- |
| `v0.7.0` only | `v0.7.0` | `v0.7.0` |
| `v0.7.0`, `v9.9.9-rc.1` | `v9.9.9-rc.1` | `v0.7.0` |
| `v0.7.0`, `v9.9.9-rc.1`, `v9.9.9` | `v9.9.9` | `v9.9.9` |

The third row matters: the exclusion is not over-broad — a stable tag is still picked up when one exists alongside an rc.

`--exclude` combined with `--match` is AND-semantics, and the hyphen form matches what `.goreleaser.yaml`'s `prerelease: auto` keys on, so the two stay consistent. `actionlint` is clean.

## Note, not addressed here

`rebuild-site` still dispatches a full build and Pages deploy for a pre-release tag. That is now a no-op version-wise — the run produces identical output and is simply wasted. Gating that job on a non-pre-release tag would be the tidier end-state, but it is a behaviour change beyond this fix.
